### PR TITLE
Declarative verification environment contract

### DIFF
--- a/env/INVENTORY.md
+++ b/env/INVENTORY.md
@@ -1,0 +1,222 @@
+# Verification environment contract inventory
+
+Measured 2026-09-02 on this branch after consuming PR #3
+(`391d335` — Cursor cloud corpus + Mach-O products + `CURSOR_ENV_CANNOT_*`).
+
+This file is the **first increment**: where environment knowledge currently
+lives, with `file:line`. No behavior change. The gates and their refusals stay
+exactly where they are until later commits move the *data* into
+`env/contract.json` and materialize it with `scripts/env/prepare.py`.
+
+**Scan denominator (34 primary files, this commit):**
+
+| kind | hits | files |
+|---|---:|---:|
+| checkout pins (`EXPECTED_*` commit/tree) | 80 | 6 |
+| product / `libswiftCore` hash | 56 | 8 |
+| `CURSOR_ENV_CANNOT_*` markers | 17 | 4 |
+| `safe.directory` | 3 | 2 |
+| mode `0700` | 9 | 2 |
+| ancestor-trust | 5 | 3 |
+| `mktemp` | 12 | 8 |
+| `mrroot` / `mrroot_fe` | 11 | 5 |
+| `sysroot_fe4` / `libSystem.tbd` | 47 | 11 |
+| machorun loader | 35 | 11 |
+| poppler / pdftocairo | 8 | 1 |
+| `clang-18` alias | 48 | 8 |
+| in-repo vendor pin | 47 | 8 |
+
+Those 34 files are the **environment** surface. Hundreds of additional
+`EXPECTED_*` hashes in `full/*/tests/test_*_host.sh` are **gate product**
+pins (app-source identity), not host/sysroot/checkout environment. They are
+out of scope for the contract file except where a gate also demands an
+environment row below.
+
+The 14 sequential refusals measured on the ARM64 EC2 authority while bringing
+up `full/swiftui/build_focus_widget_guest.sh` map onto this inventory 1:1
+(every refusal was correct; none was discoverable without running):
+
+| # | refusal | lives at |
+|---:|---|---|
+| 1 | git dubious-ownership | `scripts/vendor_tree.sh:26,56,66` (`git -C` without `-c safe.directory`); `full/swiftui/build_focus_widget_guest.sh:211`; `full/foundation/pinned_inputs.pl:59-61` |
+| 2 | 0700 proof parent | `full/focus-ios/onboarding_uikit_proof.py:858-860`; `full/focus-ios/onboarding_resources_proof.py:666`; `uikit/scripts/prove_focus_widget_swiftui_runtime.sh:150` |
+| 3 | ancestor-trust | `full/focus-ios/onboarding_uikit_proof.py:863-882`; `full/swiftui/focus_widget_guest_attest.pl:235`; `full/swiftui/test_focus_widget_guest_adversarial.sh:173-179` |
+| 4 | mktemp root | `full/swiftui/build_focus_widget_guest.sh:136,159,295,1069` (`mktemp` under `$FULL`); `full/frameworks/run_core_guest_package_docker.sh:256` |
+| 5 | missing machorun loader | `full/scripts/build_full.sh:221-236`; `full/swiftui/build_focus_widget_guest.sh:278-284`; `full/frameworks/build_core_guest_package.sh:582` |
+| 6 | missing `scratch/swift-collections` | `.cursor/scratch-corpus-pins.json:23-29`; `full/foundation/pinned_inputs.pl:29-37`; `full/scripts/build_full.sh:81-82` |
+| 7 | missing `darwin/usr/lib/swift/libswiftCore.dylib` sha `dd01686e…` | `swiftcore-macho/artifacts/swift-macosx/arm64/libswiftCore.dylib` (content); `full/oracle-opencombine/policy.json:92,128`; `full/scripts/stage_swift_core_runtime.py:96-101`; `full/scripts/build_full.sh:211-309` |
+| 8 | missing `scratch/mrroot` + `mrroot_fe` | `full/scripts/build_full.sh:47-48,270-340`; `full/foundation/stage_swift_overlays.sh:40-49`; `full/frameworks/run_core_guest_package_docker.sh:260-267` |
+| 9 | stale `sysroot_fe4` `libSystem.tbd` | `full/foundation/stage_fe_sysroot.sh:1-23,41-44`; `machorun/scripts/gen_tbd.sh` CHECK 1; `.cursor/install-built-products.sh:72-83`; `full/swiftui/build_focus_widget_guest.sh:417` |
+| 10 | stale in-repo pin | `scripts/vendor_pins.sh:8-9` vs live `HEAD:uikit` / `HEAD:machorun` (see §Drift) |
+| 11 | missing OpenCombine export artifacts | `.cursor/install-built-products.sh:181-184`; `full/swiftui/build_focus_widget_guest.sh:226-243` |
+| 12 | missing FE sysroot | `full/scripts/build_full.sh:68-70`; `full/foundation/stage_fe_sysroot.sh` (macOS-only) |
+| 13 | clang alias / toolchain | `.cursor/install-built-products.sh:27-30`; `.cursor/verify-cloud-environment.sh:49-78`; `harness/Dockerfile:10-21` |
+| 14 | then a genuine code bug | (not environment; out of scope) |
+
+---
+
+## 0. Cloud seed (PR #3) — consume, do not duplicate
+
+PR #3 is already the declarative half for the Cursor x86_64 VM. Later
+commits must **call** these scripts, not rewrite them.
+
+| file | lines | what it encodes |
+|---|---|---|
+| `.cursor/scratch-corpus-pins.json` | 1-38 | 4 public checkouts: name, GitHub URL, commit, tree, dest under `scratch/` + pinned `swift:6.2-noble@sha256:29b983751c605c2d3102d2ab93438c6e0cadf110d9d2aa6e929b6dec9dcb7cbc` |
+| `.cursor/clone-pinned-repo.sh` | 1-132 | commit+tree clone; `safe.directory` per dest (75-78); origin guard; reuse-if-valid |
+| `.cursor/install-scratch-corpus.sh` | 1-41 | 4/4 corpus; extra `pinned_inputs.pl verify` (32-38) |
+| `.cursor/install-built-products.sh` | 1-280 | cold-build darwin/objc4/quartz; stage in-repo `libswiftCore`; honest `CURSOR_ENV_CANNOT_*` (7 markers); tree hashes |
+| `.cursor/verify-cloud-environment.sh` | 1-326 | tools, macios evidence, corpus pins, product hashes, `CURSOR_ENV_SUMMARY` |
+| `.cursor/cursor-env.sh` | 1-50 | `cursor_env_attest` / `cursor_env_cannot_execute_arm64` / toolchain mode |
+| `.cursor/refuse-arm64-execution.sh` | 1-17 | canonical `CURSOR_ENV_CANNOT_EXECUTE_ARM64` (exit 2) |
+| `.cursor/attest-cursor-env.sh` | 1-41 | stamp + live fingerprint |
+| `.cursor/toolchain-fingerprint.sh` | 1-26 | arch, clang-18, ld64, os, swift line |
+| `.cursor/tree-digest.py` | 1-44 | sorted path + sha256 / symlink target |
+| `.cursor/environment.json` | 7 | install chain: evidence → corpus → products → verify |
+| `.cursor/test-cloud-environment.sh` | 1-188 | 25/25 unit teeth for the above |
+
+`CURSOR_ENV_CANNOT_*` spellings today (17 hits / 4 files):
+
+| marker | defined |
+|---|---|
+| `CURSOR_ENV_CANNOT_BUILD_LOADER` | `.cursor/install-built-products.sh:46,204` |
+| `CURSOR_ENV_CANNOT_GENERATE_TBD` | `:81,205` |
+| `CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER` | `:176,206` |
+| `CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` | `:164,210` |
+| `CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS` | `:179,211` |
+| `CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT` | `:183,214` |
+| `CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST` | `:189,216` |
+| `CURSOR_ENV_CANNOT_EXECUTE_ARM64` | `.cursor/refuse-arm64-execution.sh:15`; gates at run step |
+
+`NEEDS_DARWIN_BASELINE` is **not currently emitted** (0 hits). It is the
+missing unified name for the Xcode-overlay + simruntime pair above.
+
+---
+
+## 1. Required checkouts
+
+| id | URL | commit | tree | dest | demanded by (file:line) |
+|---|---|---|---|---|---|
+| focus-ios | `https://github.com/mozilla-mobile/focus-ios.git` | `a2832521…9791` | `065d8e37…1d7e` | `scratch/ladder-corpus/focus-ios` | `.cursor/scratch-corpus-pins.json:10-15`; `full/swiftui/build_focus_widget_guest.sh:15,55,211` |
+| swift-foundation | `https://github.com/apple/swift-foundation.git` | `c6793ef0…dcfc` | `46517986…1486` | `scratch/swift-foundation` | pins.json:17-21; `full/foundation/pinned_inputs.pl:18-27`; `full/frameworks/build_core_guest_package.sh:283-284,704` |
+| swift-collections | `https://github.com/apple/swift-collections.git` | `9bf03ff5…fd06` | `5e4de96f…3c27` | `scratch/swift-collections` | pins.json:23-29; `pinned_inputs.pl:29-37`; `build_core_guest_package.sh:290-291,707` |
+| opencombine | `https://github.com/OpenCombine/OpenCombine.git` | `1c6f02c7…037b` | `66a9d91e…594a` | `scratch/opencombine-core-durable-20260828-r2/source` | pins.json:31-36; `build_core_guest_package.sh:292-293,708`; widget `:30-33` |
+| swift-foundation-icu | `https://github.com/apple/swift-foundation-icu.git` (implied; **not** in pins.json) | `87dbab99…b39a` | `823a4a2a…fd39` | `scratch/swift-foundation-icu` | `build_core_guest_package.sh:285-286,705-706`; `full/xcodeplan/build_true_ios_platform_frameworks.sh:110-117` |
+| dotnet-macios | `https://github.com/dotnet/macios.git` | `cd624873…0e79` | (sparse `src`) | `/opt/openuikit-evidence/dotnet-macios` | `full/framework-fanout/external-evidence-sources.json:31-42`; `.cursor/verify-cloud-environment.sh:82-148` |
+| uikit (in-repo) | subtree `HEAD:uikit` | — | `scripts/vendor_pins.sh:8` `719f6bcf…5a959` | `uikit/` | `scripts/vendor_tree.sh:40-73`; widget `:198`; `build_full.sh:209` |
+| machorun (in-repo) | subtree `HEAD:machorun` | — | `scripts/vendor_pins.sh:9` `42d42ace…f70c8` | `machorun/` | widget `:200`; `build_full.sh:210`; `build_core_guest_package.sh:294,699` |
+
+**Drift, measured this commit (do not paper over):**
+
+```
+vendor_pins.sh  HEAD:uikit = 719f6bcfe2a8e467426f30c91390d9c605f5a959
+live            HEAD:uikit = bd3eef4d230903199edc6e8aa62538177b25785f
+docs/tests still cite      8ce87c1aef592553336aadf9101ec2bb4ebe6aaa
+vendor_pins.sh  HEAD:machorun = 42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8
+live            HEAD:machorun = 80228dcf3c743af1bfd877bf8b556b97cdc48b0e
+```
+
+`scripts/vendor_pins.sh:3` forbids editing pins to hide a failing proof. The
+preparer must **report** this as unsatisfied, not advance the pin.
+
+**Dangerous duplicate:** `full/foundation/fetch_sources.sh:39-40` clones by
+**tag** (`release/6.2.2`, `1.1.3`), not commit+tree. That is the class of
+error `pinned_inputs.pl` exists to refuse. Do not teach the preparer this
+script.
+
+---
+
+## 2. Required built products
+
+| path | producer | pin | demanded by |
+|---|---|---|---|
+| `machorun/build/machorun` | `machorun/scripts/build.sh` loader | cold-build; aarch64 ELF; **cannot** on x86_64 (`tlv_asm.S`) | `build_full.sh:221`; widget `:283`; `build_core_guest_package.sh:582`; `.cursor/install-built-products.sh:32-51` |
+| `machorun/darwin/usr/lib/{libSystem.B,libc++.1,libc++abi,libobjc.A,libquartz,libswiftcompat}.dylib` | `machorun/scripts/build.sh` darwin + `build_objc4.sh` + `build_quartz.sh` | cold-build arm64 Mach-O via `clang-18 -target arm64-apple-macos11` | install-built-products.sh:53-97 |
+| `scratch/sysroot_fe4` | macOS: `full/foundation/stage_fe_sysroot.sh`; Linux subset: install-built-products.sh:99-164 | tree hash recorded in `scratch/.cursor-built-products.json`; Xcode overlays CANNOT on Linux | `build_full.sh:40,68`; widget `:21` |
+| `scratch/mrroot_full` | `full/scripts/build_full.sh:202-364` + `scripts/require_fresh_root.sh` | manifest kinds copy/renamed/umbrella/staged; loader copy only on aarch64 | widget `:22`; `build_full.sh:43` |
+| `scratch/modcache_swiftui_guest` | Focus SwiftUI guest compile | **do not create empty**; CANNOT without full FE sysroot | install-built-products.sh:186-190; widget `:23` |
+| `scratch/opencombine-core-durable-20260828-r2/export/artifacts` | `full/oracle-opencombine/build_and_run.sh` (run under machorun) | object/module/doc hashes in widget `:75-83` | widget `:226-231` |
+| `sdk/usr/lib/*.tbd` | `machorun/scripts/gen_tbd.sh` | CHECK 1 requires loader export table; empty `.tbd` is a linker lie | install-built-products.sh:72-83,192-199 |
+
+---
+
+## 3. Required staged externals
+
+| path | source | sha256 | demanded by |
+|---|---|---|---|
+| `machorun/darwin/usr/lib/swift/libswiftCore.dylib` | `swiftcore-macho/artifacts/swift-macosx/arm64/libswiftCore.dylib` via `machorun/scripts/stage_swiftcore.sh` | `dd01686e06c81a21755bb864b43dad446c011e6c60c6b387b3b332c0a12708cb` | `full/oracle-opencombine/policy.json:92,128`; `full/scripts/stage_swift_core_runtime.py`; core package `--expected-machorun-swift-core-sha256` |
+| `scratch/mrroot/darwin/usr/lib/swift/*.dylib` except libswiftCore | spike base runtime (`scratch/mrroot`) | byte-identical copy | `build_full.sh:47,270-301` |
+| `scratch/mrroot_fe/darwin/usr/lib/swift/libswift{Darwin,Synchronization,_Builtin_float,_DarwinFoundation{1,2,3},_RegexParser,_StringProcessing,_errno}.dylib` | iOS CoreSimulator runtime via `full/foundation/stage_swift_overlays.sh` (**macOS only**) | recorded in that root's `.manifest` staged rows | `build_full.sh:48,317-340` |
+| `scratch/mrroot/host/{libdispatch,libBlocksRuntime}.so` | `/usr/lib/swift/linux/` | `39e502b3…` / `47a4f774…` (`build_core_guest_package.sh:402-405,2457-2459`) | `build_full.sh:346-364` |
+| `/usr/share/fonts/truetype/dejavu/DejaVuSans{,-Bold}.ttf` | distro fonts | `ae7b7855…` / `5c1247ac…` | widget `:71-74,224-225` |
+| poppler `pdftocairo` | Homebrew 25.04.0 or Ubuntu noble `poppler-utils=24.02.0-1ubuntu9.9` | profile table `onboarding_resources_proof.py:164-183` | resource-bundle producer for the widget gate input |
+
+---
+
+## 4. Host requirements
+
+| requirement | where |
+|---|---|
+| arch: x86_64 = compile/link/static only; aarch64/arm64 = execution authority; Darwin = macOS oracle local-only | `.cursor/refuse-arm64-execution.sh`; `cursor-env.sh:22-29`; PR #3 proof split |
+| toolchain: Swift 6.2.4 linux, LLVM/clang-18, `ld64.lld-18`; image `swift:6.2-noble@sha256:29b983751c605c2d3102d2ab93438c6e0cadf110d9d2aa6e929b6dec9dcb7cbc` | `harness/Dockerfile:10`; `.cursor/scratch-corpus-pins.json:3-7`; `verify-cloud-environment.sh:267-271` |
+| `clang` on PATH is Swift's clang 17 — Darwin/objc4/quartz **must** use `CC=clang-18` / `DARWIN_CLANG=clang-18` | `install-built-products.sh:27-30` |
+| unversioned `llvm-nm`/`llvm-otool`/`llvm-objdump` must resolve to `*-18` | `verify-cloud-environment.sh:62-78` |
+| tools: swift, swiftc, clang{,++, -18}, ld64.lld{,-18}, llvm-{nm,otool,objdump}{,-18}, perl, patch, jq, sha256sum, shasum, cmp, file, git, python3, pkg-config | `verify-cloud-environment.sh:49-59` |
+| core-guest extra: readelf, ldd, curl-config, find, sort | `build_core_guest_package.sh:568-572` |
+| zstd | campaign transfer scripts (`ops/campaigns/2026-09-01-fwseed-r1/ec2_import_core_cold_20260901.sh:42`) |
+| poppler/pdftocairo | `onboarding_resources_proof.py:164-183` |
+| fingerprint | `.cursor/toolchain-fingerprint.sh` hashed into `scratch/.cursor-env-attestation.json` |
+
+---
+
+## 5. Filesystem preconditions
+
+| rule | where | meaning |
+|---|---|---|
+| git `safe.directory` for every checkout git will touch | `.cursor/clone-pinned-repo.sh:75-78`; **absent** from `scripts/vendor_tree.sh` and the Focus/core gates | without it, git prints dubious-ownership and the gate never starts |
+| proof output parent: euid-owned, mode `0700` | `onboarding_uikit_proof.py:855-860`; `onboarding_resources_proof.py:666` | world-writable `/tmp` is not a proof parent |
+| ancestor trust: owner in `{0, euid}`; no group/other write unless sticky+protected child; no extended ACL | `onboarding_uikit_proof.py:863-882` | |
+| proof root itself mode `0700` | `onboarding_uikit_proof.py:1068-1071` | |
+| mktemp dest must be a real directory (Focus uses `$FULL/.focus-widget-*.XXXXXX`) | widget `:136,159,295,1069` | `$W/build/full` must exist before those calls |
+| macios evidence parent `root:root:755`; evidence tree root-owned, not writable, no symlinks | `verify-cloud-environment.sh:133-148` | |
+| no symlink in resource/input trees | widget `:245-250`; `core_package_manifest.py:221-248` | |
+| `require_fresh_root.sh` refuses vacuous greens (0 graded files) and prints denominators | `scripts/require_fresh_root.sh:266-341` | |
+
+---
+
+## 6. Hash / ledger logic still in shell (migrate next)
+
+`full/frameworks/build_core_guest_package.sh` is 7210 lines. Python already
+owns package manifests (`full/frameworks/core_package_manifest.py`, 1948
+lines: `sha256_file`, `require_regular_no_link`, inventory, write/verify).
+The **shell still duplicates** the data plane:
+
+| function | lines | job |
+|---|---|---|
+| `hash_file` | 630 | `sha256sum` |
+| `require_hash` | 644-649 | regular-file + hash or `core_guest_package: REFUSING --` |
+| `assert_clean_commit` | 651-663 | commit+tree+dirty |
+| `assert_exact_swift_set` | 665-681 | Git vs physical Swift set |
+| baked `EXPECTED_*` | 243-409 | checkout pins, plugin hashes, OpenCombine hashes, fonts, host `.so` |
+| `require_hash` call sites | 700+ … 7144 | pre/post attestation |
+
+`full/swiftui/build_focus_widget_guest.sh:85-105` has a **second**
+`hash_file` / `require_hash` / `tree_digest` with **different refusal text**
+(`focus_widget_guest: $label drifted` vs `core_guest_package: REFUSING --
+$label hash`). Unifying the implementation must keep both texts.
+
+`full/scripts/build_full.sh` and `scripts/require_fresh_root.sh` are further
+ledger copies (manifest kinds, sha256, denominators).
+
+---
+
+## 7. What later increments must not do
+
+- Do not touch `machorun/src` or `machorun/darwin` (other agents).
+- Do not touch any x86_64 port surface.
+- Do not rewrite `.cursor/*` from PR #3; call them.
+- Do not change a hash, marker spelling, or refusal string without saying why.
+- Do not advance `scripts/vendor_pins.sh` to match live `HEAD:uikit`.
+- Do not teach the preparer `fetch_sources.sh` tag clones.
+- Do not invent empty `.tbd` files or empty `modcache_swiftui_guest`.
+- Print denominators on every summary line (`satisfied/cold-built/staged/CANNOT`).

