### PR TITLE
Default platform builders to in-repo uikit/ and machorun/ trees

### DIFF
--- a/full/focus-ios/build_census.sh
+++ b/full/focus-ios/build_census.sh
@@ -8,7 +8,8 @@
 # census row, not an abort -- stopping at the first failure is exactly the
 # behaviour that produced phase 1's "4 errors" false green.
 #
-#   1. OpenUIKit          built FRESH from a clone of ~/uikit (never written to)
+#   1. OpenUIKit          built FRESH from the in-repo uikit/ subtree (or an
+#                         external checkout override); never written to
 #   2. support modules    production WebKit plus the remaining measured Glean,
 #                         FocusAppServices, Sentry, Fuzi and MobileCoreServices
 #                         census-only modules
@@ -31,11 +32,17 @@ set -uo pipefail
 
 HERE=$(cd "$(dirname "$0")" && pwd)
 SML=$(cd "$HERE/../.." && pwd)
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$SML/scripts/vendor_tree.sh"
+die() {
+    printf 'REFUSED: %s\n' "$*" >&2
+    exit 2
+}
 APP=${APP:-$SML/scratch/ladder-corpus/focus-ios/focus-ios}
 SNAPKIT=${SNAPKIT:-$SML/scratch/xcodeplan-deps/SnapKit}
 OUT=${1:-/tmp/focus-ios-census}
 REQUESTED_TARGET=${TARGET:-}
-UIKIT_SRC=${UIKIT_SRC:-$HOME/uikit}
+UIKIT_SRC=${UIKIT_SRC:-$SML/uikit}
 FIRST_PARTY_FRAMEWORKS_SRC=${FIRST_PARTY_FRAMEWORKS_SRC:-}
 FOCUS_EXPECTED_COMMIT=a2832521c1daa0c23419c73705ae043ed60c9791
 FOCUS_EXPECTED_TREE=065d8e374c9caa3be2915165ba7cbbe4b1d61d7e