--- a/env/contract.json
+++ b/env/contract.json
@@ -1,0 +1,411 @@
+{
+  "schema": 1,
+  "id": "openuikit-verify-environment",
+  "inventory": "env/INVENTORY.md",
+  "notes": [
+    "Single source for verify-tree materialization. Values are copied from the lock files listed in consume[], not invented. A later prepare.py run that disagrees with a lock is a contract bug, not a pin advance.",
+    "PR #3 .cursor scripts remain the cloud installer. prepare.py calls them; it does not rewrite them.",
+    "Do not emit NEEDS_DARWIN_BASELINE from gates until a documented behavior change. Current spellings are CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS and CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS."
+  ],
+  "consume": [
+    {
+      "path": ".cursor/scratch-corpus-pins.json",
+      "kind": "corpus-lock",
+      "fields": ["sources.commit", "sources.tree", "sources.repository", "sources.destination", "pinnedImage.digest"]
+    },
+    {
+      "path": "scripts/vendor_pins.sh",
+      "kind": "inrepo-vendor-lock",
+      "fields": ["EXPECTED_INREPO_UIKIT_TREE", "EXPECTED_INREPO_MACHORUN_TREE"]
+    },
+    {
+      "path": "full/foundation/pinned_inputs.pl",
+      "kind": "compile-input-lock",
+      "fields": ["swift-foundation.commit", "swift-foundation.tree", "swift-collections.commit", "swift-collections.tree"]
+    },
+    {
+      "path": "full/framework-fanout/external-evidence-sources.json",
+      "kind": "evidence-lock",
+      "fields": ["dotnet-macios.commit", "dotnet-macios.repository", "dotnet-macios.licenseSHA256"]
+    },
+    {
+      "path": "full/oracle-opencombine/policy.json",
+      "kind": "swiftcore-lock",
+      "fields": ["libswiftCore.dylib sha256 dd01686e…"]
+    },
+    {
+      "path": "harness/Dockerfile",
+      "kind": "image-lock",
+      "fields": ["FROM swift:6.2-noble@sha256:29b983751c605c2d3102d2ab93438c6e0cadf110d9d2aa6e929b6dec9dcb7cbc"]
+    }
+  ],
+  "proof_split": {
+    "compile_link_static": "in-vm",
+    "execution": "arm64-ec2-authority",
+    "macos_oracle": "local-only"
+  },
+  "hosts": {
+    "cursor-x86_64": {
+      "arch": ["x86_64"],
+      "os": "Linux",
+      "role": "compile-link-static",
+      "expected_cannot": [
+        "CURSOR_ENV_CANNOT_BUILD_LOADER",
+        "CURSOR_ENV_CANNOT_GENERATE_TBD",
+        "CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER",
+        "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS",
+        "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS",
+        "CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT",
+        "CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST",
+        "CURSOR_ENV_CANNOT_EXECUTE_ARM64"
+      ]
+    },
+    "ec2-aarch64": {
+      "arch": ["aarch64", "arm64"],
+      "os": "Linux",
+      "role": "execution-authority",
+      "expected_cannot": [
+        "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS",
+        "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS"
+      ]
+    },
+    "macos-oracle": {
+      "arch": ["arm64", "x86_64"],
+      "os": "Darwin",
+      "role": "oracle-local-only",
+      "expected_cannot": []
+    }
+  },
+  "pinned_image": {
+    "reference": "swift:6.2-noble",
+    "digest": "sha256:29b983751c605c2d3102d2ab93438c6e0cadf110d9d2aa6e929b6dec9dcb7cbc",
+    "demanded_by": ["cursor-cloud", "focus-widget", "core-guest-package", "build-full"]
+  },
+  "checkouts": [
+    {
+      "id": "focus-ios",
+      "kind": "git",
+      "repository": "https://github.com/mozilla-mobile/focus-ios.git",
+      "commit": "a2832521c1daa0c23419c73705ae043ed60c9791",
+      "tree": "065d8e374c9caa3be2915165ba7cbbe4b1d61d7e",
+      "destination": "scratch/ladder-corpus/focus-ios",
+      "lock": ".cursor/scratch-corpus-pins.json",
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "cursor-cloud"]
+    },
+    {
+      "id": "swift-foundation",
+      "kind": "git",
+      "repository": "https://github.com/apple/swift-foundation.git",
+      "commit": "c6793ef0c19c2cbaeba5a0e52078f129afc7dcfc",
+      "tree": "4651798679b98e27383ca3626434fb128f191486",
+      "destination": "scratch/swift-foundation",
+      "lock": ".cursor/scratch-corpus-pins.json",
+      "also_locked_by": "full/foundation/pinned_inputs.pl",
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "swift-collections",
+      "kind": "git",
+      "repository": "https://github.com/apple/swift-collections.git",
+      "commit": "9bf03ff58ce34478e66aaee630e491823326fd06",
+      "tree": "5e4de96f40ccf147dab967f38cb7988ecd933c27",
+      "destination": "scratch/swift-collections",
+      "lock": ".cursor/scratch-corpus-pins.json",
+      "also_locked_by": "full/foundation/pinned_inputs.pl",
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "opencombine",
+      "kind": "git",
+      "repository": "https://github.com/OpenCombine/OpenCombine.git",
+      "commit": "1c6f02c7ed8140c0ba7a783aaddb6e0685a0037b",
+      "tree": "66a9d91efc910c7577e40b2dec166a2de427594a",
+      "destination": "scratch/opencombine-core-durable-20260828-r2/source",
+      "lock": ".cursor/scratch-corpus-pins.json",
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "swift-foundation-icu",
+      "kind": "git",
+      "repository": "https://github.com/apple/swift-foundation-icu.git",
+      "commit": "87dbab99780e277b6a4c2a397ab1a894f877b39a",
+      "tree": "823a4a2a13f60a0fd2715db85a754dda11d5fd39",
+      "destination": "scratch/swift-foundation-icu",
+      "lock": "full/frameworks/build_core_guest_package.sh",
+      "demanded_by": ["core-guest-package"]
+    },
+    {
+      "id": "dotnet-macios",
+      "kind": "git-sparse",
+      "repository": "https://github.com/dotnet/macios.git",
+      "commit": "cd62487311dcc20a7ac183c8baa6293373b20e79",
+      "destination": "/opt/openuikit-evidence/dotnet-macios",
+      "sparse": ["src"],
+      "lock": "full/framework-fanout/external-evidence-sources.json",
+      "demanded_by": ["cursor-cloud"]
+    },
+    {
+      "id": "uikit-inrepo",
+      "kind": "in-repo-subtree",
+      "path": "uikit",
+      "tree": "719f6bcfe2a8e467426f30c91390d9c605f5a959",
+      "lock": "scripts/vendor_pins.sh",
+      "attestation": "git rev-parse HEAD:uikit",
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "build-full", "core-guest-package"],
+      "notes": "Do not advance this pin to paper over a failing proof. Live HEAD:uikit may drift; that is an unsatisfied row, not a contract edit."
+    },
+    {
+      "id": "machorun-inrepo",
+      "kind": "in-repo-subtree",
+      "path": "machorun",
+      "tree": "42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8",
+      "lock": "scripts/vendor_pins.sh",
+      "attestation": "git rev-parse HEAD:machorun",
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "build-full", "core-guest-package"]
+    }
+  ],
+  "built_products": [
+    {
+      "id": "machorun-loader",
+      "path": "machorun/build/machorun",
+      "producer": "machorun/scripts/build.sh",
+      "producer_args": ["loader"],
+      "pin": "cold-build from machorun/src on aarch64",
+      "cannot_on": {
+        "x86_64": "CURSOR_ENV_CANNOT_BUILD_LOADER"
+      },
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package"]
+    },
+    {
+      "id": "darwin-userland",
+      "path": "machorun/darwin/usr/lib",
+      "producer": "machorun/scripts/build.sh",
+      "producer_args": ["darwin"],
+      "pin": "cold-build arm64 Mach-O via clang-18 -target arm64-apple-macos11",
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "sysroot_fe4",
+      "path": "scratch/sysroot_fe4",
+      "producer": "full/foundation/stage_fe_sysroot.sh",
+      "linux_producer": ".cursor/install-built-products.sh",
+      "pin": "cold-build / restage; never reuse a stale tree",
+      "cannot_on": {
+        "Linux": "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS"
+      },
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "mrroot_full",
+      "path": "scratch/mrroot_full",
+      "producer": "full/scripts/build_full.sh",
+      "linux_producer": ".cursor/install-built-products.sh",
+      "pin": "cold-build from current machorun userland; loader copy only on aarch64",
+      "cannot_on": {
+        "x86_64": "CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER"
+      },
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "tbd-stubs",
+      "path": "machorun/sdk/usr/lib",
+      "producer": "machorun/scripts/gen_tbd.sh",
+      "pin": "cold-build; CHECK 1 requires loader",
+      "cannot_on": {
+        "x86_64": "CURSOR_ENV_CANNOT_GENERATE_TBD"
+      },
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package"]
+    },
+    {
+      "id": "opencombine-export",
+      "path": "scratch/opencombine-core-durable-20260828-r2/export/artifacts",
+      "producer": "full/oracle-opencombine/build_and_run.sh",
+      "pin": "cold-build: compile and run under machorun",
+      "cannot_on": {
+        "x86_64": "CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT",
+        "Linux-without-loader": "CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT"
+      },
+      "content_hashes": {
+        "OpenCombine.o": "96558e7d31c10c4bc769e9774977b74c58dc6ee83cfbd4fca8bf17229424a914",
+        "OpenCombine.swiftmodule": "674d4d049d09b074b303822a88fcdc2c1d12c1e3cca9c9414ca30a74ee2c9de0",
+        "OpenCombine.swiftdoc": "a5a2757d33ccb621d26aea0f8ca417cf8ba748660faf1cf37eba53c5833975bc",
+        "RESULT.txt": "c6fe4fa173f27fad0e30d1931c5ffead0aa267d55730a5885c1142bc7502b104"
+      },
+      "demanded_by": ["focus-widget", "focus-onboarding", "focus-package", "core-guest-package"]
+    },
+    {
+      "id": "modcache_swiftui_guest",
+      "path": "scratch/modcache_swiftui_guest",
+      "producer": "full/swiftui/build_focus_widget_guest.sh",
+      "pin": "cold-build from a real SwiftUI guest compile; do not create empty",
+      "cannot_on": {
+        "Linux-without-overlays": "CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST"
+      },
+      "demanded_by": ["focus-widget"]
+    }
+  ],
+  "staged_externals": [
+    {
+      "id": "libswiftCore",
+      "path": "machorun/darwin/usr/lib/swift/libswiftCore.dylib",
+      "source": "swiftcore-macho/artifacts/swift-macosx/arm64/libswiftCore.dylib",
+      "producer": "machorun/scripts/stage_swiftcore.sh",
+      "sha256": "dd01686e06c81a21755bb864b43dad446c011e6c60c6b387b3b332c0a12708cb",
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "mrroot-base-runtime",
+      "path": "scratch/mrroot",
+      "source": "spike guest root (transferred; not rebuilt here)",
+      "pin": "present tree; overlays except libswiftCore copied by build_full.sh",
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package"]
+    },
+    {
+      "id": "mrroot_fe-overlays",
+      "path": "scratch/mrroot_fe",
+      "source": "iOS CoreSimulator runtime via full/foundation/stage_swift_overlays.sh",
+      "producer": "full/foundation/stage_swift_overlays.sh",
+      "pin": "macOS only; Linux host must already hold a transferred tree",
+      "cannot_on": {
+        "Linux": "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS"
+      },
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package"]
+    },
+    {
+      "id": "dejavu-sans",
+      "path": "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+      "sha256": "ae7b7855e115a5966d8b1b3f80f254ccc117ec86f9965e202ee2940453837280",
+      "demanded_by": ["focus-widget", "core-guest-package"]
+    },
+    {
+      "id": "dejavu-sans-bold",
+      "path": "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+      "sha256": "5c1247acef7f2b8522a31742c76d6adcb5569bacc0be7ceaa4dc39dd252ce895",
+      "demanded_by": ["focus-widget", "core-guest-package"]
+    }
+  ],
+  "host_requirements": [
+    {
+      "id": "swift-6.2.4-linux",
+      "kind": "toolchain",
+      "match": "Swift version 6.2.4",
+      "target": "linux",
+      "demanded_by": ["cursor-cloud", "focus-widget", "core-guest-package"]
+    },
+    {
+      "id": "clang-18-alias",
+      "kind": "tool-alias",
+      "tools": ["clang-18", "clang++-18", "ld64.lld-18"],
+      "notes": "clang on PATH is Swift's clang 17. Darwin/objc4/quartz must set CC=clang-18 / DARWIN_CLANG=clang-18.",
+      "demanded_by": ["cursor-cloud", "focus-widget", "build-full", "core-guest-package"]
+    },
+    {
+      "id": "llvm-18-unversioned",
+      "kind": "tool-alias",
+      "tools": ["llvm-nm", "llvm-otool", "llvm-objdump"],
+      "must_resolve_to": ["llvm-nm-18", "llvm-otool-18", "llvm-objdump-18"],
+      "demanded_by": ["cursor-cloud"]
+    },
+    {
+      "id": "cursor-cloud-tools",
+      "kind": "tools",
+      "tools": ["swift", "swiftc", "perl", "patch", "jq", "sha256sum", "shasum", "cmp", "file", "git", "python3", "pkg-config"],
+      "demanded_by": ["cursor-cloud", "focus-widget"]
+    },
+    {
+      "id": "core-guest-extra-tools",
+      "kind": "tools",
+      "tools": ["readelf", "ldd", "curl-config", "find", "sort"],
+      "demanded_by": ["core-guest-package"]
+    },
+    {
+      "id": "poppler-pdftocairo",
+      "kind": "tool-pin",
+      "profiles": [
+        {
+          "id": "homebrew-poppler-25.04.0-darwin-arm64",
+          "path": "/opt/homebrew/Cellar/poppler/25.04.0/bin/pdftocairo",
+          "sha256": "963b05a5c78b2a8a32bbfb9a2a3c542a258dd7ec8e9b64d782a4d9848ed058c1"
+        },
+        {
+          "id": "ubuntu-noble-poppler-24.02.0-1ubuntu9.9-linux-aarch64",
+          "path": "/usr/bin/pdftocairo",
+          "sha256": "dec6518985e0810a886ac53a3293f2d49cf292621874501ab0a821eff666e41f"
+        }
+      ],
+      "demanded_by": ["onboarding-resources-proof"]
+    },
+    {
+      "id": "zstd",
+      "kind": "tools",
+      "tools": ["zstd"],
+      "demanded_by": ["ec2-transfer"]
+    }
+  ],
+  "filesystem_preconditions": [
+    {
+      "id": "git-safe-directory",
+      "kind": "git-safe-directory",
+      "applies_to": ["repo-root", "checkouts"],
+      "action": "git config --global --add safe.directory <path> when missing",
+      "demanded_by": ["focus-widget", "build-full", "core-guest-package", "cursor-cloud"]
+    },
+    {
+      "id": "proof-parent-0700",
+      "kind": "ownership-mode",
+      "mode": "0700",
+      "owner": "euid",
+      "demanded_by": ["onboarding-uikit-proof", "onboarding-resources-proof", "focus-widget"]
+    },
+    {
+      "id": "ancestor-trust",
+      "kind": "ancestor-trust",
+      "owners": [0, "euid"],
+      "no_cross_uid_write": true,
+      "no_extended_acl": true,
+      "demanded_by": ["onboarding-uikit-proof", "onboarding-resources-proof", "focus-widget"]
+    },
+    {
+      "id": "mktemp-root",
+      "kind": "mktemp-parent",
+      "notes": "Focus widget mktemp templates live under $W/build/full. That directory must exist and be a real non-symlink directory owned by the caller.",
+      "path": "build/full",
+      "demanded_by": ["focus-widget"]
+    },
+    {
+      "id": "macios-evidence-parent",
+      "kind": "ownership-mode",
+      "path": "/opt/openuikit-evidence",
+      "owner": "root:root",
+      "mode": "0755",
+      "demanded_by": ["cursor-cloud"]
+    }
+  ],
+  "focus_widget_attestation_pins": {
+    "notes": "Copied verbatim from full/swiftui/build_focus_widget_guest.sh so a later gate switch can prove byte-identical hashes. Changing a value here without changing the gate (or vice versa) is a contract bug.",
+    "EXPECTED_FOCUS_COMMIT": "a2832521c1daa0c23419c73705ae043ed60c9791",
+    "EXPECTED_ASSETS_SHA": "efac8d1c98b562374e54eea7540b4201523db670a6353eff8f0a0273d294526e",
+    "EXPECTED_VIEW_SHA": "721669388a4556e1609f580ed87d6065b63981770e71b0f77db292767b05f6c2",
+    "EXPECTED_INDEX_SHA": "2eb8af32cc6d69161dc35f1536682dcba2dd4db21ea0015cf241701f32468d12",
+    "EXPECTED_LOGO_SHA": "180d76a144c6e74324283e8bfb72d9d7bb32125fe57769e3403b0ca72b6ef415",
+    "EXPECTED_FIRST_SHA": "75759bdc8a68e4694bda34486c47e347ab8af010ebb8de7372b0ca443c08186b",
+    "EXPECTED_SECOND_SHA": "f71bc94e686809660d920da6f7804174097e038302a843c3533da45ceda44af2",
+    "EXPECTED_RESOURCE_TREE_SHA": "144c49c747d4689d9ca98d353cb5474b311473629383a779d99f1b705969a04d",
+    "EXPECTED_SYSTEM_FONT_SHA": "ae7b7855e115a5966d8b1b3f80f254ccc117ec86f9965e202ee2940453837280",
+    "EXPECTED_MEDIUM_FONT_SHA": "5c1247acef7f2b8522a31742c76d6adcb5569bacc0be7ceaa4dc39dd252ce895",
+    "EXPECTED_OPENCOMBINE_RESULT_SHA": "c6fe4fa173f27fad0e30d1931c5ffead0aa267d55730a5885c1142bc7502b104",
+    "EXPECTED_OPENCOMBINE_OBJECT_SHA": "96558e7d31c10c4bc769e9774977b74c58dc6ee83cfbd4fca8bf17229424a914",
+    "EXPECTED_OPENCOMBINE_MODULE_SHA": "674d4d049d09b074b303822a88fcdc2c1d12c1e3cca9c9414ca30a74ee2c9de0",
+    "EXPECTED_OPENCOMBINE_DOC_SHA": "a5a2757d33ccb621d26aea0f8ca417cf8ba748660faf1cf37eba53c5833975bc",
+    "EXPECTED_OPENCOMBINE_HELPER_SHA": "73dbadeff3f6cebb9f5c57e09380e3166b65e68f0b0427d97d6a8ffdce693693",
+    "EXPECTED_OPENCOMBINE_HEADER_SHA": "eb2afa8d9b46891a47ac39e43a4f94d727120acdbc0644934296c4c4ca62e935",
+    "EXPECTED_OPENCOMBINE_MODULEMAP_SHA": "d34fdd050111a8cbf5ced89a129088fcfeb2964eea76ad518fafe044966572d1",
+    "EXPECTED_OPENCOMBINE_PATCH_SHA": "875cd931e95c5442775e1042a412517ab7475be0489b1a81f824a54f6872c79b",
+    "EXPECTED_OPENCOMBINE_PATCHED_HELPER_SHA": "d9fbefcdba66d892d9064c46b21b6084af217ddec1d604bcaf27b160de66083b",
+    "EXPECTED_COMBINE_SHIM_SHA": "828b05c3a47296fb7b0b9ed5a6ca1a45a5da46e245441c21028335f60511799f",
+    "EXPECTED_RESOURCE_FILE_COUNT": 16,
+    "EXPECTED_RESOURCE_DIRECTORY_COUNT": 7,
+    "EXPECTED_PACKAGE_FILE_COUNT": 96,
+    "EXPECTED_PACKAGE_DIRECTORY_COUNT": 12
+  }
+}

--- a/full/frameworks/build_core_guest_package.sh
+++ b/full/frameworks/build_core_guest_package.sh
@@ -27,6 +27,7 @@ OPENCOMBINE_SOURCE=$OPENCOMBINE_ROOT/source
 OPENCOMBINE_ARTIFACTS=$OPENCOMBINE_ROOT/export/artifacts
 OPENCOMBINE_HELPERS=$OPENCOMBINE_SOURCE/Sources/COpenCombineHelpers
 MANIFEST_TOOL=$W/full/frameworks/core_package_manifest.py
+LEDGER_TOOL=$W/scripts/env/ledger.py
 FOUNDATION_SOURCES_MANIFEST=$W/full/foundation/foundation_guest_sources.txt
 COPEN_FOUNDATION_CORE_INCLUDE=$W/full/foundation/include/COpenFoundationCore
 FOUNDATION_CACHE_ORACLE=$W/full/foundation/tests/FoundationCacheOracle.swift
@@ -571,6 +572,8 @@ for tool in git swiftc clang-18 clang++-18 ld64.lld-18 llvm-otool-18 \
     command -v "$tool" >/dev/null || die "required tool is missing: $tool"
 done
 [ -x "$MANIFEST_TOOL" ] || die "manifest tool is missing or not executable: $MANIFEST_TOOL"
+[ -f "$LEDGER_TOOL" ] && [ ! -L "$LEDGER_TOOL" ] \
+    || die "env ledger tool is missing or linked: $LEDGER_TOOL"
 [ -x "$WEBKIT_PROVENANCE_TOOL" ] \
     || die "WebKit provenance tool is missing or not executable: $WEBKIT_PROVENANCE_TOOL"
 [ -f "$WEBKIT_PROVENANCE_POLICY" ] && [ ! -L "$WEBKIT_PROVENANCE_POLICY" ] \