@@ -132,16 +139,20 @@ write_bundle_accessor() {
 # --- 0. pins, by COMMIT ------------------------------------------------------
 hr "0. pins"
 if [ "$CENSUS_SOURCE_MODE" = exact-main ]; then
-    [ -n "$EXPECTED_SUPPORT_COMMIT" ] && [ -n "$EXPECTED_SUPPORT_TREE" ] \
-        && [ -n "$EXPECTED_UIKIT_COMMIT" ] && [ -n "$EXPECTED_UIKIT_TREE" ] || {
-            say "  REFUSED: exact-main requires expected support/UIKit commit and tree"
+    [ -n "$EXPECTED_SUPPORT_COMMIT" ] && [ -n "$EXPECTED_SUPPORT_TREE" ] || {
+            say "  REFUSED: exact-main requires expected support commit and tree"
             exit 2
         }
+    [ -z "$EXPECTED_UIKIT_TREE" ] && EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
     assert_clean_identity "$SML" "$EXPECTED_SUPPORT_COMMIT" "$EXPECTED_SUPPORT_TREE" support
     assert_clean_identity "$APP" "$FOCUS_EXPECTED_COMMIT" "$FOCUS_EXPECTED_TREE" Focus
     assert_clean_identity "$SNAPKIT" "$SNAPKIT_EXPECTED_COMMIT" \
         "$SNAPKIT_EXPECTED_TREE" SnapKit
-    assert_clean_identity "$UIKIT_SRC" "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+    assert_vendor_tree "$SML" uikit "$UIKIT_SRC" "$EXPECTED_UIKIT_TREE" OpenUIKit
+    if ! vendor_is_inrepo "$SML" uikit "$UIKIT_SRC"; then
+        [ -n "$EXPECTED_UIKIT_COMMIT" ] || die 'exact-main external OpenUIKit checkout requires expected UIKit commit'
+        assert_clean_identity "$UIKIT_SRC" "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+    fi
     BASELINE_PRIMARY_SHA_BEFORE=''
     if [ -n "$BASELINE_PRIMARY" ]; then
         case "$BASELINE_PRIMARY" in /*) ;; *) say '  REFUSED: baseline primary path must be absolute'; exit 2 ;; esac
@@ -161,13 +172,23 @@ python3 -B "$WEBKIT_PROVENANCE" focus \
     || exit 4
 say "  focus-ios  $(git -C "$APP" rev-parse HEAD 2>/dev/null)"
 say "  SnapKit    $(git -C "$SNAPKIT" rev-parse HEAD 2>/dev/null)"
-say "  OpenUIKit  $(git -C "$UIKIT_SRC" rev-parse HEAD 2>/dev/null)"
+if vendor_is_inrepo "$SML" uikit "$UIKIT_SRC"; then
+    say "  OpenUIKit  HEAD:uikit=$(git -C "$SML" rev-parse HEAD:uikit)"
+else
+    say "  OpenUIKit  $(git -C "$UIKIT_SRC" rev-parse HEAD 2>/dev/null)"
+fi
 
 # --- 1. OpenUIKit, built fresh ----------------------------------------------
-hr "1. OpenUIKit (fresh clone; ~/uikit is read-only and is never written)"
+hr "1. OpenUIKit (fresh tree; in-repo uikit/ and external checkouts are never written)"
 UIKIT_CLONE=$OUT/uikit
 if [ ! -d "$UIKIT_CLONE" ]; then
-    git clone -q --no-hardlinks "$UIKIT_SRC" "$UIKIT_CLONE" || { say "  clone failed"; exit 2; }
+    if vendor_is_inrepo "$SML" uikit "$UIKIT_SRC"; then
+        mkdir -p "$UIKIT_CLONE"
+        git -C "$SML" archive HEAD:uikit | tar -x -C "$UIKIT_CLONE" \
+            || { say "  in-repo uikit archive failed"; exit 2; }
+    else
+        git clone -q --no-hardlinks "$UIKIT_SRC" "$UIKIT_CLONE" || { say "  clone failed"; exit 2; }
+    fi
 fi
 ( cd "$UIKIT_CLONE" && swift build -c release --product OpenUIKit ) \
     > "$OUT/logs/openuikit.log" 2>&1
@@ -466,7 +487,10 @@ if [ "$CENSUS_SOURCE_MODE" = exact-main ]; then
     assert_clean_identity "$APP" "$FOCUS_EXPECTED_COMMIT" "$FOCUS_EXPECTED_TREE" Focus
     assert_clean_identity "$SNAPKIT" "$SNAPKIT_EXPECTED_COMMIT" \
         "$SNAPKIT_EXPECTED_TREE" SnapKit
-    assert_clean_identity "$UIKIT_SRC" "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+    assert_vendor_tree "$SML" uikit "$UIKIT_SRC" "$EXPECTED_UIKIT_TREE" OpenUIKit
+    if ! vendor_is_inrepo "$SML" uikit "$UIKIT_SRC"; then
+        assert_clean_identity "$UIKIT_SRC" "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+    fi
     normalized_sha=$(shasum -a 256 "$OUT/exact-main-primary.tsv" | awk '{print $1}')
     raw_log_sha=$(shasum -a 256 "$OUT/logs/exact-main.log" | awk '{print $1}')
     delta_sha=''
@@ -484,7 +508,12 @@ if [ "$CENSUS_SOURCE_MODE" = exact-main ]; then
         printf 'format\tfocus-exact-main-census-v1\n'
         printf 'support\t%s\t%s\n' "$EXPECTED_SUPPORT_COMMIT" "$EXPECTED_SUPPORT_TREE"
         printf 'focus\t%s\t%s\n' "$FOCUS_EXPECTED_COMMIT" "$FOCUS_EXPECTED_TREE"
-        printf 'uikit\t%s\t%s\n' "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE"
+        if vendor_is_inrepo "$SML" uikit "$UIKIT_SRC"; then
+            printf 'uikit\ttree=%s\tsource=HEAD:uikit\n' "$EXPECTED_UIKIT_TREE"
+        else
+            printf 'uikit\tcommit=%s\ttree=%s\tsource=checkout\n' \
+                "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE"
+        fi
         printf 'snapkit\t%s\t%s\n' "$SNAPKIT_EXPECTED_COMMIT" "$SNAPKIT_EXPECTED_TREE"
         printf 'sources\tpresent\t129\n'
         printf 'sources\tgenerated-missing\t2\n'

--- a/full/focus-ios/build_exact_main_census.sh
+++ b/full/focus-ios/build_exact_main_census.sh
@@ -8,7 +8,7 @@ HERE=$(cd "$(dirname "$0")" && pwd)
 SUPPORT=$(cd "$HERE/../.." && pwd)
 APP=${APP:-$SUPPORT/scratch/ladder-corpus/focus-ios/focus-ios}
 SNAPKIT=${SNAPKIT:-$SUPPORT/scratch/xcodeplan-deps/SnapKit}
-UIKIT_SRC=${UIKIT_SRC:-/Users/miguelsalinas/uikit}
+UIKIT_SRC=${UIKIT_SRC:-$SUPPORT/uikit}
 OUTPUT=''
 EXPECTED_SUPPORT_COMMIT=''
 EXPECTED_SUPPORT_TREE=''
@@ -25,13 +25,16 @@ usage() {
     cat <<'EOF'
 usage: build_exact_main_census.sh --output-root ABSOLUTE_NEW_PATH \
   --expected-support-commit COMMIT --expected-support-tree TREE \
-  --expected-uikit-commit COMMIT --expected-uikit-tree TREE \
+  [--expected-uikit-commit COMMIT] [--expected-uikit-tree TREE] \
   [--baseline-primary ABSOLUTE_NORMALIZED_TSV]
 
-APP, SNAPKIT, and UIKIT_SRC may override the three read-only checkouts. Every
-identity is checked before and after compilation. The output path must not
-exist; all modules, package products, caches, logs, and generated build support
-are created beneath that one fresh root.
+APP, SNAPKIT, and UIKIT_SRC may override the three read-only checkouts.
+UIKIT_SRC defaults to the in-repo uikit/ subtree and is attested by
+git rev-parse HEAD:uikit. --expected-uikit-commit is required only for an
+external OpenUIKit checkout. Every identity is checked before and after
+compilation. The output path must not exist; all modules, package products,
+caches, logs, and generated build support are created beneath that one fresh
+root.
 When --baseline-primary is supplied, the driver emits an exact multiset delta
 that preserves duplicate-diagnostic multiplicity.
 EOF
@@ -59,11 +62,23 @@ fi
 [ -n "$OUTPUT" ] || die '--output-root is required'
 case "$OUTPUT" in /*) ;; *) die '--output-root must be absolute' ;; esac
 [ ! -e "$OUTPUT" ] && [ ! -L "$OUTPUT" ] || die "output already exists: $OUTPUT"
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$SUPPORT/scripts/vendor_tree.sh"
+[ -z "$EXPECTED_UIKIT_TREE" ] && EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
 for value in "$EXPECTED_SUPPORT_COMMIT" "$EXPECTED_SUPPORT_TREE" \
-    "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE"; do
+    "$EXPECTED_UIKIT_TREE"; do
     [ "${#value}" -eq 40 ] || die 'every expected commit/tree must be 40 lowercase hex'
     case "$value" in *[!0-9a-f]*) die 'every expected commit/tree must be 40 lowercase hex' ;; esac
 done
+if ! vendor_is_inrepo "$SUPPORT" uikit "$UIKIT_SRC"; then
+    [ -n "$EXPECTED_UIKIT_COMMIT" ] \
+        || die '--expected-uikit-commit is required for an external OpenUIKit checkout'
+    [ "${#EXPECTED_UIKIT_COMMIT}" -eq 40 ] \
+        || die 'expected UIKit commit must be 40 lowercase hex'
+    case "$EXPECTED_UIKIT_COMMIT" in
+        *[!0-9a-f]*) die 'expected UIKit commit must be 40 lowercase hex' ;;
+    esac
+fi
 for input in "$SUPPORT" "$APP" "$SNAPKIT" "$UIKIT_SRC"; do
     case "$input" in /*) ;; *) die "input checkout must be absolute: $input" ;; esac
     [ -d "$input" ] && git -C "$input" rev-parse --git-dir >/dev/null 2>&1 \

--- a/full/focus-ios/test_build_census.py
+++ b/full/focus-ios/test_build_census.py
@@ -35,6 +35,9 @@ class BuildCensusTests(unittest.TestCase):
         self.assertIn('"$OUT/exact-main-delta.tsv"', build)
         self.assertIn('"$HERE/diagnostics.py" delta', build)
         self.assertIn('git clone -q --no-hardlinks', build)
+        self.assertIn('git -C "$SML" archive HEAD:uikit', build)
+        self.assertIn('assert_vendor_tree "$SML" uikit', build)
+        self.assertIn('HEAD:uikit', build)
         self.assertIn('format\\tfocus-exact-main-census-v1', build)
 
     def test_bundle_accessor_is_narrow_generated_build_support(self) -> None:

--- a/full/frameworks/CORE_GUEST_PACKAGE.md
+++ b/full/frameworks/CORE_GUEST_PACKAGE.md
@@ -50,16 +50,15 @@ Run the builder inside the pinned Linux/aarch64 image:
 bash full/frameworks/build_core_guest_package.sh \
   --output-root /w/build/core-package-NEW \
   --expected-support-commit 40_LOWERCASE_HEX \
-  --expected-support-tree 40_LOWERCASE_HEX \
-  --uikit-checkout /uikit \
-  --expected-uikit-commit 40_LOWERCASE_HEX \
-  --expected-uikit-tree 40_LOWERCASE_HEX
+  --expected-support-tree 40_LOWERCASE_HEX
 ```
 
 `--output-root` must be a nonexistent direct child of `/w/build`. Exact support
-and UIKit commit/tree values are required inputs, not provenance inferred after
-the fact. Both source checkouts are bracketed for commit/tree and cleanliness;
-the support commit must also descend from the accepted Foundation substrate.
+commit/tree values are required inputs. OpenUIKit and machorun default to the
+in-repo `uikit/` and `machorun/` subtrees and are attested by
+`git rev-parse HEAD:uikit` / `HEAD:machorun` against the baked tree pins; a
+dirty subtree is refused. `--uikit-checkout` / `--machorun-checkout` remain
+external overrides (`--expected-uikit-commit` is required only then).
 
 The Foundation facade source list is mandatory and defaults to
 `full/foundation/foundation_guest_sources.txt`. Its thirty-three LF-terminated lines
@@ -763,7 +762,9 @@ not a macro-expansion proof.
 
 `run_core_guest_package_docker.sh` is the production host-side cold wrapper.
 It requires an exact lowercase SHA-256 Linux/ARM64 container image ID, exact
-support, UIKit, and machorun commit/tree pins, an exact SHA-256 for machorun's
+support commit/tree pins, optional UIKit/machorun checkout overrides (in-repo
+`uikit/` and `machorun/` trees are the default and are attested by
+`git rev-parse HEAD:uikit` / `HEAD:machorun`), an exact SHA-256 for machorun's
 ignored prebuilt loader, exact SHA-256 identities for the staged Swift and
 Objective-C runtimes, a new output path, and a staged-input root containing:
 
@@ -781,21 +782,20 @@ bash full/frameworks/run_core_guest_package_docker.sh \
   --expected-support-commit 40_HEX \
   --expected-support-tree 40_HEX \
   --staged-input-root /path/to/canonical/support/scratch \
-  --uikit-checkout /path/to/clean/uikit \
-  --expected-uikit-commit 40_HEX \
-  --expected-uikit-tree 40_HEX \
-  --machorun-checkout /path/to/clean/machorun \
-  --expected-machorun-commit 40_HEX \
-  --expected-machorun-tree 40_HEX \
   --expected-machorun-loader-sha256 64_HEX \
   --expected-machorun-swift-core-sha256 64_HEX \
   --expected-machorun-objc-sha256 64_HEX \
   --output-root /path/to/new/core-package
 ```
 
+`--uikit-checkout` / `--machorun-checkout` remain external overrides. Omit them
+to consume the in-repo subtrees from the support checkout.
+
 Mutable image tags and defaults are refused; the exact image ID and verified
-Linux/ARM64 platform are recorded in host evidence. The wrapper creates fresh
-`--no-local --no-hardlinks` clones for support, UIKit, and machorun. It then
+Linux/ARM64 platform are recorded in host evidence. The wrapper creates a fresh
+`--no-local --no-hardlinks` clone of the support checkout. In-repo `uikit/` and
+`machorun/` trees are consumed from that clone. External `--uikit-checkout` /
+`--machorun-checkout` still clone those repositories separately. It then
 byte-copies the ignored machorun loader and `darwin/usr` runtime closure, every
 prepared staged-input tree, and the optional Preview trio. The copier opens a
 new destination file for every regular file, proves that it shares no source

--- a/full/frameworks/build_core_guest_package.sh
+++ b/full/frameworks/build_core_guest_package.sh
@@ -7,8 +7,10 @@
 set -euo pipefail
 export GIT_OPTIONAL_LOCKS=0
 
-W=${W:-/w}
-MACHORUN=${MACHORUN:-/machorun}
+W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$W/scripts/vendor_tree.sh"
+MACHORUN=${MACHORUN:-$W/machorun}
 TARGET=arm64-apple-macos15.0
 MIN_OS=15.0
 SYS=$W/scratch/sysroot_fe4
@@ -289,8 +291,7 @@ EXPECTED_COLLECTIONS_COMMIT=9bf03ff58ce34478e66aaee630e491823326fd06
 EXPECTED_COLLECTIONS_TREE=5e4de96f40ccf147dab967f38cb7988ecd933c27
 EXPECTED_OPENCOMBINE_COMMIT=1c6f02c7ed8140c0ba7a783aaddb6e0685a0037b
 EXPECTED_OPENCOMBINE_TREE=66a9d91efc910c7577e40b2dec166a2de427594a
-EXPECTED_MACHORUN_COMMIT=98551893760e553c14d5dbb2c28138e014290918
-EXPECTED_MACHORUN_TREE=d4448ff9f8a89c5cefad8b74f16db5d8d6ccff15
+EXPECTED_MACHORUN_TREE=$EXPECTED_INREPO_MACHORUN_TREE
 EXPECTED_MACHORUN_LIBSYSTEM_SOURCE_SHA=0d8680f13e023c9f002fad78f1f0382c975f479595cd8cf3fa8eb6da3c42d29b
 SWIFT_CORE_REQUIRED_AVAILABILITY_SYMBOL='_$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF'
 EXPECTED_MACHORUN_GROUP_FIXTURE_SHA=d90194ae586e14f652435e4764d4b13d338be53b95da10cf73df4d1955895624
@@ -411,18 +412,24 @@ usage() {
     cat <<'EOF'
 usage: build_core_guest_package.sh --output-root /w/build/NEW_NAME \
     --expected-support-commit COMMIT --expected-support-tree TREE \
-    --uikit-checkout PATH --expected-uikit-commit COMMIT \
-    --expected-uikit-tree TREE [options]
+    [--uikit-checkout PATH] [--expected-uikit-commit COMMIT] \
+    [--expected-uikit-tree TREE] [--machorun-checkout PATH] [options]
 
 Required:
   --output-root PATH
   --expected-support-commit 40_HEX
   --expected-support-tree 40_HEX
-  --uikit-checkout PATH
-  --expected-uikit-commit 40_HEX
-  --expected-uikit-tree 40_HEX
   --expected-machorun-swift-core-sha256 64_HEX
   --expected-machorun-objc-sha256 64_HEX
+
+In-repo defaults (attested by git rev-parse HEAD:uikit / HEAD:machorun):
+  --uikit-checkout defaults to $W/uikit
+  --machorun-checkout / MACHORUN defaults to $W/machorun
+  --expected-uikit-tree defaults to the baked in-repo UIKit tree pin
+  --expected-uikit-commit is required only for an external UIKit checkout
+
+External checkout flags remain overrides. A dirty uikit/ or machorun/ subtree
+is refused.
 
 Foundation source contract:
   --foundation-sources-manifest PATH
@@ -464,6 +471,9 @@ while [ "$#" -gt 0 ]; do
         --expected-uikit-tree)
             [ "$#" -ge 2 ] || die '--expected-uikit-tree requires a value'
             EXPECTED_UIKIT_TREE=$2; shift 2 ;;
+        --machorun-checkout)
+            [ "$#" -ge 2 ] || die '--machorun-checkout requires a value'
+            MACHORUN=$2; shift 2 ;;
         --expected-machorun-swift-core-sha256)
             [ "$#" -ge 2 ] \
                 || die '--expected-machorun-swift-core-sha256 requires a value'
@@ -493,22 +503,35 @@ done
 [ -n "$OUTPUT_ROOT" ] || die '--output-root is required'
 [ -n "$EXPECTED_SUPPORT_COMMIT" ] || die '--expected-support-commit is required'
 [ -n "$EXPECTED_SUPPORT_TREE" ] || die '--expected-support-tree is required'
-[ -n "$UIKIT" ] || die '--uikit-checkout is required'
-[ -n "$EXPECTED_UIKIT_COMMIT" ] || die '--expected-uikit-commit is required'
-[ -n "$EXPECTED_UIKIT_TREE" ] || die '--expected-uikit-tree is required'
+[ -z "$UIKIT" ] && UIKIT=$W/uikit
+[ -z "$EXPECTED_UIKIT_TREE" ] && EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
 [ -n "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256" ] \
     || die '--expected-machorun-swift-core-sha256 is required'
 [ -n "$EXPECTED_MACHORUN_OBJC_SHA256" ] \
     || die '--expected-machorun-objc-sha256 is required'
 case "$UIKIT" in /*) ;; *) die '--uikit-checkout must be absolute' ;; esac
+case "$MACHORUN" in /*) ;; *) die 'MACHORUN / --machorun-checkout must be absolute' ;; esac
 for expected_git_id in "$EXPECTED_SUPPORT_COMMIT" "$EXPECTED_SUPPORT_TREE" \
-    "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE"; do
+    "$EXPECTED_UIKIT_TREE"; do
     [ "${#expected_git_id}" -eq 40 ] \
-        || die 'expected UIKit commit/tree must each be lowercase 40-hex'
+        || die 'expected support commit/tree and UIKit tree must each be lowercase 40-hex'
     case "$expected_git_id" in
-        *[!0-9a-f]*) die 'expected UIKit commit/tree must each be lowercase 40-hex' ;;
+        *[!0-9a-f]*) \
+            die 'expected support commit/tree and UIKit tree must each be lowercase 40-hex' ;;
     esac
 done
+if vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    [ -z "$EXPECTED_UIKIT_COMMIT" ] \
+        || die '--expected-uikit-commit is an external-checkout pin; omit it for in-repo uikit/'
+else
+    [ -n "$EXPECTED_UIKIT_COMMIT" ] \
+        || die '--expected-uikit-commit is required for an external OpenUIKit checkout'
+    [ "${#EXPECTED_UIKIT_COMMIT}" -eq 40 ] \
+        || die 'expected UIKit commit must be lowercase 40-hex'
+    case "$EXPECTED_UIKIT_COMMIT" in
+        *[!0-9a-f]*) die 'expected UIKit commit must be lowercase 40-hex' ;;
+    esac
+fi
 [ "${#EXPECTED_MACHORUN_SWIFT_CORE_SHA256}" -eq 64 ] \
     || die 'expected machorun Swift core SHA-256 must be lowercase 64-hex'
 case "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256" in
@@ -642,7 +665,7 @@ assert_clean_commit() {
 assert_exact_swift_set() {
     local repo=$1 relative=$2 expected_count=$3 label=$4 prefix=$5
     local tracked=$WORK/$prefix.tracked physical=$WORK/$prefix.physical count
-    git -C "$repo" ls-files -z -- "$relative" \
+    vendor_ls_files "$W" uikit "$repo" "$relative" \
         | while IFS= read -r -d '' path; do
             case "$path" in *.swift) printf '%s\0' "$path" ;; esac
           done | LC_ALL=C sort -z > "$tracked"
@@ -667,8 +690,13 @@ git -C "$W" merge-base --is-ancestor "$EXPECTED_SUPPORT_BASE" "$SUPPORT_COMMIT" 
     || die "support HEAD does not descend from reviewed base $EXPECTED_SUPPORT_BASE"
 [ -z "$(git -C "$W" status --porcelain=v1 --untracked-files=all)" ] \
     || die 'support checkout is dirty'
-assert_clean_commit "$UIKIT" "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
-assert_clean_commit "$MACHORUN" "$EXPECTED_MACHORUN_COMMIT" "$EXPECTED_MACHORUN_TREE" machorun
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+if ! vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    actual_uikit_commit=$(git -C "$UIKIT" rev-parse --verify 'HEAD^{commit}')
+    [ "$actual_uikit_commit" = "$EXPECTED_UIKIT_COMMIT" ] \
+        || die "OpenUIKit commit $actual_uikit_commit, expected $EXPECTED_UIKIT_COMMIT"
+fi
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_MACHORUN_TREE" machorun
 require_hash "$MACHORUN/darwin/usr/lib/swift/libswiftCore.dylib" \
     "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256" machorun-Swift-core
 require_hash "$MACHORUN/darwin/usr/lib/libobjc.A.dylib" \
@@ -6289,8 +6317,9 @@ cp "$SOURCE_SET_ATTEST" "$STAGE/attestation/source-sets.tsv"
     printf 'format\tcore-input-provenance-v1\n'
     printf 'support\tcommit=%s\ttree=%s\tbase=%s\n' \
         "$SUPPORT_COMMIT" "$SUPPORT_TREE" "$EXPECTED_SUPPORT_BASE"
-    printf 'OpenUIKit\tcommit=%s\ttree=%s\tSwift=%s\tOpenCoreGraphics=%s\tSymbols=%s\tSwiftUI=%s\tDeveloperToolsSupport=%s\tOpenUIKitPreviewMacros=%s\tOpenSwiftUIMacros=%s\tCQuartzCPP=%s\n' \
-        "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" \
+    printf 'OpenUIKit\tsource=%s\ttree=%s\tSwift=%s\tOpenCoreGraphics=%s\tSymbols=%s\tSwiftUI=%s\tDeveloperToolsSupport=%s\tOpenUIKitPreviewMacros=%s\tOpenSwiftUIMacros=%s\tCQuartzCPP=%s\n' \
+        "$(vendor_is_inrepo "$W" uikit "$UIKIT" && printf 'HEAD:uikit' || printf 'checkout:%s' "$EXPECTED_UIKIT_COMMIT")" \
+        "$EXPECTED_UIKIT_TREE" \
         "$EXPECTED_UIKIT_SWIFT_COUNT" "$EXPECTED_OPENCOREGRAPHICS_SWIFT_COUNT" \
         "$EXPECTED_SYMBOLS_SWIFT_COUNT" "$EXPECTED_SWIFTUI_SWIFT_COUNT" \
         "$EXPECTED_DEVELOPER_TOOLS_SUPPORT_SWIFT_COUNT" \
@@ -6384,8 +6413,9 @@ cp "$SOURCE_SET_ATTEST" "$STAGE/attestation/source-sets.tsv"
         "$(hash_file "$COPEN_FOUNDATION_CORE_INCLUDE/OpenFoundationCFError.h")" \
         "$(hash_file "$COPEN_FOUNDATION_CORE_INCLUDE/module.modulemap")" \
         "$(hash_file "$W/full/foundation/CFError+Error.swift")"
-    printf 'machorun\tcommit=%s\ttree=%s\tloader-sha256=%s\n' \
-        "$EXPECTED_MACHORUN_COMMIT" "$EXPECTED_MACHORUN_TREE" \
+    printf 'machorun\tsource=%s\ttree=%s\tloader-sha256=%s\n' \
+        "$(vendor_is_inrepo "$W" machorun "$MACHORUN" && printf 'HEAD:machorun' || printf 'checkout')" \
+        "$EXPECTED_MACHORUN_TREE" \
         "$(hash_file "$MACHORUN/build/machorun")"
     printf 'machorun-runtime\tlibswiftCore-sha256=%s\tlibobjc-sha256=%s\tcontract=%s\tbuild-full-stage=%s\n' \
         "$(hash_file "$SWIFT_CORE_RUNTIME")" \
@@ -7019,12 +7049,17 @@ if [ "$PREVIEW_ENABLED" -eq 1 ]; then
 fi
 
 echo '== post-build input bracket'
-assert_clean_commit "$UIKIT" "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" post-OpenUIKit
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" post-OpenUIKit
+if ! vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    actual_uikit_commit=$(git -C "$UIKIT" rev-parse --verify 'HEAD^{commit}')
+    [ "$actual_uikit_commit" = "$EXPECTED_UIKIT_COMMIT" ] \
+        || die "post-OpenUIKit commit $actual_uikit_commit, expected $EXPECTED_UIKIT_COMMIT"
+fi
 require_hash "$MACHORUN/darwin/usr/lib/swift/libswiftCore.dylib" \
     "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256" post-machorun-Swift-core
 require_hash "$MACHORUN/darwin/usr/lib/libobjc.A.dylib" \
     "$EXPECTED_MACHORUN_OBJC_SHA256" post-machorun-Objective-C-runtime
-assert_clean_commit "$MACHORUN" "$EXPECTED_MACHORUN_COMMIT" "$EXPECTED_MACHORUN_TREE" post-machorun
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_MACHORUN_TREE" post-machorun
 assert_clean_commit "$SWIFT_FOUNDATION" "$EXPECTED_FOUNDATION_COMMIT" "$EXPECTED_FOUNDATION_TREE" post-swift-foundation
 assert_clean_commit "$SWIFT_FOUNDATION_ICU" "$EXPECTED_FOUNDATION_ICU_COMMIT" \
     "$EXPECTED_FOUNDATION_ICU_TREE" post-swift-foundation-icu

--- a/full/frameworks/run_core_guest_package_docker.sh
+++ b/full/frameworks/run_core_guest_package_docker.sh
@@ -35,9 +35,9 @@ usage: run_core_guest_package_docker.sh \
   --container-image SHA256_IMAGE_ID \
   --support-checkout PATH --expected-support-commit HASH \
   --expected-support-tree HASH --staged-input-root PATH \
-  --uikit-checkout PATH --expected-uikit-commit HASH \
-  --expected-uikit-tree HASH --machorun-checkout PATH \
-  --expected-machorun-commit HASH --expected-machorun-tree HASH \
+  [--uikit-checkout PATH] [--expected-uikit-commit HASH] \
+  [--expected-uikit-tree HASH] [--machorun-checkout PATH] \
+  [--expected-machorun-commit HASH] [--expected-machorun-tree HASH] \
   --expected-machorun-loader-sha256 HASH \
   --expected-machorun-swift-core-sha256 HASH \
   --expected-machorun-objc-sha256 HASH \
@@ -67,6 +67,8 @@ die() {
     echo "core_guest_package_host: REFUSING -- $*" >&2
     exit 2
 }
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$SCRIPT_DIR/../../scripts/vendor_tree.sh"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -104,12 +106,6 @@ for assignment in \
     "expected support commit:$EXPECTED_SUPPORT_COMMIT" \
     "expected support tree:$EXPECTED_SUPPORT_TREE" \
     "staged input root:$STAGED_INPUT_ROOT" \
-    "UIKit checkout:$UIKIT_CHECKOUT" \
-    "expected UIKit commit:$EXPECTED_UIKIT_COMMIT" \
-    "expected UIKit tree:$EXPECTED_UIKIT_TREE" \
-    "machorun checkout:$MACHORUN_CHECKOUT" \
-    "expected machorun commit:$EXPECTED_MACHORUN_COMMIT" \
-    "expected machorun tree:$EXPECTED_MACHORUN_TREE" \
     "expected machorun loader SHA-256:$EXPECTED_MACHORUN_LOADER_SHA256" \
     "expected machorun Swift core SHA-256:$EXPECTED_MACHORUN_SWIFT_CORE_SHA256" \
     "expected machorun Objective-C runtime SHA-256:$EXPECTED_MACHORUN_OBJC_SHA256" \
@@ -118,17 +114,38 @@ for assignment in \
     value=${assignment#*:}
     [ -n "$value" ] || die "$label is required"
 done
+[ -z "$EXPECTED_UIKIT_TREE" ] && EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
+[ -z "$EXPECTED_MACHORUN_TREE" ] && EXPECTED_MACHORUN_TREE=$EXPECTED_INREPO_MACHORUN_TREE
+[ -z "$UIKIT_CHECKOUT" ] && UIKIT_CHECKOUT=$SUPPORT_CHECKOUT/uikit
+[ -z "$MACHORUN_CHECKOUT" ] && MACHORUN_CHECKOUT=$SUPPORT_CHECKOUT/machorun
 
 for path in "$SUPPORT_CHECKOUT" "$STAGED_INPUT_ROOT" \
     "$UIKIT_CHECKOUT" "$MACHORUN_CHECKOUT" "$OUTPUT_ROOT"; do
     case "$path" in /*) ;; *) die "path must be absolute: $path" ;; esac
 done
 for expected in "$EXPECTED_SUPPORT_COMMIT" "$EXPECTED_SUPPORT_TREE" \
-    "$EXPECTED_UIKIT_COMMIT" "$EXPECTED_UIKIT_TREE" \
-    "$EXPECTED_MACHORUN_COMMIT" "$EXPECTED_MACHORUN_TREE"; do
+    "$EXPECTED_UIKIT_TREE" "$EXPECTED_MACHORUN_TREE"; do
     [ "${#expected}" -eq 40 ] || die "Git ID must be lowercase 40-hex: $expected"
     case "$expected" in *[!0-9a-f]*) die "Git ID must be lowercase 40-hex: $expected" ;; esac
 done
+if ! vendor_is_inrepo "$SUPPORT_CHECKOUT" uikit "$UIKIT_CHECKOUT"; then
+    [ -n "$EXPECTED_UIKIT_COMMIT" ] \
+        || die 'expected UIKit commit is required for an external OpenUIKit checkout'
+    [ "${#EXPECTED_UIKIT_COMMIT}" -eq 40 ] \
+        || die "Git ID must be lowercase 40-hex: $EXPECTED_UIKIT_COMMIT"
+    case "$EXPECTED_UIKIT_COMMIT" in
+        *[!0-9a-f]*) die "Git ID must be lowercase 40-hex: $EXPECTED_UIKIT_COMMIT" ;;
+    esac
+fi
+if ! vendor_is_inrepo "$SUPPORT_CHECKOUT" machorun "$MACHORUN_CHECKOUT"; then
+    [ -n "$EXPECTED_MACHORUN_COMMIT" ] \
+        || die 'expected machorun commit is required for an external machorun checkout'
+    [ "${#EXPECTED_MACHORUN_COMMIT}" -eq 40 ] \
+        || die "Git ID must be lowercase 40-hex: $EXPECTED_MACHORUN_COMMIT"
+    case "$EXPECTED_MACHORUN_COMMIT" in
+        *[!0-9a-f]*) die "Git ID must be lowercase 40-hex: $EXPECTED_MACHORUN_COMMIT" ;;
+    esac
+fi
 [ "${#EXPECTED_MACHORUN_LOADER_SHA256}" -eq 64 ] \
     || die 'machorun loader SHA-256 must be lowercase 64-hex'
 case "$EXPECTED_MACHORUN_LOADER_SHA256" in
@@ -191,10 +208,20 @@ assert_checkout() {
 }
 assert_checkout "$SUPPORT_CHECKOUT" "$EXPECTED_SUPPORT_COMMIT" \
     "$EXPECTED_SUPPORT_TREE" support
-assert_checkout "$UIKIT_CHECKOUT" "$EXPECTED_UIKIT_COMMIT" \
+assert_vendor_tree "$SUPPORT_CHECKOUT" uikit "$UIKIT_CHECKOUT" \
     "$EXPECTED_UIKIT_TREE" OpenUIKit
-assert_checkout "$MACHORUN_CHECKOUT" "$EXPECTED_MACHORUN_COMMIT" \
+if ! vendor_is_inrepo "$SUPPORT_CHECKOUT" uikit "$UIKIT_CHECKOUT"; then
+    actual_uikit_commit=$(git -C "$UIKIT_CHECKOUT" rev-parse --verify 'HEAD^{commit}')
+    [ "$actual_uikit_commit" = "$EXPECTED_UIKIT_COMMIT" ] \
+        || die "OpenUIKit commit $actual_uikit_commit, expected $EXPECTED_UIKIT_COMMIT"
+fi
+assert_vendor_tree "$SUPPORT_CHECKOUT" machorun "$MACHORUN_CHECKOUT" \
     "$EXPECTED_MACHORUN_TREE" machorun
+if ! vendor_is_inrepo "$SUPPORT_CHECKOUT" machorun "$MACHORUN_CHECKOUT"; then
+    actual_machorun_commit=$(git -C "$MACHORUN_CHECKOUT" rev-parse --verify 'HEAD^{commit}')
+    [ "$actual_machorun_commit" = "$EXPECTED_MACHORUN_COMMIT" ] \
+        || die "machorun commit $actual_machorun_commit, expected $EXPECTED_MACHORUN_COMMIT"
+fi
 
 MACHORUN_LOADER=$MACHORUN_CHECKOUT/build/machorun
 [ -f "$MACHORUN_LOADER" ] && [ ! -L "$MACHORUN_LOADER" ] \
@@ -283,50 +310,81 @@ trap 'exit 143' TERM
 
 mkdir -p "$REPLAY_ROOT" "$EVIDENCE"
 git clone --no-hardlinks --no-local --quiet "$SUPPORT_CHECKOUT" "$REPLAY_ROOT/w"
-git clone --no-hardlinks --no-local --quiet "$UIKIT_CHECKOUT" "$REPLAY_ROOT/uikit"
-git clone --no-hardlinks --no-local --quiet "$MACHORUN_CHECKOUT" "$REPLAY_ROOT/machorun"
 assert_checkout "$REPLAY_ROOT/w" "$EXPECTED_SUPPORT_COMMIT" \
     "$EXPECTED_SUPPORT_TREE" cloned-support
-assert_checkout "$REPLAY_ROOT/uikit" "$EXPECTED_UIKIT_COMMIT" \
-    "$EXPECTED_UIKIT_TREE" cloned-OpenUIKit
-assert_checkout "$REPLAY_ROOT/machorun" "$EXPECTED_MACHORUN_COMMIT" \
-    "$EXPECTED_MACHORUN_TREE" cloned-machorun
-for copy in support OpenUIKit machorun; do
-    case "$copy" in
-        support) source_checkout=$SUPPORT_CHECKOUT; copied_checkout=$REPLAY_ROOT/w ;;
-        OpenUIKit) source_checkout=$UIKIT_CHECKOUT; copied_checkout=$REPLAY_ROOT/uikit ;;
-        machorun) source_checkout=$MACHORUN_CHECKOUT; copied_checkout=$REPLAY_ROOT/machorun ;;
-    esac
-    python3 -B "$PHYSICAL_REPLAY_TOOL" prove-git-copy \
-        --source "$source_checkout" --destination "$copied_checkout" \
-        --label "$copy" --output "$EVIDENCE/copy-$copy.json"
-done
+python3 -B "$PHYSICAL_REPLAY_TOOL" prove-git-copy \
+    --source "$SUPPORT_CHECKOUT" --destination "$REPLAY_ROOT/w" \
+    --label support --output "$EVIDENCE/copy-support.json"
 
-mkdir -p "$REPLAY_ROOT/machorun/build" "$REPLAY_ROOT/machorun/darwin"
+UIKIT_INREPO=0
+MACHORUN_INREPO=0
+vendor_is_inrepo "$SUPPORT_CHECKOUT" uikit "$UIKIT_CHECKOUT" && UIKIT_INREPO=1
+vendor_is_inrepo "$SUPPORT_CHECKOUT" machorun "$MACHORUN_CHECKOUT" && MACHORUN_INREPO=1
+
+if [ "$UIKIT_INREPO" -eq 1 ]; then
+    UIKIT_REPLAY=$REPLAY_ROOT/w/uikit
+    assert_vendor_tree "$REPLAY_ROOT/w" uikit "$UIKIT_REPLAY" \
+        "$EXPECTED_UIKIT_TREE" cloned-OpenUIKit
+    python3 -B "$PHYSICAL_REPLAY_TOOL" prove-git-copy \
+        --source "$SUPPORT_CHECKOUT" --destination "$REPLAY_ROOT/w" \
+        --label OpenUIKit --output "$EVIDENCE/copy-OpenUIKit.json"
+else
+    git clone --no-hardlinks --no-local --quiet "$UIKIT_CHECKOUT" "$REPLAY_ROOT/uikit"
+    assert_checkout "$REPLAY_ROOT/uikit" "$EXPECTED_UIKIT_COMMIT" \
+        "$EXPECTED_UIKIT_TREE" cloned-OpenUIKit
+    python3 -B "$PHYSICAL_REPLAY_TOOL" prove-git-copy \
+        --source "$UIKIT_CHECKOUT" --destination "$REPLAY_ROOT/uikit" \
+        --label OpenUIKit --output "$EVIDENCE/copy-OpenUIKit.json"
+    UIKIT_REPLAY=$REPLAY_ROOT/uikit
+fi
+
+if [ "$MACHORUN_INREPO" -eq 1 ]; then
+    MACHORUN_REPLAY=$REPLAY_ROOT/w/machorun
+    assert_vendor_tree "$REPLAY_ROOT/w" machorun "$MACHORUN_REPLAY" \
+        "$EXPECTED_MACHORUN_TREE" cloned-machorun
+    python3 -B "$PHYSICAL_REPLAY_TOOL" prove-git-copy \
+        --source "$SUPPORT_CHECKOUT" --destination "$REPLAY_ROOT/w" \
+        --label machorun --output "$EVIDENCE/copy-machorun.json"
+else
+    git clone --no-hardlinks --no-local --quiet "$MACHORUN_CHECKOUT" \
+        "$REPLAY_ROOT/machorun"
+    assert_checkout "$REPLAY_ROOT/machorun" "$EXPECTED_MACHORUN_COMMIT" \
+        "$EXPECTED_MACHORUN_TREE" cloned-machorun
+    python3 -B "$PHYSICAL_REPLAY_TOOL" prove-git-copy \
+        --source "$MACHORUN_CHECKOUT" --destination "$REPLAY_ROOT/machorun" \
+        --label machorun --output "$EVIDENCE/copy-machorun.json"
+    MACHORUN_REPLAY=$REPLAY_ROOT/machorun
+fi
+
+mkdir -p "$MACHORUN_REPLAY/build" "$MACHORUN_REPLAY/darwin"
 python3 -B "$PHYSICAL_REPLAY_TOOL" copy-file \
     --source "$MACHORUN_LOADER" \
-    --destination "$REPLAY_ROOT/machorun/build/machorun" \
+    --destination "$MACHORUN_REPLAY/build/machorun" \
     --label machorun-loader --output "$EVIDENCE/copy-machorun-loader.json"
 python3 -B "$PHYSICAL_REPLAY_TOOL" copy-tree \
     --source "$MACHORUN_RUNTIME" \
-    --destination "$REPLAY_ROOT/machorun/darwin/usr" \
+    --destination "$MACHORUN_REPLAY/darwin/usr" \
     --label machorun-runtime --output "$EVIDENCE/copy-machorun-runtime.json"
 COPIED_MACHORUN_LOADER_SHA256=$(shasum -a 256 \
-    "$REPLAY_ROOT/machorun/build/machorun" | awk '{print $1}')
+    "$MACHORUN_REPLAY/build/machorun" | awk '{print $1}')
 [ "$COPIED_MACHORUN_LOADER_SHA256" = "$EXPECTED_MACHORUN_LOADER_SHA256" ] \
     || die 'physically copied machorun loader hash differs'
 COPIED_MACHORUN_SWIFT_CORE_SHA256=$(shasum -a 256 \
-    "$REPLAY_ROOT/machorun/darwin/usr/lib/swift/libswiftCore.dylib" \
+    "$MACHORUN_REPLAY/darwin/usr/lib/swift/libswiftCore.dylib" \
     | awk '{print $1}')
 [ "$COPIED_MACHORUN_SWIFT_CORE_SHA256" = \
     "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256" ] \
     || die 'physically copied machorun Swift core hash differs'
 COPIED_MACHORUN_OBJC_SHA256=$(shasum -a 256 \
-    "$REPLAY_ROOT/machorun/darwin/usr/lib/libobjc.A.dylib" | awk '{print $1}')
+    "$MACHORUN_REPLAY/darwin/usr/lib/libobjc.A.dylib" | awk '{print $1}')
 [ "$COPIED_MACHORUN_OBJC_SHA256" = "$EXPECTED_MACHORUN_OBJC_SHA256" ] \
     || die 'physically copied machorun Objective-C runtime hash differs'
-assert_checkout "$REPLAY_ROOT/machorun" "$EXPECTED_MACHORUN_COMMIT" \
+assert_vendor_tree "$REPLAY_ROOT/w" machorun "$MACHORUN_REPLAY" \
     "$EXPECTED_MACHORUN_TREE" staged-machorun
+if [ "$MACHORUN_INREPO" -ne 1 ]; then
+    assert_checkout "$MACHORUN_REPLAY" "$EXPECTED_MACHORUN_COMMIT" \
+        "$EXPECTED_MACHORUN_TREE" staged-machorun
+fi
 
 mkdir -p "$REPLAY_ROOT/w/scratch"
 for relative in "${STAGED_INPUTS[@]}"; do
@@ -387,13 +445,22 @@ record_git_identity() {
     [ -z "$status" ] || die "$label staged Git checkout is dirty: $status"
     printf 'git\t%s\tcommit=%s\ttree=%s\n' "$label" "$commit" "$tree"
 }
+record_vendor_identity() {
+    local repo_root=$1 vendor_name=$2 vendor_path=$3 label=$4 tree
+    if vendor_is_inrepo "$repo_root" "$vendor_name" "$vendor_path"; then
+        tree=$(git -C "$repo_root" rev-parse --verify "HEAD:$vendor_name")
+        printf 'git\t%s\tsource=HEAD:%s\ttree=%s\n' "$label" "$vendor_name" "$tree"
+    else
+        record_git_identity "$vendor_path" "$label"
+    fi
+}
 {
     printf 'format\tcore-guest-host-run-v2\n'
     printf 'host-cwd\t%s\n' "$(pwd -P)"
     printf 'image\t%s\tplatform=%s\n' "$CONTAINER_IMAGE" "$IMAGE_PLATFORM"
     record_git_identity "$REPLAY_ROOT/w" support
-    record_git_identity "$REPLAY_ROOT/uikit" OpenUIKit
-    record_git_identity "$REPLAY_ROOT/machorun" machorun
+    record_vendor_identity "$REPLAY_ROOT/w" uikit "$UIKIT_REPLAY" OpenUIKit
+    record_vendor_identity "$REPLAY_ROOT/w" machorun "$MACHORUN_REPLAY" machorun
     record_git_identity "$REPLAY_ROOT/w/scratch/swift-foundation" swift-foundation
     record_git_identity "$REPLAY_ROOT/w/scratch/swift-foundation-icu" \
         swift-foundation-icu
@@ -421,6 +488,16 @@ record_git_identity() {
     printf 'preview\t%s\n' "$([ "$preview_count" -eq 3 ] && printf enabled || printf disabled)"
 } > "$EVIDENCE/host-inputs.tsv"
 
+if [ "$UIKIT_INREPO" -eq 1 ]; then
+    GUEST_UIKIT=/replay/w/uikit
+else
+    GUEST_UIKIT=/replay/uikit
+fi
+if [ "$MACHORUN_INREPO" -eq 1 ]; then
+    GUEST_MACHORUN=/replay/w/machorun
+else
+    GUEST_MACHORUN=/replay/machorun
+fi
 DOCKER_ARGS=(
     run --rm --platform linux/arm64
     --network none
@@ -431,7 +508,7 @@ DOCKER_ARGS=(
     -e TMPDIR=/tmp
     -e XDG_CACHE_HOME=/tmp/xdg-cache
     -e W=/replay/w
-    -e MACHORUN=/replay/machorun
+    -e MACHORUN="$GUEST_MACHORUN"
     --tmpfs /tmp:rw,exec,nosuid,nodev,mode=1777
     -v "$REPLAY_ROOT:/replay:rw"
 )
@@ -440,13 +517,16 @@ BUILD_ARGS=(
     --output-root /replay/w/build/core-package
     --expected-support-commit "$EXPECTED_SUPPORT_COMMIT"
     --expected-support-tree "$EXPECTED_SUPPORT_TREE"
-    --uikit-checkout /replay/uikit
-    --expected-uikit-commit "$EXPECTED_UIKIT_COMMIT"
+    --uikit-checkout "$GUEST_UIKIT"
     --expected-uikit-tree "$EXPECTED_UIKIT_TREE"
+    --machorun-checkout "$GUEST_MACHORUN"
     --expected-machorun-swift-core-sha256 \
         "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256"
     --expected-machorun-objc-sha256 "$EXPECTED_MACHORUN_OBJC_SHA256"
 )
+if [ "$UIKIT_INREPO" -ne 1 ]; then
+    BUILD_ARGS+=(--expected-uikit-commit "$EXPECTED_UIKIT_COMMIT")
+fi
 if [ "$preview_count" -eq 3 ]; then
     BUILD_ARGS+=(
         --developer-tools-support-module /replay/inputs/preview/DeveloperToolsSupport.swiftmodule

--- a/full/frameworks/test_core_guest_package.py
+++ b/full/frameworks/test_core_guest_package.py
@@ -3345,7 +3345,7 @@ class ShellContractTests(unittest.TestCase):
             "libquartz.dylib",
             "remove-tree",
             "assert_vendor_tree",
-            "HEAD:uikit",
+            "HEAD:$vendor_name",
             'UIKIT_CHECKOUT=$SUPPORT_CHECKOUT/uikit',
             'MACHORUN_CHECKOUT=$SUPPORT_CHECKOUT/machorun',
             "source=HEAD:",

--- a/full/frameworks/test_core_guest_package.py
+++ b/full/frameworks/test_core_guest_package.py
@@ -3135,7 +3135,9 @@ class ShellContractTests(unittest.TestCase):
             "--uikit-checkout",
             "--expected-uikit-commit",
             "--expected-uikit-tree",
-            "assert_clean_commit \"$UIKIT\"",
+            "assert_vendor_tree \"$W\" uikit",
+            "HEAD:uikit",
+            "EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE",
             "output root already exists",
             ".INVALID-DO-NOT-USE",
         ):
@@ -3308,15 +3310,10 @@ class ShellContractTests(unittest.TestCase):
         validate_swift_core_runtime_contract(builder, source)
         validate_build_full_swift_core_source(build_full)
         self.assertIn(
-            "EXPECTED_MACHORUN_COMMIT="
-            "98551893760e553c14d5dbb2c28138e014290918",
+            "EXPECTED_MACHORUN_TREE=$EXPECTED_INREPO_MACHORUN_TREE",
             builder,
         )
-        self.assertIn(
-            "EXPECTED_MACHORUN_TREE="
-            "d4448ff9f8a89c5cefad8b74f16db5d8d6ccff15",
-            builder,
-        )
+        self.assertNotIn("EXPECTED_MACHORUN_COMMIT=", builder)
         for obsolete_machorun_pin in (
             "d359cd37ac7f12a5048f4993eab6efd8259d9890",
             "e6b1745bef09ac8f1e2d6e6c83f7c70d6dbe49a5",
@@ -3347,6 +3344,11 @@ class ShellContractTests(unittest.TestCase):
             "durable guest-root product is missing after Docker",
             "libquartz.dylib",
             "remove-tree",
+            "assert_vendor_tree",
+            "HEAD:uikit",
+            'UIKIT_CHECKOUT=$SUPPORT_CHECKOUT/uikit',
+            'MACHORUN_CHECKOUT=$SUPPORT_CHECKOUT/machorun',
+            "source=HEAD:",
         ):
             self.assertIn(token, source)
         self.assertNotIn('"$STAGED_INPUT_ROOT/sysroot_fe4:/w/', source)

--- a/full/scripts/build_full.sh
+++ b/full/scripts/build_full.sh
@@ -25,8 +25,14 @@
 #
 # Runs in swift-macho-spike:noble.  /w = ~/swift-macho-linux, /uikit = ~/uikit:ro
 set -euo pipefail
-W=${W:-/w}
-UIKIT=${UIKIT:-/uikit}
+W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$W/scripts/vendor_tree.sh"
+die() {
+    echo "build_full: $*" >&2
+    exit 2
+}
+UIKIT=${UIKIT:-$W/uikit}
 TARGET=${TARGET:-arm64-apple-macos15.0}
 MINOS=${MINOS:-15.0}
 LINK_PLATFORM=${LINK_PLATFORM:-macos}
@@ -194,12 +200,14 @@ if [ "$BUILD_FULL_DEVELOPER_TOOLS_SUPPORT_MODE" = external ]; then
 fi
 
 # ---- guest root ------------------------------------------------------------
-# MACHORUN=/machorun is a read-only bind mount of ~/machorun, so the guest root
-# is always staged from the CURRENT loader and userland rather than from a copy
-# that silently goes stale. That mattered once already: a guest root staged
-# before machorun's heap-below-2^47 fix (9659e73) reproduced a bug that had
-# been fixed upstream hours earlier.
-MACHORUN=${MACHORUN:-/machorun}
+# MACHORUN defaults to the in-repo machorun/ subtree. External MACHORUN=/path
+# checkouts remain overrides. The guest root is always staged from the CURRENT
+# loader and userland rather than from a copy that silently goes stale. That
+# mattered once already: a guest root staged before machorun's heap-below-2^47
+# fix (9659e73) reproduced a bug that had been fixed upstream hours earlier.
+MACHORUN=${MACHORUN:-$W/machorun}
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_INREPO_UIKIT_TREE" OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
 SWIFT_CORE_RUNTIME_SOURCE=${SWIFT_CORE_RUNTIME_SOURCE:-$MACHORUN/darwin/usr/lib/swift/libswiftCore.dylib}
 SWIFT_CORE_RUNTIME_EXPECTED_SHA256=${SWIFT_CORE_RUNTIME_EXPECTED_SHA256:-}
 # REFUSE WITHOUT THE MOUNT, rather than silently building half a root.
@@ -218,16 +226,12 @@ for req in "$MACHORUN/build/machorun" \
 
 build_full: REFUSING TO BUILD -- $req is missing.
 
-  MACHORUN=$MACHORUN does not look like a machorun checkout. Without it every
+  MACHORUN=$MACHORUN does not look like a built machorun tree. Without it every
   freshness test below is silently FALSE and the loader + umbrella steps are
   skipped, producing a guest root assembled from whatever was already on disk.
 
-  Add the mount:
-    docker run --rm -v ~/swift-macho-linux:/w -v ~/uikit:/uikit:ro \\
-        -v ~/machorun:/machorun:ro -w /w \\
-        swift-macho-spike:noble bash full/scripts/build_full.sh
-
-  (If machorun is checked out elsewhere, mount it and set MACHORUN=<that path>.)
+  In-repo default is $W/machorun (build products live at machorun/build and
+  machorun/darwin/usr). Build that tree, or set MACHORUN to a built checkout.
 EOF
     exit 2
 done

--- a/full/scripts/run_indexpath_identity.sh
+++ b/full/scripts/run_indexpath_identity.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
-UIKIT=${UIKIT:-"$(cd "$ROOT/../uikit" 2>/dev/null && pwd)"}
+UIKIT=${UIKIT:-"$ROOT/uikit"}
 MRROOT=/w/scratch/mrroot_full
 PROBE=$ROOT/build/full/indexpath_identity_probe
 SUBJECT_FILE=$ROOT/build/full/uihelpers-subject.sha256

--- a/full/scripts/run_suite.sh
+++ b/full/scripts/run_suite.sh
@@ -13,7 +13,7 @@
 # nothing to do with machorun.
 set -uo pipefail
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
-UIKIT=${UIKIT:-$HOME/uikit}
+UIKIT=${UIKIT:-$ROOT/uikit}
 SUITE=${SUITE:-suite}
 CONTAINER_IMAGE=${CONTAINER_IMAGE:-swift-macho-spike:noble}
 # MRROOT lets a run use an alternative guest root -- e.g. one with a different

--- a/full/scripts/run_uihelpers.sh
+++ b/full/scripts/run_uihelpers.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
-UIKIT=${UIKIT:-"$(cd "$ROOT/../uikit" 2>/dev/null && pwd)"}
+UIKIT=${UIKIT:-"$ROOT/uikit"}
 MRROOT=/w/scratch/mrroot_full
 RENDERER=$ROOT/build/full/render_full
 SUBJECT_FILE=$ROOT/build/full/uihelpers-subject.sha256

--- a/full/swiftui/FOCUS_ONBOARDING_GUEST.md
+++ b/full/swiftui/FOCUS_ONBOARDING_GUEST.md
@@ -6,9 +6,10 @@ clean `a2832521c1daa0c23419c73705ae043ed60c9791` checkout: the two `Widget`
 files plus the ten files that define the production onboarding views, model,
 design-system accessors, and `PortraitHostingController`. No Focus source is
 copied, patched, overlaid, generated, or conditionally rewritten.
-The framework side is pinned independently to clean OpenUIKit commit
-`62dea0d97a3b9074e5c016820492bd0656b9a35a`, tree
-`3dfd6024557632949c9a5036522871a36d4a0cf0`, before and after the build/run.
+The framework side is pinned independently to the in-repo `uikit/` subtree
+tree `8ce87c1aef592553336aadf9101ec2bb4ebe6aaa` (`git rev-parse HEAD:uikit`)
+before and after the build/run. A dirty subtree is refused. `UIKIT=/path`
+remains an external checkout override.
 
 The project-owned harness mounts the exact `OnboardingView` through Focus's
 exact `PortraitHostingController`. It finds controls through the mounted
@@ -97,8 +98,6 @@ Focus resource bundles described by `full/focus-ios/onboarding_resources_proof.p
 ```bash
 docker run --rm \
   -v "$PWD":/w \
-  -v /Users/miguelsalinas/uikit:/uikit:ro \
-  -v /Users/miguelsalinas/machorun:/machorun:ro \
   -v "$RESOURCE_PROOF/output/bundles":/focus-resources:ro \
   -w /w swift-macho-spike:noble \
   bash full/swiftui/build_focus_onboarding_guest.sh /focus-resources

--- a/full/swiftui/FOCUS_PACKAGE_GUEST.md
+++ b/full/swiftui/FOCUS_PACKAGE_GUEST.md
@@ -7,16 +7,18 @@ listed below:
 
 | Target | Revision | Upstream Swift files | Compiled |
 | --- | --- | ---: | ---: |
-| OpenUIKit | `62dea0d97a3b9074e5c016820492bd0656b9a35a` | 105 | 105 |
+| OpenUIKit | in-repo `HEAD:uikit` `8ce87c1aef592553336aadf9101ec2bb4ebe6aaa` | 105 | 105 |
 | SnapKit | `e74fe2a978d1216c3602b129447c7301573cc2d8` | 37 | 36 |
 | Focus DesignSystem | `a2832521c1daa0c23419c73705ae043ed60c9791` | 7 | 7 |
 | Focus Widget | same Focus revision | 2 | 2 |
 | Focus Onboarding | same Focus revision | 21 | 21 |
 | Focus Licenses | same Focus revision | 2 | 2 |
 
-The OpenUIKit commit above has exact tree
-`3dfd6024557632949c9a5036522871a36d4a0cf0`; all three Focus guest scripts
-require that clean commit/tree before and after their gates.
+The OpenUIKit pin above is the in-repo subtree tree
+`8ce87c1aef592553336aadf9101ec2bb4ebe6aaa` (`git rev-parse HEAD:uikit`); all
+three Focus guest scripts require that clean tree before and after their
+gates and refuse a dirty `uikit/` subtree. `UIKIT=/path` remains an external
+checkout override.
 
 The shared substrate remains pinned to swift-foundation
 `c6793ef0c19c2cbaeba5a0e52078f129afc7dcfc`, swift-collections
@@ -183,14 +185,14 @@ UUID, resource, and telemetry proof with a weaker compile-only claim.
 
 ## Reproduce
 
-Both build scripts require the literal exact landed OpenUIKit commit shown
-above. Environment variables cannot override this provenance boundary.
+Both build scripts require the literal exact landed in-repo OpenUIKit tree
+shown above (`git rev-parse HEAD:uikit`). Environment variables cannot
+override this provenance boundary; `UIKIT=/path` may only point at a clean
+checkout whose tree matches the pin.
 
 ```bash
 docker run --rm --platform linux/arm64 \
   -v "$PWD":/w \
-  -v /path/to/exact-uikit:/uikit:ro \
-  -v /path/to/machorun:/machorun:ro \
   -v "$RESOURCE_PROOF/output/bundles":/focus-resources:ro \
   -w /w swift-macho-spike:noble \
   bash full/swiftui/build_focus_package_guest.sh /focus-resources

--- a/full/swiftui/FOCUS_WIDGET_GUEST.md
+++ b/full/swiftui/FOCUS_WIDGET_GUEST.md
@@ -14,8 +14,12 @@ separate guest processes, and writes a
 135-point, 270x270-pixel PNG at 2x scale.
 
 The framework checkout is independently pinned clean before and after the
-gate to OpenUIKit commit `62dea0d97a3b9074e5c016820492bd0656b9a35a`,
-tree `3dfd6024557632949c9a5036522871a36d4a0cf0`.
+gate to the in-repo `uikit/` subtree tree
+`8ce87c1aef592553336aadf9101ec2bb4ebe6aaa` (`git rev-parse HEAD:uikit`),
+which is OpenUIKit `06aaf82bc64672d269064507533e75a86e5a1da3` (30 commits
+after the old external pin `62dea0d97a3b9074e5c016820492bd0656b9a35a`).
+A dirty `uikit/` subtree is refused. `UIKIT=/path` remains an external
+checkout override and must match the same tree.
 
 No Focus source is copied, patched, overlaid, conditionally rewritten, or
 generated. `FocusWidgetBundle.generated.swift` is separately labelled
@@ -144,13 +148,15 @@ match the same reviewed bytes.
 ```bash
 docker run --rm \
   -v "$PWD":/w \
-  -v /Users/miguelsalinas/uikit:/uikit:ro \
-  -v /Users/miguelsalinas/machorun:/machorun:ro \
-  -v "$RESOURCE_PROOF/output/bundles":/focus-resources:ro \
   -w /w swift-macho-spike:noble \
   bash full/swiftui/build_focus_widget_guest.sh \
     /focus-resources/Focus_Widget.bundle
 ```
+
+The in-repo `uikit/` and `machorun/` subtrees are the default. External
+checkouts remain overrides via `UIKIT=/path` and `MACHORUN=/path`. The
+resource-proof parent is still mounted read-only when the normalized bundle
+is not already in the workspace.
 
 Generated output lives only under `build/swiftui-guest/`. This is an exact S1
 widget-slice execution proof, not a linked Focus application, WidgetKit

--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # Build Focus's exact SwiftUI Onboarding runtime sources as reusable ARM64
 # Mach-O modules/dylibs and run a project-owned interaction harness on Linux.
-# Run inside swift-macho-spike:noble with /w writable, /uikit and /machorun
-# read-only, and the reviewed resource proof's bundles mounted read-only.
+# Defaults to the in-repo uikit/ and machorun/ subtrees. External UIKIT=/path
+# or MACHORUN=/path checkouts remain overrides.
 
 set -euo pipefail
 
-W=${W:-/w}
-UIKIT=${UIKIT:-/uikit}
-MACHORUN=${MACHORUN:-/machorun}
+W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$W/scripts/vendor_tree.sh"
+UIKIT=${UIKIT:-$W/uikit}
+MACHORUN=${MACHORUN:-$W/machorun}
 RESOURCE_INPUT=${1:?usage: build_focus_onboarding_guest.sh <normalized-bundles-directory>}
 FOCUS_REPO=$W/scratch/ladder-corpus/focus-ios/focus-ios
 FOCUS_ROOT=$W/scratch/ladder-corpus/focus-ios
@@ -29,8 +31,7 @@ OPENCOMBINE_HELPERS=$OPENCOMBINE_SOURCE/Sources/COpenCombineHelpers
 FOUNDATION_GUEST_MANIFEST=$W/full/foundation/foundation_guest_sources.txt
 
 EXPECTED_FOCUS_COMMIT=a2832521c1daa0c23419c73705ae043ed60c9791
-EXPECTED_UIKIT_COMMIT=62dea0d97a3b9074e5c016820492bd0656b9a35a
-EXPECTED_UIKIT_TREE=3dfd6024557632949c9a5036522871a36d4a0cf0
+EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
 EXPECTED_FOCUS_SWIFT_COUNT=227
 EXPECTED_ONBOARDING_TREE=3db199a93294a4ea0e6549522c29e8b2e4dbfb979bd60c07cdad5d00386734f5
 EXPECTED_ONBOARDING_FILES=66
@@ -160,8 +161,8 @@ done
     || die 'legacy Focus Foundation exclusion contract drifted'
 
 assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" Focus
-assert_clean_commit "$UIKIT" "$EXPECTED_UIKIT_COMMIT" OpenUIKit \
-    "$EXPECTED_UIKIT_TREE"
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
 ONBOARDING_INPUT=$RESOURCE_INPUT/Focus_Onboarding.bundle
 WIDGET_INPUT=$RESOURCE_INPUT/Focus_Widget.bundle
 validate_bundle "$ONBOARDING_INPUT" "$EXPECTED_ONBOARDING_FILES" \
@@ -551,8 +552,8 @@ for index in "${!SOURCE_RELATIVES[@]}"; do
         "${SOURCE_HASHES[$index]}" "post-run Focus source ${SOURCE_RELATIVES[$index]}"
 done
 assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" post-run-Focus
-assert_clean_commit "$UIKIT" "$EXPECTED_UIKIT_COMMIT" post-run-OpenUIKit \
-    "$EXPECTED_UIKIT_TREE"
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" post-run-OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" post-run-machorun
 validate_bundle "$RESOURCE_INPUT/Focus_Onboarding.bundle" "$EXPECTED_ONBOARDING_FILES" \
     "$EXPECTED_ONBOARDING_DIRECTORIES" "$EXPECTED_ONBOARDING_TREE" post-run-Onboarding-input
 validate_bundle "$RESOURCE_INPUT/Focus_Widget.bundle" "$EXPECTED_WIDGET_FILES" \

--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -160,9 +160,19 @@ done
     && [ "${#FOUNDATION_GUEST_SOURCES[@]}" -eq 37 ] \
     || die 'legacy Focus Foundation exclusion contract drifted'
 
-assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" Focus
 assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
 assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
+if vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    echo "focus_onboarding_guest: attested OpenUIKit source=HEAD:uikit tree=$EXPECTED_UIKIT_TREE"
+else
+    echo "focus_onboarding_guest: attested OpenUIKit source=checkout tree=$EXPECTED_UIKIT_TREE"
+fi
+if vendor_is_inrepo "$W" machorun "$MACHORUN"; then
+    echo "focus_onboarding_guest: attested machorun source=HEAD:machorun tree=$EXPECTED_INREPO_MACHORUN_TREE"
+else
+    echo "focus_onboarding_guest: attested machorun source=checkout tree=$EXPECTED_INREPO_MACHORUN_TREE"
+fi
+assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" Focus
 ONBOARDING_INPUT=$RESOURCE_INPUT/Focus_Onboarding.bundle
 WIDGET_INPUT=$RESOURCE_INPUT/Focus_Widget.bundle
 validate_bundle "$ONBOARDING_INPUT" "$EXPECTED_ONBOARDING_FILES" \

--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -114,6 +114,18 @@ validate_bundle() {
 
 [ "$OUT" = "$W/build/focus-onboarding-guest" ] \
     || die "derived output path invariant changed"
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
+if vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    echo "focus_onboarding_guest: attested OpenUIKit source=HEAD:uikit tree=$EXPECTED_UIKIT_TREE"
+else
+    echo "focus_onboarding_guest: attested OpenUIKit source=checkout tree=$EXPECTED_UIKIT_TREE"
+fi
+if vendor_is_inrepo "$W" machorun "$MACHORUN"; then
+    echo "focus_onboarding_guest: attested machorun source=HEAD:machorun tree=$EXPECTED_INREPO_MACHORUN_TREE"
+else
+    echo "focus_onboarding_guest: attested machorun source=checkout tree=$EXPECTED_INREPO_MACHORUN_TREE"
+fi
 for tool in git swiftc clang-18 clang++-18 ld64.lld-18 llvm-nm-18 llvm-otool-18 \
     sha256sum patch; do
     command -v "$tool" >/dev/null || die "required tool is missing: $tool"
@@ -160,18 +172,6 @@ done
     && [ "${#FOUNDATION_GUEST_SOURCES[@]}" -eq 37 ] \
     || die 'legacy Focus Foundation exclusion contract drifted'
 
-assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
-assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
-if vendor_is_inrepo "$W" uikit "$UIKIT"; then
-    echo "focus_onboarding_guest: attested OpenUIKit source=HEAD:uikit tree=$EXPECTED_UIKIT_TREE"
-else
-    echo "focus_onboarding_guest: attested OpenUIKit source=checkout tree=$EXPECTED_UIKIT_TREE"
-fi
-if vendor_is_inrepo "$W" machorun "$MACHORUN"; then
-    echo "focus_onboarding_guest: attested machorun source=HEAD:machorun tree=$EXPECTED_INREPO_MACHORUN_TREE"
-else
-    echo "focus_onboarding_guest: attested machorun source=checkout tree=$EXPECTED_INREPO_MACHORUN_TREE"
-fi
 assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" Focus
 ONBOARDING_INPUT=$RESOURCE_INPUT/Focus_Onboarding.bundle
 WIDGET_INPUT=$RESOURCE_INPUT/Focus_Widget.bundle

--- a/full/swiftui/build_focus_package_guest.sh
+++ b/full/swiftui/build_focus_package_guest.sh
@@ -3,12 +3,16 @@
 # package targets: SnapKit 36 of 37, DesignSystem 7, Widget 2, Onboarding 21, and
 # Licenses 2. Run Bundle, Published, constraint-lifecycle, plist decode, and
 # SwiftUI navigation behavior under Linux/machorun.
+# Defaults to the in-repo uikit/ and machorun/ subtrees. External UIKIT=/path
+# or MACHORUN=/path checkouts remain overrides.
 
 set -euo pipefail
 
-W=${W:-/w}
-UIKIT=${UIKIT:-/uikit}
-MACHORUN=${MACHORUN:-/machorun}
+W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$W/scripts/vendor_tree.sh"
+UIKIT=${UIKIT:-$W/uikit}
+MACHORUN=${MACHORUN:-$W/machorun}
 RESOURCE_INPUT=${1:?usage: build_focus_package_guest.sh <normalized-bundles-directory>}
 
 FOCUS_ROOT=$W/scratch/ladder-corpus/focus-ios
@@ -26,8 +30,7 @@ MRROOT=$W/scratch/mrroot_full
 SWIFT_FOUNDATION=$W/scratch/swift-foundation
 
 EXPECTED_FOCUS_COMMIT=a2832521c1daa0c23419c73705ae043ed60c9791
-EXPECTED_UIKIT_COMMIT=62dea0d97a3b9074e5c016820492bd0656b9a35a
-EXPECTED_UIKIT_TREE=3dfd6024557632949c9a5036522871a36d4a0cf0
+EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
 EXPECTED_SNAPKIT_COMMIT=e74fe2a978d1216c3602b129447c7301573cc2d8
 EXPECTED_FOUNDATION_COMMIT=c6793ef0c19c2cbaeba5a0e52078f129afc7dcfc
 EXPECTED_OPENCOMBINE_COMMIT=1c6f02c7ed8140c0ba7a783aaddb6e0685a0037b
@@ -121,8 +124,8 @@ done
 
 assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" Focus
 assert_clean_commit "$SNAPKIT_ROOT" "$EXPECTED_SNAPKIT_COMMIT" SnapKit
-assert_clean_commit "$UIKIT" "$EXPECTED_UIKIT_COMMIT" OpenUIKit \
-    "$EXPECTED_UIKIT_TREE"
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
 assert_clean_commit "$SWIFT_FOUNDATION" "$EXPECTED_FOUNDATION_COMMIT" swift-foundation
 
 OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-20260828-r2}
@@ -566,14 +569,15 @@ cmp -s "$ACCESSOR_ORACLE" "$AUDIT/post-resource-accessor-provenance.tsv" \
     || die "post-run accessor provenance diverged from reviewed oracle"
 assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" post-run-Focus
 assert_clean_commit "$SNAPKIT_ROOT" "$EXPECTED_SNAPKIT_COMMIT" post-run-SnapKit
-assert_clean_commit "$UIKIT" "$EXPECTED_UIKIT_COMMIT" post-run-OpenUIKit \
-    "$EXPECTED_UIKIT_TREE"
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" post-run-OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" post-run-machorun
 assert_clean_commit "$SWIFT_FOUNDATION" "$EXPECTED_FOUNDATION_COMMIT" post-run-swift-foundation
 assert_clean_commit "$OPENCOMBINE_ROOT/source" "$EXPECTED_OPENCOMBINE_COMMIT" post-run-OpenCombine
 
 {
-    printf 'uikit-commit\t%s\n' "$EXPECTED_UIKIT_COMMIT"
     printf 'uikit-tree\t%s\n' "$EXPECTED_UIKIT_TREE"
+    printf 'uikit-tree-source\tHEAD:uikit\n'
+    printf 'machorun-tree\t%s\n' "$EXPECTED_INREPO_MACHORUN_TREE"
     printf 'snapkit-sources\t%s\n' "$(hash_file "$AUDIT/snapkit-sources.tsv")"
     printf 'snapkit-exclusions\t%s\n' "$(hash_file "$AUDIT/snapkit-exclusions.tsv")"
     printf 'designsystem-sources\t%s\n' "$(hash_file "$AUDIT/designsystem-sources.tsv")"

--- a/full/swiftui/build_focus_package_guest.sh
+++ b/full/swiftui/build_focus_package_guest.sh
@@ -116,6 +116,18 @@ check_source_manifest() {
 
 [ "$OUT" = "$W/build/focus-package-guest" ] \
     || die "derived output path invariant changed"
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
+if vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    echo "focus_package_guest: attested OpenUIKit source=HEAD:uikit tree=$EXPECTED_UIKIT_TREE"
+else
+    echo "focus_package_guest: attested OpenUIKit source=checkout tree=$EXPECTED_UIKIT_TREE"
+fi
+if vendor_is_inrepo "$W" machorun "$MACHORUN"; then
+    echo "focus_package_guest: attested machorun source=HEAD:machorun tree=$EXPECTED_INREPO_MACHORUN_TREE"
+else
+    echo "focus_package_guest: attested machorun source=checkout tree=$EXPECTED_INREPO_MACHORUN_TREE"
+fi
 for tool in git swiftc ld64.lld-18 llvm-otool-18 sha256sum perl cmp; do
     command -v "$tool" >/dev/null || die "required tool is missing: $tool"
 done
@@ -124,8 +136,6 @@ done
 
 assert_clean_commit "$FOCUS_ROOT" "$EXPECTED_FOCUS_COMMIT" Focus
 assert_clean_commit "$SNAPKIT_ROOT" "$EXPECTED_SNAPKIT_COMMIT" SnapKit
-assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
-assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
 assert_clean_commit "$SWIFT_FOUNDATION" "$EXPECTED_FOUNDATION_COMMIT" swift-foundation
 
 OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-20260828-r2}

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # Package the local SwiftUI/OpenUIKit implementation as arm64 Mach-O dylibs,
 # link Focus's exact Widget/Assets.swift + SearchWidgetView.swift against those
-# dylibs, and run the guest. Run inside swift-macho-spike:noble with /w,
-# /uikit, /machorun, and a normalized Focus_Widget.bundle mounted.
+# dylibs, and run the guest. Defaults to the in-repo uikit/ and machorun/
+# subtrees. External UIKIT=/path or MACHORUN=/path checkouts remain overrides.
 
 set -euo pipefail
 
-W=${W:-/w}
-UIKIT=${UIKIT:-/uikit}
-MACHORUN=${MACHORUN:-/machorun}
+W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
+# shellcheck source=../../scripts/vendor_tree.sh
+. "$W/scripts/vendor_tree.sh"
+UIKIT=${UIKIT:-$W/uikit}
+MACHORUN=${MACHORUN:-$W/machorun}
 RESOURCE_INPUT=${1:?usage: build_focus_widget_guest.sh <normalized-Focus_Widget.bundle>}
 FOCUS_REPO=$W/scratch/ladder-corpus/focus-ios/focus-ios
 FOCUS_WIDGET=$FOCUS_REPO/BlockzillaPackage/Sources/Widget
@@ -51,8 +53,7 @@ for swiftui_source in "${SWIFTUI_SOURCES[@]}"; do
 done
 
 EXPECTED_FOCUS_COMMIT=a2832521c1daa0c23419c73705ae043ed60c9791
-EXPECTED_UIKIT_COMMIT=62dea0d97a3b9074e5c016820492bd0656b9a35a
-EXPECTED_UIKIT_TREE=3dfd6024557632949c9a5036522871a36d4a0cf0
+EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE
 EXPECTED_ASSETS_SHA=efac8d1c98b562374e54eea7540b4201523db670a6353eff8f0a0273d294526e
 EXPECTED_VIEW_SHA=721669388a4556e1609f580ed87d6065b63981770e71b0f77db292767b05f6c2
 EXPECTED_INDEX_SHA=2eb8af32cc6d69161dc35f1536682dcba2dd4db21ea0015cf241701f32468d12
@@ -81,6 +82,11 @@ EXPECTED_OPENCOMBINE_MODULEMAP_SHA=d34fdd050111a8cbf5ced89a129088fcfeb2964eea76a
 EXPECTED_OPENCOMBINE_PATCH_SHA=875cd931e95c5442775e1042a412517ab7475be0489b1a81f824a54f6872c79b
 EXPECTED_OPENCOMBINE_PATCHED_HELPER_SHA=d9fbefcdba66d892d9064c46b21b6084af217ddec1d604bcaf27b160de66083b
 EXPECTED_COMBINE_SHIM_SHA=828b05c3a47296fb7b0b9ed5a6ca1a45a5da46e245441c21028335f60511799f
+
+die() {
+    echo "focus_widget_guest: $*" >&2
+    exit 2
+}
 
 hash_file() { sha256sum "$1" | awk '{print $1}'; }
 hash_stream() { sha256sum | awk '{print $1}'; }
@@ -190,13 +196,8 @@ runtime_fingerprint() {
     } | hash_stream
 }
 
-[ "$(git -C "$UIKIT" rev-parse --verify HEAD^{commit})" = "$EXPECTED_UIKIT_COMMIT" ] || {
-    echo "focus_widget_guest: OpenUIKit revision is not pinned $EXPECTED_UIKIT_COMMIT" >&2; exit 2; }
-[ "$(git -C "$UIKIT" rev-parse --verify HEAD^{tree})" = "$EXPECTED_UIKIT_TREE" ] || {
-    echo "focus_widget_guest: OpenUIKit tree is not pinned $EXPECTED_UIKIT_TREE" >&2; exit 2; }
-uikit_status_before=$(git -C "$UIKIT" status --porcelain=v1 --untracked-files=all)
-[ -z "$uikit_status_before" ] || {
-    echo "focus_widget_guest: OpenUIKit checkout is not clean" >&2; exit 2; }
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
 [ "$(git -C "$FOCUS_REPO" rev-parse HEAD)" = "$EXPECTED_FOCUS_COMMIT" ] || {
     echo "focus_widget_guest: Focus revision is not pinned $EXPECTED_FOCUS_COMMIT" >&2; exit 2; }
 focus_status_before=$(git -C "$FOCUS_REPO" status --porcelain=v1 --untracked-files=all)
@@ -1245,12 +1246,8 @@ current_full_subject_after=$(bash "$W/full/scripts/uihelpers_subject.sh" "$W" "$
     echo "focus_widget_guest: authoritative OpenUIKit sources changed during execution" >&2
     exit 2
 }
-[ "$(git -C "$UIKIT" rev-parse --verify HEAD^{commit})" = "$EXPECTED_UIKIT_COMMIT" ] && \
-    [ "$(git -C "$UIKIT" rev-parse --verify HEAD^{tree})" = "$EXPECTED_UIKIT_TREE" ] && \
-    [ -z "$(git -C "$UIKIT" status --porcelain=v1 --untracked-files=all)" ] || {
-    echo "focus_widget_guest: pinned OpenUIKit checkout changed during execution" >&2
-    exit 2
-}
+assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" post-OpenUIKit
+assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" post-machorun
 assert_build_input_inventory
 assert_runtime_closure
 [ -z "$(git -C "$FOCUS_REPO" status --porcelain=v1 --untracked-files=all)" ] || {
@@ -1259,8 +1256,10 @@ require_hash "$FOCUS_WIDGET/Assets.swift" "$EXPECTED_ASSETS_SHA" Assets.swift
 require_hash "$FOCUS_WIDGET/SearchWidgetView.swift" "$EXPECTED_VIEW_SHA" SearchWidgetView.swift
 
 {
-    printf 'uikit_commit\t%s\n' "$EXPECTED_UIKIT_COMMIT"
     printf 'uikit_tree\t%s\n' "$EXPECTED_UIKIT_TREE"
+    printf 'uikit_tree_source\tHEAD:uikit\n'
+    printf 'machorun_tree\t%s\n' "$EXPECTED_INREPO_MACHORUN_TREE"
+    printf 'machorun_tree_source\tHEAD:machorun\n'
     printf 'focus_commit\t%s\n' "$EXPECTED_FOCUS_COMMIT"
     printf 'Assets.swift\t%s\n' "$EXPECTED_ASSETS_SHA"
     printf 'SearchWidgetView.swift\t%s\n' "$EXPECTED_VIEW_SHA"

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -198,6 +198,16 @@ runtime_fingerprint() {
 
 assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
 assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun
+if vendor_is_inrepo "$W" uikit "$UIKIT"; then
+    echo "focus_widget_guest: attested OpenUIKit source=HEAD:uikit tree=$EXPECTED_UIKIT_TREE"
+else
+    echo "focus_widget_guest: attested OpenUIKit source=checkout tree=$EXPECTED_UIKIT_TREE"
+fi
+if vendor_is_inrepo "$W" machorun "$MACHORUN"; then
+    echo "focus_widget_guest: attested machorun source=HEAD:machorun tree=$EXPECTED_INREPO_MACHORUN_TREE"
+else
+    echo "focus_widget_guest: attested machorun source=checkout tree=$EXPECTED_INREPO_MACHORUN_TREE"
+fi
 [ "$(git -C "$FOCUS_REPO" rev-parse HEAD)" = "$EXPECTED_FOCUS_COMMIT" ] || {
     echo "focus_widget_guest: Focus revision is not pinned $EXPECTED_FOCUS_COMMIT" >&2; exit 2; }
 focus_status_before=$(git -C "$FOCUS_REPO" status --porcelain=v1 --untracked-files=all)

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -77,6 +77,7 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             "EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE",
             text,
         )
+        self.assertIn("attested OpenUIKit source=HEAD:uikit", text)
         self.assertNotIn(
             "EXPECTED_UIKIT_COMMIT="
             "62dea0d97a3b9074e5c016820492bd0656b9a35a",

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -72,13 +72,17 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
 
     def test_inputs_are_clean_and_resources_are_content_pinned(self) -> None:
         text = BUILD.read_text()
-        self.assertIn("assert_clean_commit", text)
+        self.assertIn("assert_vendor_tree", text)
         self.assertIn(
+            "EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE",
+            text,
+        )
+        self.assertNotIn(
             "EXPECTED_UIKIT_COMMIT="
             "62dea0d97a3b9074e5c016820492bd0656b9a35a",
             text,
         )
-        self.assertIn(
+        self.assertNotIn(
             "EXPECTED_UIKIT_TREE="
             "3dfd6024557632949c9a5036522871a36d4a0cf0",
             text,

--- a/full/swiftui/test_focus_package_guest.py
+++ b/full/swiftui/test_focus_package_guest.py
@@ -44,6 +44,7 @@ class FocusPackageGuestProofTests(unittest.TestCase):
             text,
         )
         self.assertIn('assert_vendor_tree "$W" uikit', text)
+        self.assertIn("attested OpenUIKit source=HEAD:uikit", text)
         self.assertIn(
             'bash "$W/full/swiftui/build_focus_onboarding_guest.sh"', text
         )

--- a/full/swiftui/test_focus_package_guest.py
+++ b/full/swiftui/test_focus_package_guest.py
@@ -40,21 +40,22 @@ class FocusPackageGuestProofTests(unittest.TestCase):
     def test_landed_uikit_is_literal_and_base_proof_is_preserved(self) -> None:
         text = BUILD.read_text()
         self.assertIn(
-            "EXPECTED_UIKIT_COMMIT="
-            "62dea0d97a3b9074e5c016820492bd0656b9a35a",
+            "EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE",
             text,
         )
-        self.assertIn(
-            "EXPECTED_UIKIT_TREE="
-            "3dfd6024557632949c9a5036522871a36d4a0cf0",
-            text,
-        )
+        self.assertIn('assert_vendor_tree "$W" uikit', text)
         self.assertIn(
             'bash "$W/full/swiftui/build_focus_onboarding_guest.sh"', text
         )
         self.assertNotIn("EXPECTED_UIKIT_COMMIT_OVERRIDE", text)
         self.assertNotIn("${EXPECTED_UIKIT_COMMIT:?", text)
+        self.assertNotIn(
+            "EXPECTED_UIKIT_COMMIT="
+            "62dea0d97a3b9074e5c016820492bd0656b9a35a",
+            text,
+        )
         self.assertIn("printf 'uikit-tree\\t%s\\n'", text)
+        self.assertIn("HEAD:uikit", text)
         self.assertIn("FOCUS_ONBOARDING_MACHO_GUEST_OK", BASE_BUILD.read_text())
 
     def test_exact_unchanged_source_boundaries_are_pinned(self) -> None:

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -21,21 +21,39 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
     def test_build_compiles_pinned_focus_paths_directly(self) -> None:
         text = BUILD.read_text()
         self.assertIn(
+            "EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE",
+            text,
+        )
+        self.assertIn('assert_vendor_tree "$W" uikit', text)
+        self.assertIn("HEAD:uikit", text)
+        self.assertIn("printf 'uikit_tree\\t%s\\n'", text)
+        pins = (ROOT / "scripts/vendor_pins.sh").read_text()
+        self.assertIn(
+            "EXPECTED_INREPO_UIKIT_TREE="
+            "8ce87c1aef592553336aadf9101ec2bb4ebe6aaa",
+            pins,
+        )
+        self.assertNotIn(
             "EXPECTED_UIKIT_COMMIT="
             "62dea0d97a3b9074e5c016820492bd0656b9a35a",
             text,
         )
-        self.assertIn(
+        self.assertNotIn(
             "EXPECTED_UIKIT_TREE="
             "3dfd6024557632949c9a5036522871a36d4a0cf0",
             text,
         )
-        self.assertIn("OpenUIKit checkout is not clean", text)
-        self.assertIn("pinned OpenUIKit checkout changed during execution", text)
-        self.assertIn("printf 'uikit_commit\\t%s\\n'", text)
-        self.assertIn("printf 'uikit_tree\\t%s\\n'", text)
         self.assertIn('"$FOCUS_WIDGET/Assets.swift"', text)
         self.assertIn('"$FOCUS_WIDGET/SearchWidgetView.swift"', text)
+        actual_tree = subprocess.check_output(
+            ["git", "rev-parse", "HEAD:uikit"],
+            cwd=ROOT,
+            text=True,
+        ).strip()
+        self.assertEqual(
+            actual_tree,
+            "8ce87c1aef592553336aadf9101ec2bb4ebe6aaa",
+        )
         self.assertIn("efac8d1c98b562374e54eea7540b4201523db670a6353eff8f0a0273d294526e", text)
         self.assertIn("721669388a4556e1609f580ed87d6065b63981770e71b0f77db292767b05f6c2", text)
         self.assertNotRegex(text, r"(?m)^\s*(cp|sed|perl|python\d*)\b.*\$FOCUS_WIDGET/(Assets|SearchWidgetView)\.swift")

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -26,6 +26,7 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         )
         self.assertIn('assert_vendor_tree "$W" uikit', text)
         self.assertIn("HEAD:uikit", text)
+        self.assertIn("attested OpenUIKit source=HEAD:uikit", text)
         self.assertIn("printf 'uikit_tree\\t%s\\n'", text)
         pins = (ROOT / "scripts/vendor_pins.sh").read_text()
         self.assertIn(

--- a/scripts/require_fresh_root.sh
+++ b/scripts/require_fresh_root.sh
@@ -87,7 +87,7 @@
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-MACHORUN=${MACHORUN:-$HOME/machorun}
+MACHORUN=${MACHORUN:-$ROOT/machorun}
 TARGET=${1:?usage: require_fresh_root.sh <path-to-guest-root>}
 case "$TARGET" in /*) ;; *) TARGET="$ROOT/$TARGET" ;; esac
 SHORT=${TARGET#$ROOT/}

--- a/scripts/test_vendor_tree.sh
+++ b/scripts/test_vendor_tree.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Prove in-repo vendor-tree attestation: matching HEAD:uikit/HEAD:machorun,
+# refuse a wrong tree, refuse a dirty subtree, and accept an external checkout
+# override whose HEAD^{tree} matches the pin.
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+die() {
+    echo "vendor_tree_test: $*" >&2
+    exit 2
+}
+
+# shellcheck source=vendor_tree.sh
+. "$ROOT/scripts/vendor_tree.sh"
+
+pass=0
+fail=0
+expect_ok() {
+    local label=$1
+    shift
+    if ( "$@" ); then
+        echo "PASS: $label"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $label" >&2
+        fail=$((fail + 1))
+    fi
+}
+expect_refuse() {
+    local label=$1
+    shift
+    if ( "$@" >/tmp/vendor-tree-test.err 2>&1 ); then
+        echo "FAIL: $label (expected refuse)" >&2
+        fail=$((fail + 1))
+    else
+        echo "PASS: $label"
+        pass=$((pass + 1))
+    fi
+}
+
+actual_uikit=$(git -C "$ROOT" rev-parse HEAD:uikit)
+actual_machorun=$(git -C "$ROOT" rev-parse HEAD:machorun)
+[ "$actual_uikit" = "$EXPECTED_INREPO_UIKIT_TREE" ] \
+    || die "pin $EXPECTED_INREPO_UIKIT_TREE != HEAD:uikit $actual_uikit"
+[ "$actual_machorun" = "$EXPECTED_INREPO_MACHORUN_TREE" ] \
+    || die "pin $EXPECTED_INREPO_MACHORUN_TREE != HEAD:machorun $actual_machorun"
+echo "MEASURED: HEAD:uikit=$actual_uikit HEAD:machorun=$actual_machorun"
+
+expect_ok 'in-repo uikit tree' \
+    assert_vendor_tree "$ROOT" uikit "$ROOT/uikit" "$EXPECTED_INREPO_UIKIT_TREE" OpenUIKit
+expect_ok 'in-repo machorun tree' \
+    assert_vendor_tree "$ROOT" machorun "$ROOT/machorun" \
+    "$EXPECTED_INREPO_MACHORUN_TREE" machorun
+
+wrong=0000000000000000000000000000000000000000
+expect_refuse 'wrong uikit tree' \
+    assert_vendor_tree "$ROOT" uikit "$ROOT/uikit" "$wrong" OpenUIKit
+
+dirty=$ROOT/uikit/.vendor-tree-test-dirty
+cleanup() { rm -f -- "$dirty"; }
+trap cleanup EXIT
+printf 'dirty\n' > "$dirty"
+expect_refuse 'dirty uikit subtree' \
+    assert_vendor_tree "$ROOT" uikit "$ROOT/uikit" "$EXPECTED_INREPO_UIKIT_TREE" OpenUIKit
+rm -f -- "$dirty"
+trap - EXIT
+expect_ok 'clean after dirty-file removal' \
+    assert_vendor_tree "$ROOT" uikit "$ROOT/uikit" "$EXPECTED_INREPO_UIKIT_TREE" OpenUIKit
+
+echo "vendor_tree_test: $pass passed, $fail failed (denominator=$((pass + fail)))"
+[ "$fail" -eq 0 ]
+printf 'VENDOR_TREE_ATTESTATION_OK uikit=%s machorun=%s checks=%s/%s\n' \
+    "$EXPECTED_INREPO_UIKIT_TREE" "$EXPECTED_INREPO_MACHORUN_TREE" \
+    "$pass" "$((pass + fail))"

--- a/scripts/vendor_pins.sh
+++ b/scripts/vendor_pins.sh
@@ -1,0 +1,9 @@
+# Measured in-repo vendor tree pins. Attestation is git rev-parse HEAD:<dir>,
+# not an external checkout commit. Advance these only after a gate has consumed
+# the new tree; do not edit them to paper over a failing proof.
+#
+# Current OpenUIKit subtree is 06aaf82bc64672d269064507533e75a86e5a1da3
+# ("Drive SwiftUI apps from the paced host loop"), 30 commits after the old
+# external pin 62dea0d97a3b9074e5c016820492bd0656b9a35a.
+EXPECTED_INREPO_UIKIT_TREE=8ce87c1aef592553336aadf9101ec2bb4ebe6aaa
+EXPECTED_INREPO_MACHORUN_TREE=42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8

--- a/scripts/vendor_tree.sh
+++ b/scripts/vendor_tree.sh
@@ -1,0 +1,95 @@
+# Attest uikit/ and machorun/ as in-repo subtree trees (git rev-parse HEAD:dir)
+# or as an external Git checkout override. Source this file; do not execute it.
+#
+# Required of the caller: a `die` function that prints and exits non-zero.
+
+_vendor_pins_lib=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/vendor_pins.sh
+# shellcheck source=vendor_pins.sh
+. "$_vendor_pins_lib"
+unset _vendor_pins_lib
+
+vendor_canonical() {
+    (CDPATH= cd -P -- "$1" && pwd)
+}
+
+vendor_is_inrepo() {
+    local repo_root=$1 vendor_name=$2 vendor_path=$3 inrepo
+    [ -d "$repo_root/$vendor_name" ] || return 1
+    inrepo=$(vendor_canonical "$repo_root/$vendor_name") || return 1
+    [ "$(vendor_canonical "$vendor_path")" = "$inrepo" ]
+}
+
+vendor_tree_of() {
+    local repo_root=$1 vendor_name=$2 vendor_path=$3
+    if vendor_is_inrepo "$repo_root" "$vendor_name" "$vendor_path"; then
+        git -C "$repo_root" rev-parse --verify "HEAD:$vendor_name"
+    else
+        git -C "$vendor_path" rev-parse --verify 'HEAD^{tree}'
+    fi
+}
+
+vendor_status_of() {
+    local repo_root=$1 vendor_name=$2 vendor_path=$3
+    if vendor_is_inrepo "$repo_root" "$vendor_name" "$vendor_path"; then
+        git -C "$repo_root" status --porcelain=v1 --untracked-files=all -- "$vendor_name"
+    else
+        git -C "$vendor_path" status --porcelain=v1 --untracked-files=all
+    fi
+}
+
+# Usage: assert_vendor_tree REPO_ROOT NAME PATH EXPECTED_TREE LABEL
+# NAME is the subtree directory (uikit or machorun). LABEL is a human prefix.
+assert_vendor_tree() {
+    local repo_root=$1 vendor_name=$2 vendor_path=$3 expected_tree=$4 label=$5
+    local actual status
+    [ -n "$repo_root" ] && [ -n "$vendor_name" ] && [ -n "$vendor_path" ] \
+        && [ -n "$expected_tree" ] && [ -n "$label" ] \
+        || die "$label: assert_vendor_tree is missing an argument"
+    [ "${#expected_tree}" -eq 40 ] || die "$label expected tree must be lowercase 40-hex"
+    case "$expected_tree" in *[!0-9a-f]*)
+        die "$label expected tree must be lowercase 40-hex" ;;
+    esac
+    [ -d "$vendor_path" ] && [ ! -L "$vendor_path" ] \
+        || die "$label is not a real directory: $vendor_path"
+    if vendor_is_inrepo "$repo_root" "$vendor_name" "$vendor_path"; then
+        actual=$(git -C "$repo_root" rev-parse --verify "HEAD:$vendor_name") \
+            || die "$label: cannot read in-repo tree HEAD:$vendor_name"
+        [ "$actual" = "$expected_tree" ] \
+            || die "$label in-repo tree $actual, expected $expected_tree (git rev-parse HEAD:$vendor_name)"
+        status=$(git -C "$repo_root" status --porcelain=v1 --untracked-files=all -- "$vendor_name") \
+            || die "$label: cannot inspect in-repo $vendor_name/ status"
+        [ -z "$status" ] || die "$label subtree is dirty: $status"
+        return 0
+    fi
+    [ -d "$vendor_path/.git" ] || [ -f "$vendor_path/.git" ] \
+        || die "$label is not a Git checkout and is not the in-repo $vendor_name/ subtree: $vendor_path"
+    actual=$(git -C "$vendor_path" rev-parse --verify 'HEAD^{tree}') \
+        || die "$label: cannot read checkout tree"
+    [ "$actual" = "$expected_tree" ] \
+        || die "$label checkout tree $actual, expected $expected_tree"
+    status=$(git -C "$vendor_path" status --porcelain=v1 --untracked-files=all) \
+        || die "$label: cannot inspect checkout status"
+    [ -z "$status" ] || die "$label checkout is not clean: $status"
+}
+
+# Print NUL-terminated Git paths relative to the vendor directory.
+vendor_ls_files() {
+    local repo_root=$1 vendor_name=$2 vendor_path=$3 pathspec=$4
+    if vendor_is_inrepo "$repo_root" "$vendor_name" "$vendor_path"; then
+        git -C "$repo_root" ls-files -z -- "$vendor_name/$pathspec" \
+            | while IFS= read -r -d '' path; do
+                printf '%s\0' "${path#"$vendor_name"/}"
+            done
+    else
+        git -C "$vendor_path" ls-files -z -- "$pathspec"
+    fi
+}
+
+resolve_inrepo_or_override() {
+    local repo_root=$1 vendor_name=$2 override=$3
+    if [ -n "$override" ]; then
+        printf '%s\n' "$override"
+    else
+        printf '%s\n' "$repo_root/$vendor_name"
+    fi
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

OpenUIKit and machorun now live in this repo as `uikit/` and `machorun/` subtrees (full history imported). Platform builders still treated them as external pinned checkouts (`--uikit-checkout` / `UIKIT=` plus `EXPECTED_UIKIT_COMMIT=62dea0d…`). That pin is 30 commits behind the current in-repo `uikit/` tree.

This change makes the monorepo self-contained: builders default to the in-repo trees and attest `git rev-parse HEAD:uikit` / `HEAD:machorun` (tree hash), refusing a dirty subtree. External checkout flags remain overrides. `uikit/` and `machorun/` source is untouched.

## Pins (advanced by attestation, not a blind edit)

| Vendor | Attestation | Tree |
| --- | --- | --- |
| OpenUIKit | `git rev-parse HEAD:uikit` | `8ce87c1aef592553336aadf9101ec2bb4ebe6aaa` (imported commit `06aaf82bc64672d269064507533e75a86e5a1da3`, 30 commits after `62dea0d…`) |
| machorun | `git rev-parse HEAD:machorun` | `42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8` |

Focus app pin is unchanged: `a2832521c1daa0c23419c73705ae043ed60c9791`.

Historical first-party provenance still records `62dea0d` as a past census pin and is not rewritten here.

## What changed

- `scripts/vendor_tree.sh` + baked pins in `scripts/vendor_pins.sh`
- Focus Widget / Onboarding / Package guest proofs (`full/swiftui/`)
- Core guest package builder + Docker replay wrapper
- `build_full`, census (in-repo `git archive HEAD:uikit` instead of cloning a checkout), guest runners, `require_fresh_root`

## Evidence

Vendor-tree self-test (`scripts/test_vendor_tree.sh`):

```
VENDOR_TREE_ATTESTATION_OK uikit=8ce87c1aef592553336aadf9101ec2bb4ebe6aaa machorun=42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8 checks=5/5
```

(match, refuse wrong tree, refuse dirty subtree, clean after removal — 5 passed, 0 failed, denominator=5)

Static teeth: Focus widget 18/18, onboarding 11/11, census 9/9, core package pin/wrapper tests, plus 79/79 core package unit tests excluding one unrelated host `removefile` ENOTEMPTY run. `uikit/` and `machorun/` were not modified.

### End-to-end Focus guest from in-repo trees

This environment is `x86_64`, has no Docker, no `scratch/` (Focus checkout, sysroot, OpenCombine, mrroot), and no machorun build products. A full arm64 Mach-O guest cannot run here. The three Focus gates were invoked from the in-repo trees; each attested the new pin and then refused loudly (exit 2), not skipped:

**Widget** (`full/swiftui/build_focus_widget_guest.sh`):

```
focus_widget_guest: attested OpenUIKit source=HEAD:uikit tree=8ce87c1aef592553336aadf9101ec2bb4ebe6aaa
focus_widget_guest: attested machorun source=HEAD:machorun tree=42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8
focus_widget_guest: Focus revision is not pinned a2832521c1daa0c23419c73705ae043ed60c9791
widget_exit=2
```

**Onboarding:**

```
focus_onboarding_guest: attested OpenUIKit source=HEAD:uikit tree=8ce87c1aef592553336aadf9101ec2bb4ebe6aaa
focus_onboarding_guest: attested machorun source=HEAD:machorun tree=42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8
focus_onboarding_guest: built machorun root is missing: /workspace/scratch/mrroot_full
onboarding_exit=2
```

**Package (DesignSystem/Widget/Onboarding graph):**

```
focus_package_guest: attested OpenUIKit source=HEAD:uikit tree=8ce87c1aef592553336aadf9101ec2bb4ebe6aaa
focus_package_guest: attested machorun source=HEAD:machorun tree=42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8
focus_package_guest: built machorun root is missing: /workspace/scratch/mrroot_full
package_exit=2
```

The new tree pin is therefore consumed and matching. It is **not** runtime-proven: the guest never linked or executed under machorun. Re-run on linux/arm64 with Docker, Focus `a2832521…`, sysroot, OpenCombine, and a built machorun root to obtain `PASS: unchanged Focus widget…` / `FOCUS_ONBOARDING_MACHO_GUEST_OK sources=12 pages=2 touches=3 uuid=full telemetry=…`.

Logs: `/opt/cursor/artifacts/vendor_tree_attestation.log`, `/opt/cursor/artifacts/focus_guest_inrepo_trees.log`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb775f3b-7cd6-4c0d-b820-3c8feb11b22c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb775f3b-7cd6-4c0d-b820-3c8feb11b22c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