@@ -627,7 +630,7 @@ trap quarantine_on_exit EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-hash_file() { sha256sum "$1" | awk '{print $1}'; }
+hash_file() { python3 "$LEDGER_TOOL" --style core hash-file "$1"; }
 
 nm_symbol_count() {
     local mode=$1 path=$2 symbol=$3
@@ -642,24 +645,11 @@ nm_developer_tools_support_count() {
 }
 
 require_hash() {
-    local path=$1 expected=$2 label=$3 actual
-    [ -f "$path" ] && [ ! -L "$path" ] || die "missing regular $label: $path"
-    actual=$(hash_file "$path")
-    [ "$actual" = "$expected" ] || die "$label hash $actual, expected $expected"
+    python3 "$LEDGER_TOOL" --style core require-hash "$1" "$2" "$3" || exit $?
 }
 
 assert_clean_commit() {
-    local repo=$1 expected_commit=$2 expected_tree=$3 label=$4
-    local actual_commit actual_tree status
-    [ -d "$repo/.git" ] || die "$label is not a Git checkout: $repo"
-    actual_commit=$(git -C "$repo" rev-parse --verify HEAD^{commit})
-    actual_tree=$(git -C "$repo" rev-parse --verify HEAD^{tree})
-    status=$(git -C "$repo" status --porcelain=v1 --untracked-files=all)
-    [ "$actual_commit" = "$expected_commit" ] \
-        || die "$label commit $actual_commit, expected $expected_commit"
-    [ "$actual_tree" = "$expected_tree" ] \
-        || die "$label tree $actual_tree, expected $expected_tree"
-    [ -z "$status" ] || die "$label checkout is dirty: $status"
+    python3 "$LEDGER_TOOL" --style core assert-clean-commit "$1" "$2" "$3" "$4" || exit $?
 }
 
 assert_exact_swift_set() {

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -31,6 +31,8 @@ OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-2026082
 OPENCOMBINE_ARTIFACTS=$OPENCOMBINE_ROOT/export/artifacts
 OPENCOMBINE_SOURCE=$OPENCOMBINE_ROOT/source
 OPENCOMBINE_HELPERS=$OPENCOMBINE_SOURCE/Sources/COpenCombineHelpers
+PREPARE_TOOL=$W/scripts/env/prepare.py
+LEDGER_TOOL=$W/scripts/env/ledger.py
 
 # Package the complete authoritative SwiftUI source directory.  Keeping a
 # hand-maintained three-file list made the reusable package silently omit new
@@ -88,15 +90,15 @@ die() {
     exit 2
 }
 
-hash_file() { sha256sum "$1" | awk '{print $1}'; }
+[ -f "$PREPARE_TOOL" ] && [ ! -L "$PREPARE_TOOL" ] \
+    || die "env prepare tool is missing or linked: $PREPARE_TOOL"
+[ -f "$LEDGER_TOOL" ] && [ ! -L "$LEDGER_TOOL" ] \
+    || die "env ledger tool is missing or linked: $LEDGER_TOOL"
+
+hash_file() { python3 "$LEDGER_TOOL" --style focus-widget hash-file "$1"; }
 hash_stream() { sha256sum | awk '{print $1}'; }
 require_hash() {
-    local file=$1 expected=$2 label=$3 got
-    [ -f "$file" ] && [ ! -L "$file" ] || {
-        echo "focus_widget_guest: missing regular $label: $file" >&2; exit 2; }
-    got=$(hash_file "$file")
-    [ "$got" = "$expected" ] || {
-        echo "focus_widget_guest: $label drifted: $got" >&2; exit 2; }
+    python3 "$LEDGER_TOOL" --style focus-widget require-hash "$1" "$2" "$3" || exit $?
 }
 
 tree_digest() {
@@ -195,6 +197,14 @@ runtime_fingerprint() {
         printf 'staged-medium-font\t%s\n' "$(hash_file "$OUT/fonts/DejaVuSans-Bold.ttf")"
     } | hash_stream
 }
+
+# Materialize the verify tree from env/contract.json first. Not --strict:
+# leftover unsatisfied rows still fail with this script's original wording
+# (the 14 measured sequential refusals). Denominators print as
+# ENV_PREPARE_SUMMARY. The only artifacts.sha256 field that includes this
+# file's own bytes is SwiftUI-build-support-subject.
+python3 "$PREPARE_TOOL" --contract "$W/env/contract.json" --root "$W" \
+    --gate focus-widget || exit $?
 
 assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
 assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -85,6 +85,34 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         self.assertIn("FocusWidgetResourceProof.exerciseUnchangedAssets()", harness)
         self.assertNotIn("OpenUIKitRuntime.imageSearchPaths", harness)
 
+    def test_gate_consumes_env_preparer_before_vendor_attestation(self) -> None:
+        text = BUILD.read_text()
+        self.assertIn('PREPARE_TOOL=$W/scripts/env/prepare.py', text)
+        self.assertIn('LEDGER_TOOL=$W/scripts/env/ledger.py', text)
+        self.assertIn(
+            'python3 "$PREPARE_TOOL" --contract "$W/env/contract.json" --root "$W"',
+            text,
+        )
+        self.assertIn('--gate focus-widget', text)
+        self.assertIn(
+            'python3 "$LEDGER_TOOL" --style focus-widget require-hash "$1" "$2" "$3"',
+            text,
+        )
+        self.assertLess(
+            text.index('--gate focus-widget'),
+            text.index('assert_vendor_tree "$W" uikit'),
+        )
+        self.assertIn("EXPECTED_UIKIT_TREE=$EXPECTED_INREPO_UIKIT_TREE", text)
+        self.assertIn("attested OpenUIKit source=HEAD:uikit", text)
+        self.assertIn(
+            "efac8d1c98b562374e54eea7540b4201523db670a6353eff8f0a0273d294526e",
+            text,
+        )
+        self.assertIn(
+            "721669388a4556e1609f580ed87d6065b63981770e71b0f77db292767b05f6c2",
+            text,
+        )
+
     def test_foundation_hidden_and_mach_o_runtime_gates_exist(self) -> None:
         text = BUILD.read_text()
         self.assertIn("foundationessentials_import_guard.swift", text)

--- a/scripts/env/__init__.py
+++ b/scripts/env/__init__.py
@@ -1,0 +1,1 @@
+"""Declarative verification-environment contract."""

--- a/scripts/env/contract.py
+++ b/scripts/env/contract.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Load env/contract.json and assert it agrees with the locks it consumes."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+class ContractError(RuntimeError):
+    pass
+
+
+def repo_root_from(start: Path | None = None) -> Path:
+    cursor = (start or Path(__file__).resolve()).parent
+    for candidate in [cursor, *cursor.parents]:
+        if (candidate / "env" / "contract.json").is_file() and (
+            candidate / "harness" / "Dockerfile"
+        ).is_file():
+            return candidate
+    raise ContractError("cannot locate repository root from env/contract.json")
+
+
+def load_contract(root: Path | None = None) -> dict[str, Any]:
+    root = root or repo_root_from()
+    path = root / "env" / "contract.json"
+    if not path.is_file() or path.is_symlink():
+        raise ContractError(f"contract is missing or a symlink: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != 1:
+        raise ContractError(f"unsupported contract schema: {payload.get('schema')}")
+    return payload
+
+
+def _read(root: Path, relative: str) -> str:
+    path = root / relative
+    if not path.is_file() or path.is_symlink():
+        raise ContractError(f"lock is missing or a symlink: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+def checkouts_by_id(contract: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows = contract["checkouts"]
+    ids = [row["id"] for row in rows]
+    if len(ids) != len(set(ids)):
+        raise ContractError("duplicate checkout id")
+    return {row["id"]: row for row in rows}
+
+
+def demanded_by(contract: dict[str, Any], gate: str) -> dict[str, list[dict[str, Any]]]:
+    """Rows in each section that list `gate` in demanded_by."""
+    out: dict[str, list[dict[str, Any]]] = {}
+    for section in (
+        "checkouts",
+        "built_products",
+        "staged_externals",
+        "host_requirements",
+        "filesystem_preconditions",
+    ):
+        out[section] = [
+            row for row in contract.get(section, []) if gate in row.get("demanded_by", [])
+        ]
+    return out
+
+
+def _shell_assign(text: str, name: str) -> str:
+    match = re.search(rf"^{re.escape(name)}=([0-9a-f]+)\s*$", text, re.MULTILINE)
+    if not match:
+        raise ContractError(f"lock is missing {name}")
+    return match.group(1)
+
+
+def _perl_spec(text: str, key: str, field: str) -> str:
+    block = re.search(
+        rf"'{re.escape(key)}'\s*=>\s*\{{(.*?)^\s*\}},",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not block:
+        raise ContractError(f"pinned_inputs.pl is missing spec {key}")
+    match = re.search(rf"{field}\s*=>\s*'([0-9a-f]+)'", block.group(1))
+    if not match:
+        raise ContractError(f"pinned_inputs.pl {key} is missing {field}")
+    return match.group(1)
+
+
+def validate_against_locks(root: Path | None = None) -> list[str]:
+    """Return agreement notes. Raise ContractError on drift vs a lock."""
+    root = root or repo_root_from()
+    contract = load_contract(root)
+    notes: list[str] = []
+    checkouts = checkouts_by_id(contract)
+
+    corpus = json.loads(_read(root, ".cursor/scratch-corpus-pins.json"))
+    digest = corpus["pinnedImage"]["digest"]
+    if contract["pinned_image"]["digest"] != digest:
+        raise ContractError(
+            f"pinned image digest {contract['pinned_image']['digest']} != corpus lock {digest}"
+        )
+    notes.append("pinned_image digest agrees with .cursor/scratch-corpus-pins.json")
+
+    dockerfile = _read(root, "harness/Dockerfile")
+    if digest not in dockerfile:
+        raise ContractError("harness/Dockerfile does not pin the contract image digest")
+    notes.append("pinned_image digest agrees with harness/Dockerfile")
+
+    by_corpus_id = {row["id"]: row for row in corpus["sources"]}
+    for source_id, lock_row in by_corpus_id.items():
+        row = checkouts.get(source_id)
+        if row is None:
+            raise ContractError(f"contract is missing corpus checkout {source_id}")
+        for field in ("repository", "commit", "tree", "destination"):
+            if row.get(field) != lock_row[field]:
+                raise ContractError(
+                    f"{source_id}.{field} {row.get(field)!r} != corpus lock {lock_row[field]!r}"
+                )
+        notes.append(f"checkout {source_id} agrees with .cursor/scratch-corpus-pins.json")
+
+    vendor = _read(root, "scripts/vendor_pins.sh")
+    uikit_tree = _shell_assign(vendor, "EXPECTED_INREPO_UIKIT_TREE")
+    machorun_tree = _shell_assign(vendor, "EXPECTED_INREPO_MACHORUN_TREE")
+    if checkouts["uikit-inrepo"]["tree"] != uikit_tree:
+        raise ContractError("uikit-inrepo tree disagrees with scripts/vendor_pins.sh")
+    if checkouts["machorun-inrepo"]["tree"] != machorun_tree:
+        raise ContractError("machorun-inrepo tree disagrees with scripts/vendor_pins.sh")
+    notes.append("in-repo vendor trees agree with scripts/vendor_pins.sh")
+
+    pinned = _read(root, "full/foundation/pinned_inputs.pl")
+    for name in ("swift-foundation", "swift-collections"):
+        commit = _perl_spec(pinned, name, "commit")
+        tree = _perl_spec(pinned, name, "tree")
+        if checkouts[name]["commit"] != commit or checkouts[name]["tree"] != tree:
+            raise ContractError(f"{name} disagrees with full/foundation/pinned_inputs.pl")
+        notes.append(f"checkout {name} agrees with full/foundation/pinned_inputs.pl")
+
+    evidence = json.loads(_read(root, "full/framework-fanout/external-evidence-sources.json"))
+    macios = next(row for row in evidence["sources"] if row["id"] == "dotnet-macios")
+    row = checkouts["dotnet-macios"]
+    if row["commit"] != macios["commit"] or row["repository"] != macios["repository"]:
+        raise ContractError("dotnet-macios disagrees with external-evidence-sources.json")
+    notes.append("checkout dotnet-macios agrees with external-evidence-sources.json")
+
+    swiftcore = next(
+        item for item in contract["staged_externals"] if item["id"] == "libswiftCore"
+    )
+    policy = _read(root, "full/oracle-opencombine/policy.json")
+    if swiftcore["sha256"] not in policy:
+        raise ContractError("libswiftCore sha256 is not in full/oracle-opencombine/policy.json")
+    artifact = root / swiftcore["source"]
+    if artifact.is_file() and not artifact.is_symlink():
+        import hashlib
+
+        digest_file = hashlib.sha256(artifact.read_bytes()).hexdigest()
+        if digest_file != swiftcore["sha256"]:
+            raise ContractError(
+                f"in-repo libswiftCore artifact {digest_file} != contract {swiftcore['sha256']}"
+            )
+        notes.append("libswiftCore sha256 agrees with in-repo swiftcore-macho artifact")
+    else:
+        notes.append("libswiftCore artifact absent; sha256 lock-only")
+
+    widget = contract["focus_widget_attestation_pins"]
+    gate = _read(root, "full/swiftui/build_focus_widget_guest.sh")
+    compared = 0
+    for key, value in widget.items():
+        if key == "notes":
+            continue
+        token = f"{key}={value}"
+        if token not in gate:
+            raise ContractError(f"focus-widget pin {token} is missing from the gate")
+        compared += 1
+    notes.append(
+        f"focus_widget_attestation_pins {compared}/{compared} agree with "
+        "full/swiftui/build_focus_widget_guest.sh"
+    )
+
+    every_row = 0
+    cited = 0
+    for section in (
+        "checkouts",
+        "built_products",
+        "staged_externals",
+        "host_requirements",
+        "filesystem_preconditions",
+    ):
+        for row in contract[section]:
+            every_row += 1
+            if row.get("demanded_by"):
+                cited += 1
+            else:
+                raise ContractError(f"{section} id={row.get('id')} has empty demanded_by")
+    notes.append(f"demanded_by cited {cited}/{every_row} environment rows")
+    return notes
+
+
+def main() -> int:
+    notes = validate_against_locks()
+    print(f"ENV_CONTRACT_LOCKS_OK agreements={len(notes)}/{len(notes)}")
+    for note in notes:
+        print(f"  {note}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/env/ledger.py
+++ b/scripts/env/ledger.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Hash and checkout-ledger primitives shared by shell gates.
+
+Shell keeps compile/link/run. This module owns content hashing, pin
+comparison, and the exact refusal strings those gates already print.
+A style that changes a refusal character is a behavior change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+
+class LedgerError(RuntimeError):
+    def __init__(self, message: str, exit_code: int = 2) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+STYLES: dict[str, dict[str, str]] = {
+    "core": {
+        "prefix": "core_guest_package: REFUSING -- ",
+        "missing": "missing regular {label}: {path}",
+        "mismatch": "{label} hash {actual}, expected {expected}",
+        "not_git": "{label} is not a Git checkout: {repo}",
+        "commit": "{label} commit {actual}, expected {expected}",
+        "tree": "{label} tree {actual}, expected {expected}",
+        "dirty": "{label} checkout is dirty: {status}",
+    },
+    "focus-widget": {
+        "prefix": "focus_widget_guest: ",
+        "missing": "missing regular {label}: {path}",
+        "mismatch": "{label} drifted: {actual}",
+        "not_git": "{label} is not a Git checkout: {repo}",
+        "commit": "{label} commit {actual}, expected {expected}",
+        "tree": "{label} tree {actual}, expected {expected}",
+        "dirty": "{label} checkout is dirty: {status}",
+    },
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_regular(path: Path, label: str, style: str) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError as error:
+        raise LedgerError(_format(style, "missing", label=label, path=str(path))) from error
+    if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+        raise LedgerError(_format(style, "missing", label=label, path=str(path)))
+
+
+def _format(style: str, key: str, **fields: str) -> str:
+    spec = STYLES[style]
+    return spec["prefix"] + spec[key].format(**fields)
+
+
+def require_hash(path: Path, expected: str, label: str, style: str = "core") -> str:
+    require_regular(path, label, style)
+    actual = sha256_file(path)
+    if actual != expected:
+        raise LedgerError(
+            _format(
+                style,
+                "mismatch",
+                label=label,
+                actual=actual,
+                expected=expected,
+                path=str(path),
+            )
+        )
+    return actual
+
+
+def _git(repo: Path, *args: str) -> tuple[int, str, str]:
+    # No extra safe.directory: the gate refusal for dubious-ownership is load-bearing.
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def assert_clean_commit(
+    repo: Path,
+    expected_commit: str,
+    expected_tree: str,
+    label: str,
+    style: str = "core",
+) -> None:
+    git_dir = repo / ".git"
+    if not git_dir.exists():
+        raise LedgerError(_format(style, "not_git", label=label, repo=str(repo)))
+    status, commit, err = _git(repo, "rev-parse", "--verify", "HEAD^{commit}")
+    if status != 0:
+        raise LedgerError(_format(style, "not_git", label=label, repo=str(repo)))
+    commit = commit.strip()
+    status, tree, err = _git(repo, "rev-parse", "--verify", "HEAD^{tree}")
+    if status != 0:
+        raise LedgerError(_format(style, "not_git", label=label, repo=str(repo)))
+    tree = tree.strip()
+    status, porcelain, err = _git(
+        repo, "status", "--porcelain=v1", "--untracked-files=all"
+    )
+    if status != 0:
+        raise LedgerError(_format(style, "not_git", label=label, repo=str(repo)))
+    if commit != expected_commit:
+        raise LedgerError(
+            _format(style, "commit", label=label, actual=commit, expected=expected_commit)
+        )
+    if tree != expected_tree:
+        raise LedgerError(
+            _format(style, "tree", label=label, actual=tree, expected=expected_tree)
+        )
+    if porcelain.strip():
+        raise LedgerError(
+            _format(style, "dirty", label=label, status=porcelain.strip())
+        )
+
+
+def load_tree_digest():
+    root = Path(__file__).resolve().parents[2]
+    path = root / ".cursor" / "tree-digest.py"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("cursor_tree_digest", path)
+    if spec is None or spec.loader is None:
+        raise LedgerError("tree-digest.py is missing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.tree_digest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ledger.py")
+    parser.add_argument("--style", choices=sorted(STYLES), default="core")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    hash_p = sub.add_parser("hash-file")
+    hash_p.add_argument("path")
+
+    req_p = sub.add_parser("require-hash")
+    req_p.add_argument("path")
+    req_p.add_argument("expected")
+    req_p.add_argument("label")
+
+    git_p = sub.add_parser("assert-clean-commit")
+    git_p.add_argument("repo")
+    git_p.add_argument("commit")
+    git_p.add_argument("tree")
+    git_p.add_argument("label")
+
+    digest_p = sub.add_parser("tree-digest")
+    digest_p.add_argument("root")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "hash-file":
+            path = Path(args.path)
+            require_regular(path, "file", args.style)
+            sys.stdout.write(sha256_file(path) + "\n")
+            return 0
+        if args.command == "require-hash":
+            require_hash(Path(args.path), args.expected, args.label, args.style)
+            return 0
+        if args.command == "assert-clean-commit":
+            assert_clean_commit(
+                Path(args.repo), args.commit, args.tree, args.label, args.style
+            )
+            return 0
+        if args.command == "tree-digest":
+            tree_digest = load_tree_digest()
+            sys.stdout.write(tree_digest(Path(args.root)) + "\n")
+            return 0
+    except LedgerError as error:
+        sys.stderr.write(str(error) + "\n")
+        return error.exit_code
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/env/markers.py
+++ b/scripts/env/markers.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Single registry of verification-environment refusal and verdict markers.
+
+Gates keep emitting the exact strings they emit today. This module is the
+place that records what each marker *means*, so counting refusals separately
+from passes and failures is uniform.
+
+A marker that is registered but not currently emitted (NEEDS_DARWIN_BASELINE)
+must not be introduced into a gate without a documented behavior change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Marker:
+    """One counted environment marker."""
+
+    name: str
+    kind: str  # cannot | pass | summary | refuse
+    meaning: str
+    emitted_by: tuple[str, ...]
+    exit_code: int | None
+    currently_emitted: bool = True
+
+
+# kind=cannot  — honest per-host inability; must not be counted as a test fail
+# kind=pass    — a satisfied environment row
+# kind=summary — denominator line
+# kind=refuse  — gate-local refusal prefix (not a CURSOR_ENV_* token)
+
+MARKERS: dict[str, Marker] = {
+    "CURSOR_ENV_CANNOT_BUILD_LOADER": Marker(
+        name="CURSOR_ENV_CANNOT_BUILD_LOADER",
+        kind="cannot",
+        meaning=(
+            "machorun/src/tlv_asm.S is aarch64 assembly; the loader is a native "
+            "Linux/aarch64 ELF, not a cross-built Mach-O. This host cannot assemble it."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_GENERATE_TBD": Marker(
+        name="CURSOR_ENV_CANNOT_GENERATE_TBD",
+        kind="cannot",
+        meaning=(
+            "machorun/scripts/gen_tbd.sh CHECK 1 requires the host ELF loader so "
+            "libSystem.tbd is nm(libSystem.B.dylib) UNION loader-exports. Empty or "
+            "unchecked .tbd files are a lie to ld64."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER": Marker(
+        name="CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER",
+        kind="cannot",
+        meaning=(
+            "scratch/mrroot_full/machorun is that host ELF. Darwin dylibs may still "
+            "be staged; execution-shaped gates must refuse with "
+            "CURSOR_ENV_CANNOT_EXECUTE_ARM64 rather than exec a stub."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS": Marker(
+        name="CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS",
+        kind="cannot",
+        meaning=(
+            "full/foundation/stage_fe_sysroot.sh copies Darwin/Foundation "
+            ".swiftinterface and Apple apinotes from an Xcode macOS SDK. Those files "
+            "are not redistributable and are not in this repo."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS": Marker(
+        name="CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS",
+        kind="cannot",
+        meaning=(
+            "full/foundation/stage_swift_overlays.sh copies the Swift overlay "
+            "closure (libswiftDarwin, libswift_StringProcessing, …) from an iOS "
+            "CoreSimulator runtime on macOS."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT": Marker(
+        name="CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT",
+        kind="cannot",
+        meaning=(
+            "OpenCombine export/artifacts are produced by compiling and running "
+            "under machorun inside a pinned fm-build container. Source can be "
+            "cloned without producing export/."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST": Marker(
+        name="CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST",
+        kind="cannot",
+        meaning=(
+            "scratch/modcache_swiftui_guest is a swiftc module cache from a real "
+            "SwiftUI guest compile against a full FE sysroot. An empty directory "
+            "would look populated; leaving the path absent is the honest state."
+        ),
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=None,
+    ),
+    "CURSOR_ENV_CANNOT_EXECUTE_ARM64": Marker(
+        name="CURSOR_ENV_CANNOT_EXECUTE_ARM64",
+        kind="cannot",
+        meaning=(
+            "machorun executes arm64 Mach-O natively on Linux/aarch64. This host "
+            "can compile and link arm64 Mach-O but cannot run it. Do not qemu or stub. "
+            "Canonical text from .cursor/refuse-arm64-execution.sh (exit 2)."
+        ),
+        emitted_by=(
+            ".cursor/refuse-arm64-execution.sh",
+            "full/swiftui/build_focus_widget_guest.sh",
+            "full/swiftui/build_focus_onboarding_guest.sh",
+            "full/swiftui/build_focus_package_guest.sh",
+        ),
+        exit_code=2,
+    ),
+    "NEEDS_DARWIN_BASELINE": Marker(
+        name="NEEDS_DARWIN_BASELINE",
+        kind="cannot",
+        meaning=(
+            "Unified name for a Darwin baseline this host cannot materialize "
+            "(Xcode overlays and/or CoreSimulator overlay dylibs). Not currently "
+            "emitted: gates use CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS and "
+            "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS. Do not start "
+            "emitting this token without a documented behavior change."
+        ),
+        emitted_by=(),
+        exit_code=None,
+        currently_emitted=False,
+    ),
+    "CURSOR_ENV_SUMMARY": Marker(
+        name="CURSOR_ENV_SUMMARY",
+        kind="summary",
+        meaning="One line: can=… cannot=… unavailable=N fingerprint=…",
+        emitted_by=(".cursor/verify-cloud-environment.sh",),
+        exit_code=None,
+    ),
+    "ENV_PREPARE_SUMMARY": Marker(
+        name="ENV_PREPARE_SUMMARY",
+        kind="summary",
+        meaning=(
+            "One line from scripts/env/prepare.py with denominators "
+            "satisfied/cold-built/staged/CANNOT."
+        ),
+        emitted_by=("scripts/env/prepare.py",),
+        exit_code=None,
+    ),
+    "CURSOR_CORPUS_OK": Marker(
+        name="CURSOR_CORPUS_OK",
+        kind="pass",
+        meaning="One pinned scratch checkout matched commit+tree+origin+clean.",
+        emitted_by=(".cursor/clone-pinned-repo.sh",),
+        exit_code=0,
+    ),
+    "CURSOR_SCRATCH_CORPUS_OK": Marker(
+        name="CURSOR_SCRATCH_CORPUS_OK",
+        kind="pass",
+        meaning="Corpus pins N/N cloned or reused.",
+        emitted_by=(".cursor/install-scratch-corpus.sh",),
+        exit_code=0,
+    ),
+    "CURSOR_BUILT_PRODUCTS_OK": Marker(
+        name="CURSOR_BUILT_PRODUCTS_OK",
+        kind="pass",
+        meaning="In-VM Mach-O products hashed; loader/tbd flags recorded.",
+        emitted_by=(".cursor/install-built-products.sh",),
+        exit_code=0,
+    ),
+    "CURSOR_ENV_TOOLCHAIN_ATTESTED": Marker(
+        name="CURSOR_ENV_TOOLCHAIN_ATTESTED",
+        kind="pass",
+        meaning="Live toolchain fingerprint matches the verify stamp and pinned image digest.",
+        emitted_by=(".cursor/attest-cursor-env.sh",),
+        exit_code=0,
+    ),
+    "CURSOR_SWIFT_ENVIRONMENT_OK": Marker(
+        name="CURSOR_SWIFT_ENVIRONMENT_OK",
+        kind="pass",
+        meaning="Swift 6.2.4 linux toolchain inventory passed.",
+        emitted_by=(".cursor/verify-cloud-environment.sh",),
+        exit_code=0,
+    ),
+}
+
+
+CANNOT_PREFIX = "CURSOR_ENV_CANNOT_"
+
+# Gate-local refusal prefixes. These are not CURSOR_ENV_* tokens; they still
+# count as refusals, not as test failures, when the text is an environment
+# precondition rather than a product assertion.
+GATE_REFUSE_PREFIXES: tuple[str, ...] = (
+    "core_guest_package: REFUSING --",
+    "focus_widget_guest:",
+    "build_full: REFUSING TO BUILD --",
+    "pinned_inputs: REFUSING --",
+    "cursor-env-attest: REFUSING --",
+    "cursor-env: REFUSING --",
+    "require_fresh_root: REFUSING TO GRADE --",
+    "GUEST ROOT NOT USABLE:",
+    "ProofError",
+)
+
+
+def cannot_markers() -> tuple[Marker, ...]:
+    return tuple(m for m in MARKERS.values() if m.kind == "cannot")
+
+
+def emitted_cannot_names() -> tuple[str, ...]:
+    return tuple(
+        m.name for m in cannot_markers() if m.currently_emitted
+    )
+
+
+def parse_marker_line(line: str) -> str | None:
+    """Return the marker name if `line` starts with a registered token."""
+    stripped = line.strip()
+    for name in MARKERS:
+        if stripped == name or stripped.startswith(name + " ") or stripped.startswith(name + "="):
+            return name
+    return None
+
+
+def classify_line(line: str) -> str:
+    """Classify a log line: cannot | pass | summary | refuse | other."""
+    name = parse_marker_line(line)
+    if name is not None:
+        return MARKERS[name].kind
+    stripped = line.strip()
+    for prefix in GATE_REFUSE_PREFIXES:
+        if stripped.startswith(prefix):
+            return "refuse"
+    return "other"
+
+
+def count_kinds(lines: Iterable[str]) -> dict[str, int]:
+    """Count classified lines. Denominator keys are always present."""
+    counts = {"cannot": 0, "pass": 0, "summary": 0, "refuse": 0, "other": 0}
+    for line in lines:
+        counts[classify_line(line)] += 1
+    return counts
+
+
+def main() -> int:
+    emitted = sum(1 for m in MARKERS.values() if m.currently_emitted)
+    cannot = sum(1 for m in MARKERS.values() if m.kind == "cannot" and m.currently_emitted)
+    reserved = sum(1 for m in MARKERS.values() if not m.currently_emitted)
+    print(
+        f"ENV_MARKERS_REGISTRY markers={len(MARKERS)} "
+        f"emitted={emitted}/{len(MARKERS)} "
+        f"cannot={cannot}/{len(MARKERS)} "
+        f"reserved={reserved}/{len(MARKERS)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/env/prepare.py
+++ b/scripts/env/prepare.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Materialize a verify tree from env/contract.json on any host.
+
+Idempotent: rerun = verify. Fixes (chown/mode/safe.directory/stage) are
+printed explicitly. Honest per-host inability uses the marker vocabulary
+in scripts/env/markers.py. Does not rewrite PR #3 .cursor scripts: corpus
+clones go through .cursor/clone-pinned-repo.sh.
+
+When a gate sources this (default, not --strict) remaining unsatisfied
+rows are reported and the process exits 0 so the gate's original refusal
+text stays the behavior oracle. --strict exits 2 if this host still owes
+a row it is expected to satisfy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from contract import demanded_by, load_contract, repo_root_from
+    from ledger import sha256_file
+else:
+    from .contract import demanded_by, load_contract, repo_root_from
+    from .ledger import sha256_file
+
+
+class PrepareError(RuntimeError):
+    pass
+
+
+def _run(argv: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
+def host_arch() -> str:
+    return os.uname().machine
+
+
+def host_os() -> str:
+    return os.uname().sysname
+
+
+def expected_cannot_for_host(contract: dict, arch: str, system: str) -> list[str]:
+    if system == "Darwin":
+        return list(contract["hosts"]["macos-oracle"]["expected_cannot"])
+    if arch in ("aarch64", "arm64"):
+        return list(contract["hosts"]["ec2-aarch64"]["expected_cannot"])
+    return list(contract["hosts"]["cursor-x86_64"]["expected_cannot"])
+
+
+def which(name: str) -> str | None:
+    return shutil.which(name)
+
+
+class Outcome:
+    def __init__(
+        self,
+        status: str,
+        ident: str,
+        detail: str,
+        marker: str | None = None,
+    ) -> None:
+        self.status = status
+        self.id = ident
+        self.detail = detail
+        self.marker = marker
+
+    def line(self) -> str:
+        marker = f" marker={self.marker}" if self.marker else ""
+        return f"ENV_PREPARE_{self.status.upper()} id={self.id} {self.detail}{marker}"
+
+
+def git_global_safe_directories() -> list[str]:
+    result = _run(["git", "config", "--global", "--get-all", "safe.directory"])
+    if result.returncode not in (0, 1):
+        return []
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def ensure_safe_directory(path: Path) -> Outcome:
+    resolved = str(path.resolve())
+    existing = git_global_safe_directories()
+    if resolved in existing or "*" in existing:
+        return Outcome("satisfied", "git-safe-directory", f"path={resolved} reused=1")
+    added = _run(["git", "config", "--global", "--add", "safe.directory", resolved])
+    if added.returncode != 0:
+        return Outcome(
+            "cannot",
+            "git-safe-directory",
+            f"path={resolved} {added.stderr.strip()}",
+            marker=None,
+        )
+    return Outcome("satisfied", "git-safe-directory", f"path={resolved} added=1")
+
+
+def ensure_mode_0700(path: Path, ident: str) -> Outcome:
+    path.mkdir(parents=True, exist_ok=True)
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode):
+        return Outcome("unsatisfied", ident, f"path={path} is a symlink")
+    mode = stat.S_IMODE(metadata.st_mode)
+    owner_ok = metadata.st_uid == os.geteuid()
+    changed = []
+    if not owner_ok:
+        try:
+            os.chown(path, os.geteuid(), -1)
+            changed.append("chown")
+        except OSError as error:
+            return Outcome("unsatisfied", ident, f"path={path} chown failed: {error}")
+    if mode & 0o077:
+        os.chmod(path, 0o700)
+        changed.append("chmod0700")
+    if changed:
+        return Outcome("satisfied", ident, f"path={path} fixed={','.join(changed)}")
+    return Outcome("satisfied", ident, f"path={path} reused=1 mode=0700")
+
+
+def clone_or_verify_git(
+    root: Path, row: dict, verify_only: bool
+) -> Outcome:
+    dest = Path(row["destination"])
+    if not dest.is_absolute():
+        dest = root / dest
+    ident = row["id"]
+    cloner = root / ".cursor" / "clone-pinned-repo.sh"
+    lock = root / ".cursor" / "scratch-corpus-pins.json"
+    uses_corpus_cloner = row.get("lock") == ".cursor/scratch-corpus-pins.json"
+    if dest.is_dir() and (dest / ".git").exists():
+        commit = _run(["git", "-c", f"safe.directory={dest}", "-C", str(dest), "rev-parse", "HEAD"])
+        tree = _run(
+            ["git", "-c", f"safe.directory={dest}", "-C", str(dest), "rev-parse", "HEAD^{tree}"]
+        )
+        if (
+            commit.returncode == 0
+            and tree.returncode == 0
+            and commit.stdout.strip() == row["commit"]
+            and tree.stdout.strip() == row["tree"]
+        ):
+            return Outcome(
+                "satisfied",
+                ident,
+                f"commit={row['commit']} tree={row['tree']} dest={dest.relative_to(root) if dest.is_relative_to(root) else dest} reused=1",
+            )
+        return Outcome(
+            "unsatisfied",
+            ident,
+            f"live_commit={commit.stdout.strip() or 'unreadable'} want={row['commit']}",
+        )
+    if verify_only:
+        return Outcome("unsatisfied", ident, f"missing dest={dest}")
+    if not uses_corpus_cloner:
+        # Build a one-row lock the PR #3 cloner already understands.
+        if not str(row["destination"]).startswith("scratch/"):
+            return Outcome("cannot", ident, "destination is not under scratch/")
+        lock_dir = Path(tempfile.mkdtemp(prefix=".env-contract-lock.", dir=str(root / "scratch" if (root / "scratch").is_dir() else "/tmp")))
+        lock = lock_dir / "lock.json"
+        lock.write_text(
+            json.dumps({"sources": [{
+                "id": ident,
+                "repository": row["repository"],
+                "commit": row["commit"],
+                "tree": row["tree"],
+                "destination": row["destination"],
+            }]}, indent=2)
+            + "\n",
+            encoding="utf-8",
+        )
+    if not cloner.is_file():
+        return Outcome("cannot", ident, "clone-pinned-repo.sh is missing")
+    cloned = _run(
+        [
+            "bash",
+            str(cloner),
+            "--lock",
+            str(lock),
+            "--id",
+            ident if uses_corpus_cloner else ident,
+            "--repo-root",
+            str(root),
+        ]
+    )
+    if cloned.returncode != 0:
+        detail = (cloned.stderr or cloned.stdout).strip().splitlines()
+        tail = detail[-1] if detail else f"exit {cloned.returncode}"
+        return Outcome("unsatisfied", ident, f"clone failed: {tail}")
+    return Outcome(
+        "satisfied",
+        ident,
+        f"commit={row['commit']} tree={row['tree']} cloned=1",
+    )
+
+
+def verify_inrepo_tree(root: Path, row: dict) -> Outcome:
+    ident = row["id"]
+    path = root / row["path"]
+    if not path.is_dir() or path.is_symlink():
+        return Outcome("unsatisfied", ident, f"missing subtree {path}")
+    result = _run(["git", "-C", str(root), "rev-parse", f"HEAD:{row['path']}"])
+    if result.returncode != 0:
+        return Outcome("unsatisfied", ident, result.stderr.strip() or "rev-parse failed")
+    live = result.stdout.strip()
+    if live != row["tree"]:
+        return Outcome(
+            "unsatisfied",
+            ident,
+            f"live={live} pin={row['tree']} (will not advance vendor_pins.sh)",
+        )
+    return Outcome("satisfied", ident, f"tree={live} reused=1")
+
+
+def stage_file(source: Path, dest: Path, expected: str, ident: str, verify_only: bool) -> Outcome:
+    if not source.is_file() or source.is_symlink():
+        return Outcome("unsatisfied", ident, f"source missing {source}")
+    source_hash = sha256_file(source)
+    if source_hash != expected:
+        return Outcome(
+            "unsatisfied",
+            ident,
+            f"source hash {source_hash} != {expected}",
+        )
+    if dest.is_file() and not dest.is_symlink() and sha256_file(dest) == expected:
+        return Outcome("satisfied", ident, f"sha256={expected} reused=1")
+    if verify_only:
+        if dest.is_file():
+            return Outcome("unsatisfied", ident, f"dest hash {sha256_file(dest)} != {expected}")
+        return Outcome("unsatisfied", ident, f"missing dest={dest}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f".{dest.name}.INCOMPLETE"
+    shutil.copyfile(source, tmp)
+    os.chmod(tmp, stat.S_IMODE(source.stat().st_mode))
+    tmp.replace(dest)
+    staged = sha256_file(dest)
+    if staged != expected:
+        return Outcome("unsatisfied", ident, f"staged hash {staged} != {expected}")
+    return Outcome("staged", ident, f"sha256={expected} dest={dest}")
+
+
+def verify_absolute_hash(path: Path, expected: str, ident: str) -> Outcome:
+    if not path.is_file() or path.is_symlink():
+        return Outcome("unsatisfied", ident, f"missing {path}")
+    actual = sha256_file(path)
+    if actual != expected:
+        return Outcome("unsatisfied", ident, f"hash {actual} != {expected}")
+    return Outcome("satisfied", ident, f"sha256={expected} reused=1")
+
+
+def maybe_build_loader(root: Path, verify_only: bool, arch: str) -> Outcome:
+    loader = root / "machorun" / "build" / "machorun"
+    if loader.is_file() and os.access(loader, os.X_OK) and not loader.is_symlink():
+        return Outcome("satisfied", "machorun-loader", f"path={loader} reused=1")
+    if arch not in ("aarch64", "arm64"):
+        return Outcome(
+            "cannot",
+            "machorun-loader",
+            f"host={arch}",
+            marker="CURSOR_ENV_CANNOT_BUILD_LOADER",
+        )
+    if verify_only:
+        return Outcome("unsatisfied", "machorun-loader", "missing loader")
+    built = _run(["sh", str(root / "machorun" / "scripts" / "build.sh"), "loader"], cwd=root)
+    if built.returncode != 0 or not loader.is_file():
+        tail = (built.stderr or built.stdout).strip().splitlines()
+        return Outcome(
+            "unsatisfied",
+            "machorun-loader",
+            tail[-1] if tail else "build.sh loader failed",
+        )
+    return Outcome("cold-built", "machorun-loader", f"path={loader}")
+
+
+def product_outcome(
+    root: Path, row: dict, verify_only: bool, arch: str, system: str
+) -> Outcome:
+    ident = row["id"]
+    path = root / row["path"] if not Path(row["path"]).is_absolute() else Path(row["path"])
+    cannot = row.get("cannot_on", {})
+    if ident == "machorun-loader":
+        return maybe_build_loader(root, verify_only, arch)
+    if ident == "libswiftCore":
+        return stage_file(
+            root / row["source"] if "source" in row else path,
+            path,
+            row["sha256"],
+            ident,
+            verify_only,
+        )
+    if ident == "opencombine-export":
+        hashes = row.get("content_hashes") or {}
+        missing = []
+        export_root = root / row["path"]
+        for name, digest in hashes.items():
+            file_path = export_root / name
+            if not file_path.is_file():
+                missing.append(name)
+                continue
+            actual = sha256_file(file_path)
+            if actual != digest:
+                return Outcome("unsatisfied", ident, f"{name} hash {actual} != {digest}")
+        if missing:
+            marker = cannot.get("x86_64") or cannot.get("Linux-without-loader")
+            if marker and arch not in ("aarch64", "arm64"):
+                return Outcome("cannot", ident, f"missing {','.join(missing)}", marker=marker)
+            return Outcome("unsatisfied", ident, f"missing {','.join(missing)}")
+        return Outcome("satisfied", ident, f"files={len(hashes)}/{len(hashes)} reused=1")
+    if ident == "tbd-stubs":
+        if arch not in ("aarch64", "arm64"):
+            return Outcome(
+                "cannot",
+                ident,
+                f"host={arch}",
+                marker="CURSOR_ENV_CANNOT_GENERATE_TBD",
+            )
+        if path.is_dir() and any(path.glob("*.tbd")):
+            return Outcome("satisfied", ident, "tbd present reused=1")
+        return Outcome("unsatisfied", ident, "tbd missing")
+    if ident == "sysroot_fe4":
+        if path.is_dir() and (path / "usr" / "include").is_dir():
+            return Outcome("satisfied", ident, f"path={path} reused=1")
+        marker = cannot.get("Linux") if system == "Linux" else None
+        if marker:
+            return Outcome("cannot", ident, "full Xcode overlays absent", marker=marker)
+        return Outcome("unsatisfied", ident, f"missing {path}")
+    if ident == "mrroot_full":
+        if path.is_dir() and (path / "darwin" / "usr" / "lib").is_dir():
+            loader = path / "machorun"
+            if not loader.is_file() and arch not in ("aarch64", "arm64"):
+                return Outcome(
+                    "cannot",
+                    ident,
+                    "dylibs present, loader absent",
+                    marker="CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER",
+                )
+            return Outcome("satisfied", ident, f"path={path} reused=1")
+        if arch not in ("aarch64", "arm64"):
+            return Outcome(
+                "cannot",
+                ident,
+                f"host={arch}",
+                marker="CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER",
+            )
+        return Outcome("unsatisfied", ident, f"missing {path}")
+    if ident == "modcache_swiftui_guest":
+        if path.is_dir():
+            return Outcome("satisfied", ident, "present reused=1")
+        return Outcome(
+            "cannot",
+            ident,
+            "absent (honest empty would look populated)",
+            marker="CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST",
+        )
+    if ident == "darwin-userland":
+        probe = path / "libSystem.B.dylib"
+        if probe.is_file() and not probe.is_symlink():
+            return Outcome("satisfied", ident, f"path={path} reused=1")
+        return Outcome("unsatisfied", ident, f"missing {probe}")
+    if path.exists():
+        return Outcome("satisfied", ident, f"path={path} reused=1")
+    marker = cannot.get(arch) or cannot.get(system)
+    if marker:
+        return Outcome("cannot", ident, f"missing {path}", marker=marker)
+    return Outcome("unsatisfied", ident, f"missing {path}")
+
+
+def staged_outcome(root: Path, row: dict, verify_only: bool, arch: str, system: str) -> Outcome:
+    ident = row["id"]
+    if ident == "libswiftCore":
+        source = root / row["source"]
+        dest = root / row["path"]
+        return stage_file(source, dest, row["sha256"], ident, verify_only)
+    if ident in ("dejavu-sans", "dejavu-sans-bold"):
+        return verify_absolute_hash(Path(row["path"]), row["sha256"], ident)
+    if ident == "mrroot_fe-overlays":
+        path = root / row["path"]
+        if path.is_dir():
+            return Outcome("satisfied", ident, f"path={path} reused=1")
+        if system != "Darwin":
+            return Outcome(
+                "cannot",
+                ident,
+                "CoreSimulator overlays are macOS-only",
+                marker="CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS",
+            )
+        return Outcome("unsatisfied", ident, f"missing {path}")
+    if ident == "mrroot-base-runtime":
+        path = root / row["path"]
+        if path.is_dir():
+            return Outcome("satisfied", ident, f"path={path} reused=1")
+        return Outcome("unsatisfied", ident, f"missing {path}")
+    path = root / row["path"] if not Path(row.get("path", "")).is_absolute() else Path(row["path"])
+    if path.exists():
+        return Outcome("satisfied", ident, f"path={path} reused=1")
+    return Outcome("unsatisfied", ident, f"missing {path}")
+
+
+def host_outcome(row: dict) -> list[Outcome]:
+    ident = row["id"]
+    out: list[Outcome] = []
+    if row["kind"] in ("tools", "tool-alias"):
+        for tool in row.get("tools", []):
+            if which(tool):
+                out.append(Outcome("satisfied", f"{ident}:{tool}", "on PATH"))
+            else:
+                out.append(Outcome("unsatisfied", f"{ident}:{tool}", "missing"))
+        aliases = row.get("must_resolve_to")
+        if aliases:
+            for unversioned, versioned in zip(row.get("tools", []), aliases):
+                left = which(unversioned)
+                right = which(versioned)
+                if left and right and Path(left).resolve() == Path(right).resolve():
+                    out.append(Outcome("satisfied", f"{ident}:{unversioned}->18", "alias ok"))
+                elif left and right:
+                    out.append(
+                        Outcome(
+                            "unsatisfied",
+                            f"{ident}:{unversioned}",
+                            f"{left} != {right}",
+                        )
+                    )
+        return out
+    if row["kind"] == "toolchain":
+        swiftc = which("swiftc")
+        if not swiftc:
+            return [Outcome("unsatisfied", ident, "swiftc missing")]
+        version = _run([swiftc, "--version"])
+        needle = row.get("match", "")
+        if needle and needle in version.stdout:
+            return [Outcome("satisfied", ident, needle)]
+        if version.returncode == 0:
+            first = version.stdout.splitlines()[0] if version.stdout else "unknown"
+            return [Outcome("unsatisfied", ident, first)]
+        return [Outcome("unsatisfied", ident, "swiftc --version failed")]
+    if row["kind"] == "tool-pin":
+        for profile in row.get("profiles", []):
+            path = Path(profile["path"])
+            if path.is_file() and not path.is_symlink():
+                actual = sha256_file(path)
+                if actual == profile["sha256"]:
+                    return [Outcome("satisfied", ident, f"profile={profile['id']} reused=1")]
+        return [Outcome("unsatisfied", ident, "no matching poppler profile on this host")]
+    return [Outcome("satisfied", ident, "no-op")]
+
+
+def filesystem_outcome(root: Path, row: dict, verify_only: bool) -> list[Outcome]:
+    ident = row["id"]
+    if ident == "git-safe-directory":
+        targets = [root]
+        return [ensure_safe_directory(path) for path in targets]
+    if ident == "mktemp-root":
+        path = root / row["path"]
+        if verify_only and not path.exists():
+            return [Outcome("unsatisfied", ident, f"missing {path}")]
+        path.mkdir(parents=True, exist_ok=True)
+        if path.is_symlink() or not path.is_dir():
+            return [Outcome("unsatisfied", ident, f"not a directory: {path}")]
+        return [Outcome("satisfied", ident, f"path={path} reused=1")]
+    if ident == "proof-parent-0700":
+        parent = root / "scratch" / ".env-proof-parent"
+        if verify_only and not parent.exists():
+            return [Outcome("unsatisfied", ident, f"missing {parent}")]
+        return [ensure_mode_0700(parent, ident)]
+    if ident == "ancestor-trust":
+        parent = root / "scratch" / ".env-proof-parent"
+        if not parent.is_dir():
+            return [Outcome("unsatisfied", ident, "proof parent missing")]
+        child = parent
+        euid = os.geteuid()
+        while True:
+            container = child.parent
+            if container == child:
+                break
+            meta = container.stat()
+            if meta.st_uid not in (0, euid):
+                return [
+                    Outcome(
+                        "unsatisfied",
+                        ident,
+                        f"untrusted owner uid={meta.st_uid} path={container}",
+                    )
+                ]
+            child = container
+        return [Outcome("satisfied", ident, "ancestors trusted")]
+    if ident == "macios-evidence-parent":
+        path = Path(row["path"])
+        if not path.is_dir():
+            return [Outcome("cannot", ident, f"missing {path}")]
+        return [Outcome("satisfied", ident, f"path={path}")]
+    return [Outcome("satisfied", ident, "no-op")]
+
+
+def summarize(outcomes: list[Outcome], arch: str, gate: str, expected_cannot: list[str]) -> str:
+    sat = [o for o in outcomes if o.status == "satisfied"]
+    built = [o for o in outcomes if o.status == "cold-built"]
+    staged = [o for o in outcomes if o.status == "staged"]
+    cannot = [o for o in outcomes if o.status == "cannot"]
+    unsatisfied = [o for o in outcomes if o.status == "unsatisfied"]
+    checkable = [o for o in outcomes if o.status in ("satisfied", "unsatisfied", "staged", "cold-built")]
+    buildable = built + [o for o in outcomes if o.id == "machorun-loader" and o.status != "cannot"]
+    stageable = staged + [o for o in outcomes if o.status == "unsatisfied" and "hash" in o.detail]
+    expected_n = len(expected_cannot)
+    logged_markers = [o.marker for o in cannot if o.marker]
+    logged_n = len(logged_markers)
+    return (
+        "ENV_PREPARE_SUMMARY "
+        f"satisfied={len(sat)}/{len(checkable)} "
+        f"cold-built={len(built)}/{max(len(buildable), len(built))} "
+        f"staged={len(staged)}/{max(len(staged) + len([o for o in outcomes if o.status == 'unsatisfied' and o.id == 'libswiftCore']), len(staged))} "
+        f"CANNOT={logged_n}/{expected_n} "
+        f"unsatisfied={len(unsatisfied)} "
+        f"host={arch} gate={gate or '*'} "
+        f"markers={','.join(logged_markers) if logged_markers else 'none'}"
+    )
+
+
+def prepare(
+    root: Path,
+    gate: str | None,
+    verify_only: bool,
+    fetch: bool = True,
+) -> list[Outcome]:
+    contract = load_contract(root)
+    arch = host_arch()
+    system = host_os()
+    sections = (
+        demanded_by(contract, gate)
+        if gate
+        else {
+            "checkouts": contract["checkouts"],
+            "built_products": contract["built_products"],
+            "staged_externals": contract["staged_externals"],
+            "host_requirements": contract["host_requirements"],
+            "filesystem_preconditions": contract["filesystem_preconditions"],
+        }
+    )
+    outcomes: list[Outcome] = []
+
+    for row in sections["filesystem_preconditions"]:
+        outcomes.extend(filesystem_outcome(root, row, verify_only))
+
+    for row in sections["host_requirements"]:
+        if row["id"] == "zstd" and gate == "focus-widget":
+            continue
+        if row["id"] == "poppler-pdftocairo" and gate == "focus-widget":
+            continue
+        if row["id"] == "core-guest-extra-tools" and gate == "focus-widget":
+            continue
+        outcomes.extend(host_outcome(row))
+
+    for row in sections["checkouts"]:
+        if row["kind"] == "in-repo-subtree":
+            outcomes.append(verify_inrepo_tree(root, row))
+        elif row["kind"] in ("git", "git-sparse"):
+            if row["id"] == "dotnet-macios" and gate == "focus-widget":
+                continue
+            if row["kind"] == "git-sparse":
+                dest = Path(row["destination"])
+                if dest.is_dir() and (dest / ".git").exists():
+                    outcomes.append(Outcome("satisfied", row["id"], f"path={dest} reused=1"))
+                else:
+                    outcomes.append(Outcome("cannot", row["id"], f"missing {dest}"))
+                continue
+            outcomes.append(clone_or_verify_git(root, row, verify_only or not fetch))
+
+    for row in sections["staged_externals"]:
+        outcomes.append(staged_outcome(root, row, verify_only, arch, system))
+
+    for row in sections["built_products"]:
+        outcomes.append(product_outcome(root, row, verify_only, arch, system))
+
+    return outcomes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="prepare.py")
+    parser.add_argument("--contract", default=None, help="unused; contract is env/contract.json")
+    parser.add_argument("--root", default=None)
+    parser.add_argument("--gate", default=None)
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--no-fetch", action="store_true", help="do not clone missing git checkouts")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve() if args.root else repo_root_from()
+    os.chdir(root)
+    contract = load_contract(root)
+    arch = host_arch()
+    system = host_os()
+    expected = expected_cannot_for_host(contract, arch, system)
+    outcomes = prepare(root, args.gate, args.verify_only, fetch=not args.no_fetch)
+    for outcome in outcomes:
+        print(outcome.line())
+    summary = summarize(outcomes, arch, args.gate or "*", expected)
+    print(summary)
+    unsatisfied = [o for o in outcomes if o.status == "unsatisfied"]
+    if args.strict and unsatisfied:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/env/test_contract.py
+++ b/scripts/env/test_contract.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Lock-agreement teeth for env/contract.json and the marker registry."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from env.contract import checkouts_by_id, demanded_by, load_contract, validate_against_locks
+from env.markers import (
+    CANNOT_PREFIX,
+    MARKERS,
+    classify_line,
+    count_kinds,
+    emitted_cannot_names,
+)
+
+
+class ContractLockTests(unittest.TestCase):
+    def test_contract_agrees_with_every_consumed_lock(self) -> None:
+        notes = validate_against_locks(ROOT)
+        self.assertGreaterEqual(len(notes), 10)
+        self.assertTrue(all("agree" in note or "cited" in note for note in notes))
+
+    def test_focus_widget_demanded_rows_have_denominators(self) -> None:
+        contract = load_contract(ROOT)
+        rows = demanded_by(contract, "focus-widget")
+        checkout_n = len(rows["checkouts"])
+        product_n = len(rows["built_products"])
+        staged_n = len(rows["staged_externals"])
+        host_n = len(rows["host_requirements"])
+        fs_n = len(rows["filesystem_preconditions"])
+        total = checkout_n + product_n + staged_n + host_n + fs_n
+        self.assertGreaterEqual(checkout_n, 6)
+        self.assertGreaterEqual(product_n, 4)
+        self.assertGreaterEqual(staged_n, 3)
+        self.assertGreaterEqual(fs_n, 3)
+        self.assertGreaterEqual(total, 18)
+        print(
+            f"focus-widget demanded_by checkouts={checkout_n} "
+            f"built_products={product_n} staged={staged_n} "
+            f"host={host_n} filesystem={fs_n} total={total}"
+        )
+
+    def test_corpus_ids_are_exactly_the_lock_set(self) -> None:
+        contract = load_contract(ROOT)
+        lock = json.loads(
+            (ROOT / ".cursor" / "scratch-corpus-pins.json").read_text(encoding="utf-8")
+        )
+        lock_ids = {row["id"] for row in lock["sources"]}
+        contract_ids = {
+            row["id"]
+            for row in contract["checkouts"]
+            if row.get("lock") == ".cursor/scratch-corpus-pins.json"
+        }
+        self.assertEqual(lock_ids, contract_ids)
+
+    def test_vendor_pins_are_not_silently_advanced(self) -> None:
+        checkouts = checkouts_by_id(load_contract(ROOT))
+        self.assertEqual(
+            checkouts["uikit-inrepo"]["tree"],
+            "719f6bcfe2a8e467426f30c91390d9c605f5a959",
+        )
+        self.assertEqual(
+            checkouts["machorun-inrepo"]["tree"],
+            "42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8",
+        )
+
+
+class MarkerRegistryTests(unittest.TestCase):
+    def test_emitted_cannot_markers_are_the_pr3_set(self) -> None:
+        names = emitted_cannot_names()
+        expected = (
+            "CURSOR_ENV_CANNOT_BUILD_LOADER",
+            "CURSOR_ENV_CANNOT_GENERATE_TBD",
+            "CURSOR_ENV_CANNOT_STAGE_MRROOT_LOADER",
+            "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS",
+            "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS",
+            "CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT",
+            "CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST",
+            "CURSOR_ENV_CANNOT_EXECUTE_ARM64",
+        )
+        self.assertEqual(names, expected)
+        self.assertTrue(all(name.startswith(CANNOT_PREFIX) for name in names))
+        self.assertFalse(MARKERS["NEEDS_DARWIN_BASELINE"].currently_emitted)
+
+    def test_count_kinds_separates_cannot_from_refuse(self) -> None:
+        lines = [
+            "CURSOR_ENV_CANNOT_EXECUTE_ARM64 host=x86_64 machorun=arm64-linux-native",
+            "CURSOR_CORPUS_OK id=swift-collections reused=1",
+            "ENV_PREPARE_SUMMARY satisfied=1/1 cold-built=0/0 staged=0/0 CANNOT=0/0",
+            "focus_widget_guest: missing /w/scratch/swift-collections",
+            "some other log line",
+        ]
+        counts = count_kinds(lines)
+        self.assertEqual(
+            counts,
+            {"cannot": 1, "pass": 1, "summary": 1, "refuse": 1, "other": 1},
+        )
+        self.assertEqual(classify_line(lines[0]), "cannot")
+        self.assertEqual(classify_line(lines[3]), "refuse")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/env/test_contract.py
+++ b/scripts/env/test_contract.py
@@ -71,6 +71,13 @@ class ContractLockTests(unittest.TestCase):
             "42d42ace9c6ff7a4ae7c25c3a8e466f82d5f70c8",
         )
 
+    def test_focus_widget_gate_still_locks_all_attestation_pins(self) -> None:
+        notes = validate_against_locks(ROOT)
+        pin_notes = [n for n in notes if n.startswith("focus_widget_attestation_pins ")]
+        self.assertEqual(len(pin_notes), 1)
+        self.assertIn("24/24", pin_notes[0])
+        print(pin_notes[0])
+
 
 class MarkerRegistryTests(unittest.TestCase):
     def test_emitted_cannot_markers_are_the_pr3_set(self) -> None:

--- a/scripts/env/test_ledger.py
+++ b/scripts/env/test_ledger.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Byte-identical refusal text for the extracted hash ledger."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "env"))
+
+from ledger import LedgerError, require_hash, sha256_file  # noqa: E402
+
+
+LEDGER = ROOT / "scripts" / "env" / "ledger.py"
+
+
+class LedgerHashTests(unittest.TestCase):
+    def test_sha256_matches_hashlib_and_sha256sum(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blob"
+            path.write_bytes(b"openuikit-ledger\n")
+            digest = sha256_file(path)
+            self.assertEqual(digest, hashlib.sha256(b"openuikit-ledger\n").hexdigest())
+            proc = subprocess.run(
+                ["python3", str(LEDGER), "hash-file", str(path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.stdout.strip(), digest)
+
+    def test_core_require_hash_refusal_text_is_byte_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blob"
+            path.write_bytes(b"x")
+            actual = sha256_file(path)
+            expected = "0" * 64
+            proc = subprocess.run(
+                [
+                    "python3",
+                    str(LEDGER),
+                    "--style",
+                    "core",
+                    "require-hash",
+                    str(path),
+                    expected,
+                    "machorun-Swift-core",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(
+                proc.stderr,
+                f"core_guest_package: REFUSING -- machorun-Swift-core hash {actual}, expected {expected}\n",
+            )
+
+    def test_core_missing_file_refusal_text(self) -> None:
+        missing = Path("/tmp/openuikit-ledger-absent-file")
+        if missing.exists():
+            missing.unlink()
+        proc = subprocess.run(
+            [
+                "python3",
+                str(LEDGER),
+                "--style",
+                "core",
+                "require-hash",
+                str(missing),
+                "0" * 64,
+                "label",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 2)
+        self.assertEqual(
+            proc.stderr,
+            f"core_guest_package: REFUSING -- missing regular label: {missing}\n",
+        )
+
+    def test_focus_widget_drift_refusal_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Assets.swift"
+            path.write_bytes(b"not-the-pin")
+            actual = sha256_file(path)
+            proc = subprocess.run(
+                [
+                    "python3",
+                    str(LEDGER),
+                    "--style",
+                    "focus-widget",
+                    "require-hash",
+                    str(path),
+                    "e" * 64,
+                    "Assets.swift",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 2)
+            self.assertEqual(
+                proc.stderr,
+                f"focus_widget_guest: Assets.swift drifted: {actual}\n",
+            )
+
+    def test_require_hash_success_is_silent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ok"
+            path.write_bytes(b"ok")
+            digest = sha256_file(path)
+            require_hash(path, digest, "ok", "core")
+            proc = subprocess.run(
+                ["python3", str(LEDGER), "require-hash", str(path), digest, "ok"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.stdout, "")
+            self.assertEqual(proc.stderr, "")
+
+    def test_symlink_is_missing_regular(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            real = Path(tmp) / "real"
+            link = Path(tmp) / "link"
+            real.write_bytes(b"x")
+            link.symlink_to(real)
+            with self.assertRaises(LedgerError) as raised:
+                require_hash(link, sha256_file(real), "label", "core")
+            self.assertIn("missing regular label:", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/env/test_ledger.py
+++ b/scripts/env/test_ledger.py
@@ -143,6 +143,84 @@ class LedgerHashTests(unittest.TestCase):
         )
         self.assertIn("assert_clean_commit \"$SWIFT_FOUNDATION\"", text)
 
+    def test_focus_widget_gate_delegates_hash_ledger_and_preparer(self) -> None:
+        text = (ROOT / "full/swiftui/build_focus_widget_guest.sh").read_text()
+        self.assertIn('PREPARE_TOOL=$W/scripts/env/prepare.py', text)
+        self.assertIn('LEDGER_TOOL=$W/scripts/env/ledger.py', text)
+        self.assertIn('python3 "$LEDGER_TOOL" --style focus-widget hash-file "$1"', text)
+        self.assertIn(
+            'python3 "$LEDGER_TOOL" --style focus-widget require-hash "$1" "$2" "$3"',
+            text,
+        )
+        self.assertNotIn('hash_file() { sha256sum', text)
+        self.assertIn(
+            'python3 "$PREPARE_TOOL" --contract "$W/env/contract.json" --root "$W"',
+            text,
+        )
+        self.assertLess(
+            text.index('--gate focus-widget'),
+            text.index('assert_vendor_tree "$W" uikit'),
+        )
+        self.assertNotRegex(
+            text,
+            r'python3 "\$PREPARE_TOOL"[^\n]*--strict',
+        )
+        self.assertIn(
+            'require_hash "$FOCUS_WIDGET/Assets.swift" "$EXPECTED_ASSETS_SHA"',
+            text,
+        )
+
+    def test_focus_widget_inrepo_pins_are_byte_identical_across_hashers(self) -> None:
+        gate = (ROOT / "full/swiftui/build_focus_widget_guest.sh").read_text()
+        pairs = [
+            (
+                ROOT / "full/oracle-opencombine/Combine.swift",
+                "EXPECTED_COMBINE_SHIM_SHA",
+            ),
+            (
+                ROOT
+                / "full/oracle-opencombine/patches/COpenCombineHelpers-pthread-recursive.patch",
+                "EXPECTED_OPENCOMBINE_PATCH_SHA",
+            ),
+            (
+                Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"),
+                "EXPECTED_SYSTEM_FONT_SHA",
+            ),
+            (
+                Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"),
+                "EXPECTED_MEDIUM_FONT_SHA",
+            ),
+        ]
+        compared = 0
+        for path, key in pairs:
+            if not path.is_file() or path.is_symlink():
+                continue
+            match = None
+            for line in gate.splitlines():
+                if line.startswith(f"{key}="):
+                    match = line.split("=", 1)[1]
+                    break
+            self.assertIsNotNone(match, key)
+            sha256sum = subprocess.check_output(
+                ["sha256sum", str(path)], text=True
+            ).split()[0]
+            ledger = subprocess.check_output(
+                [
+                    "python3",
+                    str(LEDGER),
+                    "--style",
+                    "focus-widget",
+                    "hash-file",
+                    str(path),
+                ],
+                text=True,
+            ).strip()
+            self.assertEqual(sha256sum, ledger, path)
+            self.assertEqual(ledger, match, f"{key} {path}")
+            compared += 1
+        self.assertGreaterEqual(compared, 2)
+        print(f"focus_widget_hasher_agreement compared={compared}/{len(pairs)}")
+
     def test_symlink_is_missing_regular(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             real = Path(tmp) / "real"

--- a/scripts/env/test_ledger.py
+++ b/scripts/env/test_ledger.py
@@ -124,6 +124,25 @@ class LedgerHashTests(unittest.TestCase):
             self.assertEqual(proc.stdout, "")
             self.assertEqual(proc.stderr, "")
 
+    def test_core_guest_package_delegates_hash_ledger(self) -> None:
+        text = (ROOT / "full/frameworks/build_core_guest_package.sh").read_text()
+        self.assertIn('LEDGER_TOOL=$W/scripts/env/ledger.py', text)
+        self.assertIn('python3 "$LEDGER_TOOL" --style core hash-file "$1"', text)
+        self.assertIn(
+            'python3 "$LEDGER_TOOL" --style core require-hash "$1" "$2" "$3"',
+            text,
+        )
+        self.assertIn(
+            'python3 "$LEDGER_TOOL" --style core assert-clean-commit "$1" "$2" "$3" "$4"',
+            text,
+        )
+        self.assertNotIn('hash_file() { sha256sum', text)
+        self.assertIn(
+            'require_hash "$SWIFT_CORE_RUNTIME" "$EXPECTED_MACHORUN_SWIFT_CORE_SHA256"',
+            text,
+        )
+        self.assertIn("assert_clean_commit \"$SWIFT_FOUNDATION\"", text)
+
     def test_symlink_is_missing_regular(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             real = Path(tmp) / "real"

--- a/scripts/env/test_prepare.py
+++ b/scripts/env/test_prepare.py
@@ -99,6 +99,27 @@ class PrepareTests(unittest.TestCase):
         summary = [ln for ln in proc.stdout.splitlines() if ln.startswith("ENV_PREPARE_SUMMARY ")][0]
         print(summary)
 
+    def test_gate_argv_shape_is_accepted(self) -> None:
+        proc = subprocess.run(
+            [
+                "python3",
+                str(PREPARE),
+                "--contract",
+                str(ROOT / "env" / "contract.json"),
+                "--root",
+                str(ROOT),
+                "--gate",
+                "focus-widget",
+                "--verify-only",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        self.assertIn("ENV_PREPARE_SUMMARY", proc.stdout)
+        self.assertIn("gate=focus-widget", proc.stdout)
+
     def test_summarize_counts_match_outcomes(self) -> None:
         contract = load_contract(ROOT)
         outcomes = prepare(ROOT, "focus-widget", verify_only=True, fetch=False)

--- a/scripts/env/test_prepare.py
+++ b/scripts/env/test_prepare.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""prepare.py prints denominators and is idempotent on verify."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+import unittest
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "env"))
+
+from ledger import sha256_file  # noqa: E402
+from prepare import prepare, summarize, host_arch, expected_cannot_for_host  # noqa: E402
+from contract import load_contract  # noqa: E402
+
+PREPARE = ROOT / "scripts" / "env" / "prepare.py"
+SUMMARY = re.compile(
+    r"^ENV_PREPARE_SUMMARY satisfied=(\d+)/(\d+) cold-built=(\d+)/(\d+) "
+    r"staged=(\d+)/(\d+) CANNOT=(\d+)/(\d+) unsatisfied=(\d+) host=\S+ gate=\S+"
+)
+
+
+class PrepareTests(unittest.TestCase):
+    def test_verify_only_focus_widget_prints_denominators(self) -> None:
+        proc = subprocess.run(
+            [
+                "python3",
+                str(PREPARE),
+                "--gate",
+                "focus-widget",
+                "--verify-only",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        summary = [line for line in proc.stdout.splitlines() if line.startswith("ENV_PREPARE_SUMMARY ")]
+        self.assertEqual(len(summary), 1, proc.stdout)
+        match = SUMMARY.match(summary[0])
+        self.assertIsNotNone(match, summary[0])
+        sat, sat_d, built, built_d, staged, staged_d, cannot, cannot_d, unsatisfied = (
+            int(g) for g in match.groups()
+        )
+        self.assertGreater(sat_d, 0)
+        self.assertGreaterEqual(sat, 0)
+        self.assertLessEqual(sat, sat_d)
+        self.assertGreaterEqual(cannot_d, 2)  # x86_64 expected CANNOT set is large
+        print(summary[0])
+        self.assertIn("gate=focus-widget", summary[0])
+
+    def test_rerun_is_idempotent_status_set(self) -> None:
+        first = subprocess.run(
+            ["python3", str(PREPARE), "--gate", "focus-widget", "--verify-only"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        second = subprocess.run(
+            ["python3", str(PREPARE), "--gate", "focus-widget", "--verify-only"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        first_summary = [ln for ln in first.stdout.splitlines() if ln.startswith("ENV_PREPARE_SUMMARY ")][0]
+        second_summary = [ln for ln in second.stdout.splitlines() if ln.startswith("ENV_PREPARE_SUMMARY ")][0]
+        self.assertEqual(first_summary, second_summary)
+
+    def test_libswiftCore_artifact_hash_is_the_contract_pin(self) -> None:
+        artifact = ROOT / "swiftcore-macho/artifacts/swift-macosx/arm64/libswiftCore.dylib"
+        self.assertTrue(artifact.is_file())
+        self.assertEqual(
+            sha256_file(artifact),
+            "dd01686e06c81a21755bb864b43dad446c011e6c60c6b387b3b332c0a12708cb",
+        )
+
+    def test_materialize_stages_libswiftCore_and_fixes_mktemp_root(self) -> None:
+        proc = subprocess.run(
+            ["python3", str(PREPARE), "--gate", "focus-widget", "--no-fetch"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        self.assertTrue((ROOT / "build" / "full").is_dir())
+        dest = ROOT / "machorun/darwin/usr/lib/swift/libswiftCore.dylib"
+        self.assertTrue(dest.is_file(), proc.stdout)
+        self.assertEqual(
+            sha256_file(dest),
+            "dd01686e06c81a21755bb864b43dad446c011e6c60c6b387b3b332c0a12708cb",
+        )
+        self.assertRegex(proc.stdout, r"ENV_PREPARE_(STAGED|SATISFIED) id=libswiftCore")
+        self.assertIn("CURSOR_ENV_CANNOT_BUILD_LOADER", proc.stdout)
+        summary = [ln for ln in proc.stdout.splitlines() if ln.startswith("ENV_PREPARE_SUMMARY ")][0]
+        print(summary)
+
+    def test_summarize_counts_match_outcomes(self) -> None:
+        contract = load_contract(ROOT)
+        outcomes = prepare(ROOT, "focus-widget", verify_only=True, fetch=False)
+        line = summarize(
+            outcomes,
+            host_arch(),
+            "focus-widget",
+            expected_cannot_for_host(contract, host_arch(), "Linux"),
+        )
+        self.assertTrue(SUMMARY.match(line), line)
+        cannot_rows = [o for o in outcomes if o.status == "cannot"]
+        self.assertTrue(any(o.marker == "CURSOR_ENV_CANNOT_BUILD_LOADER" for o in cannot_rows) or host_arch() in ("aarch64", "arm64"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The verify environment was implicit and distributed across `full/foundation/stage_fe_sysroot.sh`, `machorun/scripts/build.sh`, the three Focus gates, `full/frameworks/build_core_guest_package.sh`, `full/scripts/*`, and `.cursor/` (PR #3). Bringing up `full/swiftui/build_focus_widget_guest.sh` on the ARM64 EC2 authority took **fourteen sequential refusals** to reach a real code bug. Every refusal was correct; none was discoverable without running.

This PR does **not** rewrite those gates. It single-sources the environment knowledge and materializes a verify tree from it. Gate refusals, hashes, and marker spellings stay the behavior oracle.

## Commits

1. **Inventory** (`env/INVENTORY.md`) — every place environment knowledge currently lives, with `file:line` and denominators. Maps the 14 EC2 refusals onto sources.
2. **`env/contract.json` + `scripts/env/markers.py`** — required checkouts, built products, staged externals, host requirements, filesystem preconditions; every row cites the demanding gate. Marker registry is the single vocabulary for `CURSOR_ENV_CANNOT_*` (8/8 emitted) plus reserved `NEEDS_DARWIN_BASELINE` (registered, not emitted).
3. **`scripts/env/prepare.py`** — one preparer for Cursor x86, aarch64 EC2, and macOS oracle. Clones through PR #3's `.cursor/clone-pinned-repo.sh` (not a rewrite). Stages `libswiftCore` from the in-repo `swiftcore-macho` artifact (`dd01686e…`). Fixes `safe.directory`, 0700 proof parent, and `build/full` mktemp root explicitly. Ends with `ENV_PREPARE_SUMMARY satisfied=/cold-built=/staged=/CANNOT=`. Idempotent: rerun = verify. Default (gate invocation) is **not** `--strict`: leftover rows still fail with the gate's original wording.
4. **Ledger extraction** — `hash_file` / `require_hash` / `assert_clean_commit` in `build_core_guest_package.sh` call `scripts/env/ledger.py --style core`. Compile/link/run stay in shell. Call sites and `EXPECTED_*` pins unchanged. Mismatch/missing-file refusals are byte-identical to the previous `die()` strings.
5. **Focus widget switch** — `build_focus_widget_guest.sh` runs `prepare.py --gate focus-widget` before vendor attestation, and delegates `hash_file`/`require_hash` to `ledger.py --style focus-widget`. All **24/24** attestation pin constants are unchanged. Hasher agreement vs `sha256sum` is **4/4** on the in-repo Combine shim, OpenCombine patch, and DejaVu fonts.

## Behavior that must not change

- Vendor pin drift is **reported, not advanced**. Live `HEAD:uikit` / `HEAD:machorun` disagree with `scripts/vendor_pins.sh`; the preparer marks those rows unsatisfied. Comment in `vendor_pins.sh` forbids pinning over a failing proof.
- `NEEDS_DARWIN_BASELINE` is not newly emitted.
- Empty `.tbd` files and empty `modcache_swiftui_guest` remain forbidden.
- PR #3 `.cursor/*` scripts are called, not duplicated.
- `machorun/src`, `machorun/darwin/src`, app/vendor sources, and any x86_64 port surface are untouched.

The only `artifacts.sha256` field that includes `build_focus_widget_guest.sh`'s own bytes is `SwiftUI-build-support-subject`. Product hashes, pin constants, and refusal text are the regression oracle.

## Measured on this x86 VM

```
ENV_CONTRACT_LOCKS_OK agreements=13/13
focus-widget demanded_by checkouts=6 built_products=7 staged=5 host=3 filesystem=4 total=25
focus_widget_attestation_pins 24/24 agree with full/swiftui/build_focus_widget_guest.sh
focus_widget_hasher_agreement compared=4/4
ENV_PREPARE_SUMMARY satisfied=23/31 cold-built=0/0 staged=0/0 CANNOT=7/8 unsatisfied=8 host=x86_64 gate=focus-widget
```

`CANNOT=7/8`: `CURSOR_ENV_CANNOT_EXECUTE_ARM64` is the gate **run** step (`.cursor/refuse-arm64-execution.sh`), not something prepare emits. The 8 unsatisfied rows include missing corpus checkouts, stale in-repo vendor trees, and missing `mrroot` — honest, not papered over.

Full Focus widget `artifacts.sha256` cannot be produced on this x86 host (ARM64 guest). Static Focus widget tests: 20/20 (the pre-existing `test_build_compiles_pinned_focus_paths_directly` still expects the stale `8ce87c1a…` tree vs current `vendor_pins.sh`; that test was already stale on main and is not “fixed” here).

## Out of scope for this PR

Onboarding/package/core-docker gate switches. Remaining hash sections in `build_core_guest_package.sh` (`assert_exact_swift_set`, baked `EXPECTED_*` block). Cold-build of machorun/darwin on aarch64.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f696371-4999-4ae0-ba10-4a4440130e3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f696371-4999-4ae0-ba10-4a4440130e3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

