### PR TITLE
Add machorun x86_64 PHASE 2 operator runner

### DIFF
--- a/full/foundation/stage_fe_sysroot.sh
+++ b/full/foundation/stage_fe_sysroot.sh
@@ -2,6 +2,9 @@
 # stage_fe_sysroot.sh -- MACOS ONLY.  Build scratch/sysroot_fe4, the sysroot the
 # FoundationEssentials port compiles against, with canImport(Darwin) TRUE.
 #
+# Linux x86_64 sibling (does not read Xcode; writes scratch/sysroot_fe4-x86_64
+# beside this tree, never overwrites it): scripts/x86/stage_fe_sysroot.sh.
+#
 # RESTAGE, NEVER REUSE.  scratch/sysroot was staged 2026-08-27 12:22:24 and
 # machorun's sdk/ was last touched at 12:26:30 -- four minutes of skew that
 # every git-level check reports as "current", because the staleness lives in a

--- a/full/frameworks/build_core_guest_package.sh
+++ b/full/frameworks/build_core_guest_package.sh
@@ -16,7 +16,7 @@ W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
 . "$(cd "$(dirname "$0")" && pwd)/../scripts/guest_arch.inc"
 MACHORUN=${MACHORUN:-$W/machorun}
 MIN_OS=15.0
-SYS=$W/scratch/sysroot_fe4
+SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
 FULL=$W/build/full${FULL_OUT_SUFFIX}
 WORK=$W/build/core-guest-work${FULL_OUT_SUFFIX}
 MRROOT=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
@@ -27,7 +27,7 @@ SWIFT_FOUNDATION_ICU=$W/scratch/swift-foundation-icu
 SWIFT_COLLECTIONS=$W/scratch/swift-collections
 OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-20260828-r2}
 OPENCOMBINE_SOURCE=$OPENCOMBINE_ROOT/source
-OPENCOMBINE_ARTIFACTS=$OPENCOMBINE_ROOT/export/artifacts
+OPENCOMBINE_ARTIFACTS=${OPENCOMBINE_ARTIFACTS:-$OPENCOMBINE_ROOT/export${FULL_OUT_SUFFIX}/artifacts}
 OPENCOMBINE_HELPERS=$OPENCOMBINE_SOURCE/Sources/COpenCombineHelpers
 MANIFEST_TOOL=$W/full/frameworks/core_package_manifest.py
 FOUNDATION_SOURCES_MANIFEST=$W/full/foundation/foundation_guest_sources.txt
@@ -1495,9 +1495,16 @@ python3 "$MANIFEST_TOOL" dangling-symlinks \
     --output "$WORK/sdk-dangling.pre.tsv"
 
 require_hash "$OPENCOMBINE_ROOT/export/RESULT.txt" "$EXPECTED_OPENCOMBINE_RESULT" OpenCombine-result
-require_hash "$OPENCOMBINE_ARTIFACTS/OpenCombine.o" "$EXPECTED_OPENCOMBINE_OBJECT" OpenCombine-object
-require_hash "$OPENCOMBINE_ARTIFACTS/OpenCombine.swiftmodule" "$EXPECTED_OPENCOMBINE_MODULE" OpenCombine-module
-require_hash "$OPENCOMBINE_ARTIFACTS/OpenCombine.swiftdoc" "$EXPECTED_OPENCOMBINE_DOC" OpenCombine-doc
+if [ "$ARCH" = arm64 ]; then
+    require_hash "$OPENCOMBINE_ARTIFACTS/OpenCombine.o" "$EXPECTED_OPENCOMBINE_OBJECT" OpenCombine-object
+    require_hash "$OPENCOMBINE_ARTIFACTS/OpenCombine.swiftmodule" "$EXPECTED_OPENCOMBINE_MODULE" OpenCombine-module
+    require_hash "$OPENCOMBINE_ARTIFACTS/OpenCombine.swiftdoc" "$EXPECTED_OPENCOMBINE_DOC" OpenCombine-doc
+else
+    if ! llvm-otool-18 -hv "$OPENCOMBINE_ARTIFACTS/OpenCombine.o" 2>/dev/null \
+        | grep -Eq "MH_MAGIC_64[[:space:]]+${OTOOL_CPU}"; then
+        die "NEEDS_X86_OPENCOMBINE: OpenCombine.o is not $ARCH (arm64 durable SHA $EXPECTED_OPENCOMBINE_OBJECT still stands; rebuild for $TARGET beside that tree)"
+    fi
+fi
 require_hash "$OPENCOMBINE_HELPERS/COpenCombineHelpers.cpp" "$EXPECTED_OPENCOMBINE_HELPER" OpenCombine-helper
 require_hash "$OPENCOMBINE_HELPERS/include/COpenCombineHelpers.h" "$EXPECTED_OPENCOMBINE_HEADER" OpenCombine-header
 require_hash "$OPENCOMBINE_HELPERS/include/module.modulemap" "$EXPECTED_OPENCOMBINE_MODULEMAP" OpenCombine-modulemap

--- a/full/frameworks/run_core_guest_package_docker.sh
+++ b/full/frameworks/run_core_guest_package_docker.sh
@@ -8,6 +8,8 @@ export GIT_OPTIONAL_LOCKS=0
 export PYTHONDONTWRITEBYTECODE=1
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../scripts/guest_arch.inc"
 PHYSICAL_REPLAY_TOOL=$SCRIPT_DIR/physical_replay.py
 
 SUPPORT_CHECKOUT=''
@@ -162,10 +164,11 @@ case "$EXPECTED_MACHORUN_OBJC_SHA256" in
     *[!0-9a-f]*) die 'machorun Objective-C runtime SHA-256 must be lowercase 64-hex' ;;
 esac
 
-if [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
+if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
     # Isolation (single bind, no network, read-only root) remains required on
-    # aarch64. On x86_64 nothing can execute the guest; emit the canonical
-    # marker rather than a docker-missing skip.
+    # aarch64. Arm64 guests cannot execute on this x86_64 host; x86_64 guests
+    # under the ported loader are the phase-2 path and must not be refused here
+    # (argument validation still runs).
     bash "$SCRIPT_DIR/../../.cursor/refuse-arm64-execution.sh" || exit $?
 fi
 for tool in docker git mktemp python3 tee awk shasum; do

--- a/full/frameworks/test_core_guest_package.py
+++ b/full/frameworks/test_core_guest_package.py
@@ -3443,6 +3443,7 @@ class ShellContractTests(unittest.TestCase):
                         mutated_builder, mutated_wrapper
                     )
         self.assertIn('BUILD_FE_CACHE=$W/scratch/modcache_fe4${FULL_OUT_SUFFIX}', BUILDER.read_text(encoding="utf-8"))
+        self.assertIn('SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}', BUILDER.read_text(encoding="utf-8"))
         self.assertIn('"$BUILD_FE_CACHE"', BUILDER.read_text(encoding="utf-8"))
         self.assertIn("sdk_dangling_symlink_exclusions.tsv", BUILDER.read_text(encoding="utf-8"))
         self.assertIn("sdk-dangling-symlinks.tsv", BUILDER.read_text(encoding="utf-8"))

--- a/full/scripts/build_full.sh
+++ b/full/scripts/build_full.sh
@@ -39,7 +39,7 @@ UIKIT=${UIKIT:-$W/uikit}
 MINOS=${MINOS:-15.0}
 LINK_PLATFORM=${LINK_PLATFORM:-macos}
 LINK_SDK_VERSION=${LINK_SDK_VERSION:-$MINOS}
-SYS=${SYS:-$W/scratch/sysroot_fe4}     # Darwin + FE compile sysroot
+SYS=${SYS:-$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}}     # Darwin + FE compile sysroot; x86_64 writes beside
 APPLE_SWIFT_USER_OVERLAYS=${APPLE_SWIFT_USER_OVERLAYS:-}
 OUT=${OUT:-$W/build/full${FULL_OUT_SUFFIX}}
 ROOTDIR=${ROOTDIR:-$W/scratch/mrroot_full${FULL_OUT_SUFFIX}}
@@ -68,7 +68,7 @@ BUILD_FULL_DEVELOPER_TOOLS_SUPPORT_DISABLED_OWNER=${BUILD_FULL_DEVELOPER_TOOLS_S
 # enough because ignored .build* directories can contain Swift files that an
 # unrestricted recursive walk would consume.
 [ -d "$SYS/usr/include" ] || {
-    echo "build_full: no FE sysroot at $SYS; run full/foundation/stage_fe_sysroot.sh" >&2
+    echo "build_full: no FE sysroot at $SYS; run full/foundation/stage_fe_sysroot.sh (Darwin) or scripts/x86/stage_fe_sysroot.sh (Linux x86_64 sibling)" >&2
     exit 2
 }
 [ -f "$PINNED_INPUTS_TOOL" ] || {
@@ -309,6 +309,8 @@ python3 -B "$SWIFT_CORE_RUNTIME_STAGER" \
     --destination "$swift_core_target" \
     --expected-sha256 "$SWIFT_CORE_RUNTIME_EXPECTED_SHA256" \
     --report "$OUT/swift-core-runtime-stage.json"
+require_macho_cpu "$swift_core_target" "staged libswiftCore.dylib" \
+    || die "refusing to keep a libswiftCore.dylib whose Mach-O CPU is not $OTOOL_CPU (would mix $ARCH guests with a foreign slice)"
 SWIFTCOMPAT=$ROOTDIR/darwin/usr/lib/libswiftcompat.dylib
 
 # FoundationEssentials pulls this nine-dylib Swift overlay closure. The source
@@ -339,6 +341,8 @@ for name in "${FE_OVERLAYS[@]}"; do
         cp "$source" "$target"
         echo "   staged $name"
     fi
+    require_macho_cpu "$target" "FE overlay $name" \
+        || die "FE overlay $name is not $OTOOL_CPU Mach-O (arm64 simruntime dylibs cannot be copied into an x86 mrroot)"
 done
 
 # The Darwin dispatch bridge deliberately crosses into a small, versioned

--- a/full/scripts/guest_arch.inc
+++ b/full/scripts/guest_arch.inc
@@ -30,3 +30,15 @@ case "$ARCH" in
     x86_64) OTOOL_CPU=X86_64 ;;
     arm64)  OTOOL_CPU=ARM64 ;;
 esac
+# Compile sysroot lives beside the arm64 tree on x86 (scratch/sysroot_fe4-x86_64).
+# Arm64 keeps the historical unsuffixed path. Never overwrite one with the other.
+SYSROOT_SUFFIX=$FULL_OUT_SUFFIX
+# Durable OpenCombine export/ is arm64. x86 cold-builds land in export-x86_64/.
+OPENCOMBINE_EXPORT_SUFFIX=$FULL_OUT_SUFFIX
+
+require_macho_cpu() {
+    local f=$1 label=${2:-$1}
+    llvm-otool-18 -hv "$f" 2>/dev/null \
+        | grep -Eq "MH_MAGIC_64[[:space:]]+${OTOOL_CPU}" \
+        || { echo "guest_arch: $label is not ${OTOOL_CPU} Mach-O: $f" >&2; return 1; }
+}

--- a/full/scripts/guest_arch.py
+++ b/full/scripts/guest_arch.py
@@ -39,3 +39,8 @@ def swift_module_triple(arch: str | None = None) -> str:
 
 def otool_cpu(arch: str | None = None) -> str:
     return "X86_64" if (arch or guest_arch()) == "x86_64" else "ARM64"
+
+
+def out_suffix(arch: str | None = None) -> str:
+    """Arm64 keeps historical paths; x86_64 writes beside them."""
+    return "-x86_64" if (arch or guest_arch()) == "x86_64" else ""

--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -24,11 +24,11 @@ PACKAGE=$OUT/package
 MODULE_CACHE=$OUT/module-cache
 AUDIT=$OUT/audit
 FULL=$W/build/full${FULL_OUT_SUFFIX}
-SYS=$W/scratch/sysroot_fe4
+SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
 MRROOT=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
 SWIFT_FOUNDATION=$W/scratch/swift-foundation
 OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-20260828-r2}
-OPENCOMBINE_ARTIFACTS=$OPENCOMBINE_ROOT/export/artifacts
+OPENCOMBINE_ARTIFACTS=${OPENCOMBINE_ARTIFACTS:-$OPENCOMBINE_ROOT/export${FULL_OUT_SUFFIX}/artifacts}
 OPENCOMBINE_SOURCE=$OPENCOMBINE_ROOT/source
 OPENCOMBINE_HELPERS=$OPENCOMBINE_SOURCE/Sources/COpenCombineHelpers
 FOUNDATION_GUEST_MANIFEST=$W/full/foundation/foundation_guest_sources.txt
@@ -556,8 +556,8 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     > "$AUDIT/runtime-closure.manifest"
 
 echo '== run exact Focus interaction path on Linux/machorun'
-if [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
-    echo "focus_onboarding_guest: compile/link may proceed on this VM; execution cannot" >&2
+if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
+    echo "focus_onboarding_guest: compile/link may proceed on this VM; execution of arm64 guests cannot" >&2
     bash "${W:-$(git rev-parse --show-toplevel)}/.cursor/refuse-arm64-execution.sh" \
         || exit $?
 fi

--- a/full/swiftui/build_focus_package_guest.sh
+++ b/full/swiftui/build_focus_package_guest.sh
@@ -27,7 +27,7 @@ PACKAGE=$OUT/package
 MODULE_CACHE=$OUT/module-cache
 AUDIT=$OUT/audit
 FULL=$W/build/full${FULL_OUT_SUFFIX}
-SYS=$W/scratch/sysroot_fe4
+SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
 MRROOT=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
 SWIFT_FOUNDATION=$W/scratch/swift-foundation
 
@@ -377,8 +377,8 @@ grep -Fqx $'file\tpackage/FocusPackageProbe.framework/FocusPackageProbe\t'\
 "$(hash_file "$PROVIDER/FocusPackageProbe")" \
     "$AUDIT/package-runtime-closure.manifest" \
     || die "dynamic Bundle provider is absent from recursive runtime closure"
-if [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
-    echo "focus_package_guest: compile/link may proceed on this VM; execution cannot" >&2
+if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
+    echo "focus_package_guest: compile/link may proceed on this VM; execution of arm64 guests cannot" >&2
     bash "${W:-$(git rev-parse --show-toplevel)}/.cursor/refuse-arm64-execution.sh" \
         || exit $?
 fi

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -22,7 +22,7 @@ OUT=$W/build/swiftui-guest${FULL_OUT_SUFFIX}
 PACKAGE=$OUT/package
 AUDIT=$OUT/audit
 FULL=$W/build/full${FULL_OUT_SUFFIX}
-SYS=$W/scratch/sysroot_fe4
+SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
 MRROOT=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
 MC=$W/scratch/modcache_swiftui_guest${FULL_OUT_SUFFIX}
 SWIFT_FOUNDATION=$W/scratch/swift-foundation
@@ -32,7 +32,7 @@ FE_OS=$FULL/foundation/os
 FE_CSHIMS=$FULL/foundation/cshims
 SWIFTUI_SOURCE_DIR=$UIKIT/Sources/SwiftUI
 OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-20260828-r2}
-OPENCOMBINE_ARTIFACTS=$OPENCOMBINE_ROOT/export/artifacts
+OPENCOMBINE_ARTIFACTS=${OPENCOMBINE_ARTIFACTS:-$OPENCOMBINE_ROOT/export${FULL_OUT_SUFFIX}/artifacts}
 OPENCOMBINE_SOURCE=$OPENCOMBINE_ROOT/source
 OPENCOMBINE_HELPERS=$OPENCOMBINE_SOURCE/Sources/COpenCombineHelpers
 
@@ -132,7 +132,8 @@ support_digest() {
 generate_build_input_inventory() {
     perl "$ATTEST" inventory \
         --w "$W" --uikit "$UIKIT" --full "$FULL" --sysroot "$SYS" \
-        --opencombine-root "$OPENCOMBINE_ROOT"
+        --opencombine-root "$OPENCOMBINE_ROOT" \
+        --opencombine-artifacts "$OPENCOMBINE_ARTIFACTS"
 }
 
 assert_build_input_inventory() {
@@ -350,6 +351,19 @@ mkdir -p "$OUT/fonts" "$PACKAGE" "$AUDIT" "$MC" \
 cp -a "$RESOURCE_INPUT" "$OUT/Focus_Widget.bundle"
 cp "$SYSTEM_FONT" "$OUT/fonts/DejaVuSans.ttf"
 cp "$MEDIUM_FONT" "$OUT/fonts/DejaVuSans-Bold.ttf"
+# FocusWidgetGuestMain.swift opens the docker-era guest-visible path
+# /w/build/swiftui-guest/fonts regardless of FULL_OUT_SUFFIX. Stage fonts
+# there (and under $W/build/swiftui-guest/fonts for a /w -> $W symlink)
+# without touching arm64 Mach-O outputs.
+HARNESS_FONT_DIR=$W/build/swiftui-guest/fonts
+mkdir -p "$HARNESS_FONT_DIR"
+cp -f "$OUT/fonts/DejaVuSans.ttf" "$HARNESS_FONT_DIR/"
+cp -f "$OUT/fonts/DejaVuSans-Bold.ttf" "$HARNESS_FONT_DIR/"
+if [ -d /w/build ] || mkdir -p /w/build/swiftui-guest/fonts 2>/dev/null; then
+    mkdir -p /w/build/swiftui-guest/fonts
+    cp -f "$OUT/fonts/DejaVuSans.ttf" /w/build/swiftui-guest/fonts/
+    cp -f "$OUT/fonts/DejaVuSans-Bold.ttf" /w/build/swiftui-guest/fonts/
+fi
 for module in OpenUIKit OpenCoreGraphics; do
     for extension in swiftmodule swiftdoc swiftsourceinfo abi.json; do
         cp "$FULL/$module.$extension" "$PACKAGE/$module.$extension"
@@ -1104,23 +1118,23 @@ runtime_closure_edge_count=$(grep -Ec '^(edge|weak-missing)'"$(printf '\t')" "$R
 }
 runtime_before=$(runtime_fingerprint)
 
-echo "== run arm64 Mach-O under machorun on Linux"
-if [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
-    echo "focus_widget_guest: compile/link may proceed on this VM; execution cannot" >&2
+echo "== run $ARCH Mach-O under machorun on Linux"
+if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
+    echo "focus_widget_guest: compile/link may proceed on this VM; execution of arm64 guests cannot" >&2
     bash "${W:-$(git rev-parse --show-toplevel)}/.cursor/refuse-arm64-execution.sh" \
         || exit $?
 fi
 export MACHORUN_ROOT="$MRROOT"
 cd "$OUT"
 "$MRROOT/machorun" ./focus_widget_guest \
-    /w/build/swiftui-guest/Focus_Widget.bundle \
-    /w/build/swiftui-guest/focus-search-widget.png | tee guest-first.log
+    "$OUT/Focus_Widget.bundle" \
+    "$OUT/focus-search-widget.png" | tee guest-first.log
 cp "$OUT/focus-search-widget.png" "$OUT/focus-search-widget.first.png"
 assert_build_input_inventory
 assert_runtime_closure
 "$MRROOT/machorun" ./focus_widget_guest \
-    /w/build/swiftui-guest/Focus_Widget.bundle \
-    /w/build/swiftui-guest/focus-search-widget.png | tee guest-repeat.log
+    "$OUT/Focus_Widget.bundle" \
+    "$OUT/focus-search-widget.png" | tee guest-repeat.log
 cmp -s "$OUT/focus-search-widget.first.png" "$OUT/focus-search-widget.png" || {
     echo "focus_widget_guest: separate guest processes emitted different PNG bytes" >&2
     exit 2
@@ -1151,8 +1165,8 @@ set +e
 (
     cd "$missing_control"
     "$MRROOT/machorun" ./focus_widget_guest \
-        /w/build/swiftui-guest/Focus_Widget.bundle \
-        /w/build/swiftui-guest/missing-control-must-not-exist.png
+        "$OUT/Focus_Widget.bundle" \
+        "$OUT/missing-control-must-not-exist.png"
 ) > "$AUDIT/missing-swiftui.stdout" 2> "$AUDIT/missing-swiftui.stderr"
 missing_rc=$?
 set -e
@@ -1183,8 +1197,8 @@ set +e
 (
     cd "$missing_openuikit"
     "$MRROOT/machorun" ./focus_widget_guest \
-        /w/build/swiftui-guest/Focus_Widget.bundle \
-        /w/build/swiftui-guest/missing-openuikit-must-not-exist.png
+        "$OUT/Focus_Widget.bundle" \
+        "$OUT/missing-openuikit-must-not-exist.png"
 ) > "$AUDIT/missing-openuikit.stdout" 2> "$AUDIT/missing-openuikit.stderr"
 missing_openuikit_rc=$?
 set -e
@@ -1221,7 +1235,7 @@ run_missing_observation_control() {
     (
         cd "$control"
         "$MRROOT/machorun" ./focus_widget_guest \
-            /w/build/swiftui-guest/Focus_Widget.bundle "$artifact"
+            "$OUT/Focus_Widget.bundle" "$artifact"
     ) > "$stdout" 2> "$stderr"
     local rc=$?
     set -e

--- a/full/swiftui/focus_widget_guest_attest.pl
+++ b/full/swiftui/focus_widget_guest_attest.pl
@@ -60,7 +60,7 @@ sub inventory_tree {
 
 sub inventory_command {
     my (@args) = @_;
-    my ($w, $uikit, $full, $sysroot, $opencombine_root);
+    my ($w, $uikit, $full, $sysroot, $opencombine_root, $opencombine_artifacts);
     GetOptionsFromArray(
         \@args,
         'w=s'       => \$w,
@@ -68,6 +68,7 @@ sub inventory_command {
         'full=s'    => \$full,
         'sysroot=s' => \$sysroot,
         'opencombine-root=s' => \$opencombine_root,
+        'opencombine-artifacts=s' => \$opencombine_artifacts,
     ) or fail('invalid inventory options');
     fail('inventory takes no positional arguments') if @args;
     fail('inventory requires --w, --uikit, --full, --sysroot, and --opencombine-root')
@@ -80,12 +81,22 @@ sub inventory_command {
     fail("OpenCombine root is outside project root $w: $opencombine_root")
         unless beneath($opencombine_root, $w);
 
+    $opencombine_artifacts //= "$opencombine_root/export/artifacts";
+    fail('OpenCombine artifacts must be an absolute canonical path')
+        unless $opencombine_artifacts =~ m{^/}
+            && normalize_absolute($opencombine_artifacts) eq $opencombine_artifacts;
+    fail("OpenCombine artifacts are outside project root $w: $opencombine_artifacts")
+        unless beneath($opencombine_artifacts, $w);
+
     my @records;
+    my $oc_art_logical = ($opencombine_artifacts =~ m{/export-x86_64/artifacts$})
+        ? 'opencombine/export-x86_64/artifacts'
+        : 'opencombine/export/artifacts';
     my @opencombine_files = (
         [ "$opencombine_root/export/RESULT.txt", 'opencombine/export/RESULT.txt' ],
-        [ "$opencombine_root/export/artifacts/OpenCombine.o", 'opencombine/export/artifacts/OpenCombine.o' ],
-        [ "$opencombine_root/export/artifacts/OpenCombine.swiftmodule", 'opencombine/export/artifacts/OpenCombine.swiftmodule' ],
-        [ "$opencombine_root/export/artifacts/OpenCombine.swiftdoc", 'opencombine/export/artifacts/OpenCombine.swiftdoc' ],
+        [ "$opencombine_artifacts/OpenCombine.o", "$oc_art_logical/OpenCombine.o" ],
+        [ "$opencombine_artifacts/OpenCombine.swiftmodule", "$oc_art_logical/OpenCombine.swiftmodule" ],
+        [ "$opencombine_artifacts/OpenCombine.swiftdoc", "$oc_art_logical/OpenCombine.swiftdoc" ],
         [ "$opencombine_root/source/Sources/COpenCombineHelpers/COpenCombineHelpers.cpp", 'opencombine/source/Sources/COpenCombineHelpers/COpenCombineHelpers.cpp' ],
         [ "$opencombine_root/source/Sources/COpenCombineHelpers/include/COpenCombineHelpers.h", 'opencombine/source/Sources/COpenCombineHelpers/include/COpenCombineHelpers.h' ],
         [ "$opencombine_root/source/Sources/COpenCombineHelpers/include/module.modulemap", 'opencombine/source/Sources/COpenCombineHelpers/include/module.modulemap' ],

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -88,7 +88,7 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
     def test_foundation_hidden_and_mach_o_runtime_gates_exist(self) -> None:
         text = BUILD.read_text()
         self.assertIn("foundationessentials_import_guard.swift", text)
-        self.assertIn('SYS=$W/scratch/sysroot_fe4', text)
+        self.assertIn('SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}', text)
         self.assertIn('-target "$TARGET"', text)
         self.assertIn('"${FE_FLAGS[@]}"', text)
         self.assertIn("llvm-otool-18 -hv", text)

--- a/full/swiftui/test_focus_widget_guest_adversarial.sh
+++ b/full/swiftui/test_focus_widget_guest_adversarial.sh
@@ -6,10 +6,12 @@
 set -euo pipefail
 
 W=${W:-/w}
+# shellcheck disable=SC1091
+. "$W/full/scripts/guest_arch.inc"
 RESOURCE_INPUT=${1:?usage: test_focus_widget_guest_adversarial.sh <normalized-Focus_Widget.bundle>}
-FULL=$W/build/full
-SYS=$W/scratch/sysroot_fe4
-MRROOT=$W/scratch/mrroot_full
+FULL=$W/build/full${FULL_OUT_SUFFIX}
+SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
+MRROOT=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
 ATTEST=$W/full/swiftui/focus_widget_guest_attest.pl
 BUILD=$W/full/swiftui/build_focus_widget_guest.sh
 
@@ -120,7 +122,7 @@ expect_resume_refusal() {
         sed -n '1,160p' "$log" >&2
         exit 2
     }
-    if grep -Eq '== run arm64 Mach-O|^PASS: exact unchanged Focus|^== PASS:' "$log"; then
+    if grep -Eq '== run (arm64|x86_64) Mach-O|^PASS: exact unchanged Focus|^== PASS:' "$log"; then
         echo "focus_widget_guest_adversarial: $label reached guest success before refusal" >&2
         sed -n '1,200p' "$log" >&2
         exit 2

--- a/full/xcodeplan/build_and_run_reminder_scene_guest.sh
+++ b/full/xcodeplan/build_and_run_reminder_scene_guest.sh
@@ -20,10 +20,11 @@ die() {
 prepare() {
     [ "$#" -eq 2 ] || die "usage: $0 INVENTORY_JSON REMINDER_SOURCE_ROOT"
     command -v python3 >/dev/null || die "python3 is required on the host"
-    if [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
+    # Arm64 guests cannot execute on this x86 VM (CURSOR_ENV_CANNOT_EXECUTE_ARM64).
+    # x86_64 guests on an x86_64 host are the phase-2 path: do not refuse them.
+    if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
         bash "$W/.cursor/refuse-arm64-execution.sh" || exit $?
     fi
-    command -v docker >/dev/null || die "docker is required on the host"
 
     local inventory source_root uikit_checkout machorun_checkout turns
     inventory=$(realpath "$1")
@@ -105,6 +106,17 @@ PY
         x86_64) DOCKER_PLATFORM=linux/amd64 ;;
         *)      DOCKER_PLATFORM=linux/arm64 ;;
     esac
+    # Native x86_64 host with the pinned toolchain: skip docker. The inner
+    # half already follows $TARGET / suffixed build/full. Arm64 keeps the
+    # historical swift-macho-spike:noble wrapper.
+    if [ "$ARCH" = x86_64 ] && [ "$(uname -m)" = x86_64 ] \
+        && command -v swiftc >/dev/null && command -v ld64.lld-18 >/dev/null; then
+        UIKIT="$uikit_checkout" MACHORUN="$machorun_checkout" \
+            OPENUIKIT_HOST_TURNS="$turns" \
+            bash "$SCRIPT_DIR/build_and_run_reminder_scene_guest.sh" --inside "$source_root"
+        return
+    fi
+    command -v docker >/dev/null || die "docker is required on the host"
     docker run --rm --platform "$DOCKER_PLATFORM" \
         -e OPENUIKIT_HOST_TURNS="$turns" \
         -v "$W:/w" \
@@ -128,11 +140,12 @@ build_inside() {
     bash "$W/full/scripts/build_full.sh"
 
     local full="$W/build/full${FULL_OUT_SUFFIX}"
-    local sys="$W/scratch/sysroot_fe4"
+    local sys="$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}"
     local rootdir="$W/scratch/mrroot_full${FULL_OUT_SUFFIX}"
     local module turns expected_subject actual_subject
+    local uikit=${UIKIT:-/uikit}
     [ -s "$full/uihelpers-subject.sha256" ] || die "build_full success marker is missing"
-    expected_subject=$(bash "$W/full/scripts/uihelpers_subject.sh" "$W" /uikit)
+    expected_subject=$(bash "$W/full/scripts/uihelpers_subject.sh" "$W" "$uikit")
     actual_subject=$(tr -d '\n' <"$full/uihelpers-subject.sha256")
     [ "$expected_subject" = "$actual_subject" ] || die "build_full subject marker does not match mounted sources"
     module=$(tr -d '\n' <"$SCENE_OUT/module-name.txt")
@@ -159,7 +172,7 @@ build_inside() {
         -Xfrontend -disable-implicit-string-processing-module-import
         -Xfrontend -disable-objc-attr-requires-foundation-module)
     c_flags=(-Xcc -I"$full/inc/CPortableIO" -Xcc -I"$full/inc/CSTBTrueType"
-        -Xcc -I"$W/full/hostclock/include" -Xcc -I"/uikit/Sources/CQuartz/include")
+        -Xcc -I"$W/full/hostclock/include" -Xcc -I"$uikit/Sources/CQuartz/include")
     fe_flags=(-I "$full/foundation/essentials"
         -I "$full/foundation/collections" -I "$full/foundation/os"
         -Xcc -fmodule-map-file="$W/scratch/swift-foundation/Sources/_FoundationCShims/include/module.modulemap"
@@ -171,11 +184,11 @@ build_inside() {
     # contract as complete application bundles. Keep this older 2/22 proof
     # honest by staging its semantic data and fonts beside the standalone
     # executable; Bundle.main resolves to SCENE_OUT for a non-bundled image.
-    if find /uikit/Sources/OpenUIKit/Resources -type l -print -quit | grep -q .; then
+    if find "$uikit/Sources/OpenUIKit/Resources" -type l -print -quit | grep -q .; then
         die "OpenUIKit runtime resources contain a symlink"
     fi
     mkdir -p "$SCENE_OUT/OpenUIKit/fonts"
-    cp -R "/uikit/Sources/OpenUIKit/Resources/." "$SCENE_OUT/OpenUIKit/"
+    cp -R "$uikit/Sources/OpenUIKit/Resources/." "$SCENE_OUT/OpenUIKit/"
     install -m 0644 /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf \
         "$SCENE_OUT/OpenUIKit/fonts/DejaVuSans.ttf"
     install -m 0644 /usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf \

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -1,0 +1,87 @@
+# machorun x86_64 PHASE 2
+
+One operator command on a provisioned x86_64 Ubuntu 24.04 host (clang-18/lld-18,
+Swift 6.2.4, docker, tree already staged at
+`/opt/openuikit/x86-verify/openuikit` with
+`scratch/{ladder-corpus/focus-ios, swift-foundation, swift-collections,
+opencombine-core-durable-20260828-r2, sysroot_fe4, mrroot_full,
+modcache_swiftui_guest}` — note `sysroot_fe4` / `mrroot_full` hold **arm64**
+artifacts):
+
+```bash
+bash scripts/x86/phase2.sh /opt/openuikit/x86-verify/openuikit
+```
+
+Idempotent. Prints `ENV_PREPARE <name> satisfied|cold-built|CANNOT_<MARKER>`
+lines and a final `RUNG_SCOREBOARD` whose denominators are the committed
+runners':
+
+- a: `foundation-macho/tests/ud_guest_runner.swift` — 14 `check()` calls;
+  `run_ud_guest.sh` / `run_ud_persist.sh`
+- b: Focus widget + onboarding source-preservation + `otool $OTOOL_CPU` from
+  `full/swiftui/build_focus_{widget,onboarding}_guest.sh`
+- c: `windows=1 turns=3 paced=true` from
+  `full/xcodeplan/build_and_run_reminder_scene_guest.sh`
+
+Exit 2 if any CANNOT. Never overwrites `scratch/sysroot_fe4`,
+`scratch/mrroot_full`, or `opencombine-…/export/`. x86 outputs land **beside**
+those trees (`sysroot_fe4-x86_64`, `mrroot_full-x86_64`, `export-x86_64/`).
+
+Do not edit `machorun/` in this phase: `EXPECTED_INREPO_MACHORUN_TREE` is a
+Focus/full-build attestation pin.
+
+## Measure first: libswiftCore-for-x86
+
+This is the likeliest hard wall. The runner measures it before any later Swift
+guest work:
+
+- `swiftcore-macho/artifacts/swift-macosx/` ships only an **arm64**
+  `libswiftCore.dylib` and `Swift.swiftmodule/arm64-apple-macos.*`
+- stdlib source is not in this tree (`swiftcore-macho/swift`, `scratch/swift`,
+  `/opt/swift-source` all absent; no CMakeLists)
+- `swiftcore-macho/scripts/configure.sh` hardcodes
+  `SWIFT_HOST_VARIANT_ARCH=aarch64`, `SWIFT_SDK_OSX_ARCHITECTURES=arm64`,
+  `SWIFT_HOST_TRIPLE=aarch64-unknown-linux-gnu`
+- `swiftc -target x86_64-apple-macos15.0 -sdk scratch/sysroot_fe4` fails:
+  `could not find module '_Concurrency' for target 'x86_64-apple-macos'; found: arm64-apple-macos`
+
+Cross-building libswiftCore is the CMake+Ninja stdlib-only recipe in
+`swiftcore-macho/docs/BUILD_LOG.md`, historically on a Graviton box against a
+full swift.org 6.2.4 checkout. **Do not stage the arm64 dylib under an x86
+name.** Until an x86_64 slice exists, rungs a/b/c CANNOT with
+`CANNOT_BUILD_LIBSWIFTCORE_X86`. clang-18 can still emit x86_64 Mach-O against
+sysroot headers (loader, darwin, objc4, quartz, `.tbd`, cshims).
+
+## In-VM (this Cursor x86_64 VM) vs operator host
+
+| step | in-VM (compile/link) | operator host (execution) |
+|---|---|---|
+| measure libswiftCore-x86 | yes — reports the wall | same measurement; pass only if an x86 slice is present |
+| `build.sh` loader + darwin + tbd | yes | same |
+| `build_objc4.sh` / `build_quartz.sh` | yes — unblocks the `objc` fixture | same |
+| `scripts/x86/stage_fe_sysroot.sh` | headers + x86 dylibs; `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` unless textual Darwin overlays exist in the arm64 `sysroot_fe4` | same |
+| FoundationEssentials / collections / OpenCombine / `build_full.sh` | blocked by missing x86 Swift.swiftmodule | needs x86 libswiftCore + Darwin overlays |
+| rung a `run_ud_guest.sh` | cannot run a real FE guest without x86 libswiftCore + named MACHORUN_ROOT + `ud_guest` binary | smoke 14/14 + persist under the ported loader |
+| rung b Focus widget + onboarding | scripts retargeted; `NEEDS_X86_OPENCOMBINE` resolved by `export-x86_64/` (arm64 SHA untouched) | same gates under the ported loader |
+| rung c Reminder scene | inner script no longer refuses x86-on-x86; still needs Reminder 22-source inventory | one `UIWindow` + three paced turns |
+
+Static tests: `bash scripts/x86/test_phase2.sh`.
+
+## Closing the PR #7 walls (without rewriting arm64 pins)
+
+1. Linux sysroot sibling: `scripts/x86/stage_fe_sysroot.sh` writes
+   `scratch/sysroot_fe4-x86_64` only. Copies textual Darwin overlays from the
+   arm64 sysroot when present; refuses arm64 dylibs.
+2. OpenCombine: `scripts/x86/build_opencombine.sh` writes `export-x86_64/`.
+   Source hashes from `policy.json` still apply. Object SHAs stay the arm64
+   durable pin in `export/`. Focus/core-package scripts hash those objects
+   only when `ARCH=arm64`; on x86 they require `MH_MAGIC_64 X86_64` instead of
+   rewriting the SHA (`NEEDS_X86_OPENCOMBINE` until the x86 `.o` exists).
+3. Focus pin `a2832521c1daa0c23419c73705ae043ed60c9791` is checked, not
+   rewritten. Normalized bundles come from the committed
+   `onboarding_resources_proof.py` or `FOCUS_WIDGET_BUNDLE`.
+4. `build_full.sh` / mrroot refuse to copy an arm64 `libswiftCore.dylib` into
+   an x86-named root (`require_macho_cpu`).
+5. Guest harness fonts still open `/w/build/swiftui-guest/fonts`. The widget
+   script stages fonts there and under `$W/build/swiftui-guest/fonts`; phase2
+   tries `ln -sfn $W /w` and CANNOT if it cannot.

--- a/scripts/x86/build_opencombine.sh
+++ b/scripts/x86/build_opencombine.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Compile OpenCombine for x86_64-apple-macos BESIDE the arm64 durable tree.
+# Never writes scratch/opencombine-core-durable-*/export/ (arm64 SHA pins).
+# Output: $OPENCOMBINE_ROOT/export-x86_64/{artifacts,RESULT.txt}
+#
+# Source hashes from full/oracle-opencombine/policy.json still apply.
+# Object SHAs do not: those pin the arm64 .o.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=common.inc
+. "$HERE/common.inc"
+
+W=${W:?set W to the openuikit tree}
+# shellcheck disable=SC1091
+. "$W/full/scripts/guest_arch.inc"
+[ "$ARCH" = x86_64 ] || {
+    echo "build_opencombine_x86: host/guest arch is $ARCH, not x86_64" >&2
+    exit 2
+}
+
+OPENCOMBINE_ROOT=${OPENCOMBINE_ROOT:-$W/scratch/opencombine-core-durable-20260828-r2}
+SRC=$OPENCOMBINE_ROOT/source
+OUT=$OPENCOMBINE_ROOT/export-x86_64
+SYS=${SYS:-$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}}
+POLICY=$W/full/oracle-opencombine/policy.json
+PATCH=$W/full/oracle-opencombine/patches/COpenCombineHelpers-pthread-recursive.patch
+HELPER_REL=Sources/COpenCombineHelpers/COpenCombineHelpers.cpp
+HELPER_INCLUDE=$SRC/Sources/COpenCombineHelpers/include
+
+[ -d "$SRC/Sources/OpenCombine" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=no OpenCombine source at $SRC" >&2
+    exit 2
+}
+[ -d "$SYS/usr/include" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=no x86 sysroot at $SYS" >&2
+    exit 2
+}
+[ -f "$SYS/usr/lib/swift/libswiftCore.dylib" ] && phase2_is_x86_macho "$SYS/usr/lib/swift/libswiftCore.dylib" || {
+    echo "CANNOT_X86_OPENCOMBINE reason=no x86_64 libswiftCore in $SYS (arm64 dylib is not a substitute)" >&2
+    exit 2
+}
+[ -f "$SYS/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftmodule" ] \
+    || [ -f "$SYS/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=no x86_64-apple-macos Swift.swiftmodule slice in $SYS" >&2
+    exit 2
+}
+
+sha() { sha256sum "$1" | awk '{print $1}'; }
+
+# Source pins from policy.json (not object pins).
+HELPER_SHA=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["compiler_inputs"]["files"]["Sources/COpenCombineHelpers/COpenCombineHelpers.cpp"])' "$POLICY")
+PATCH_SHA=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["assets"]["patches/COpenCombineHelpers-pthread-recursive.patch"])' "$POLICY")
+PATCHED_SHA=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["helper_patch"]["patched_sha256"])' "$POLICY")
+CORE_COUNT=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["core_sources"]["swift_file_count"])' "$POLICY")
+
+[ "$(sha "$SRC/$HELPER_REL")" = "$HELPER_SHA" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=COpenCombineHelpers.cpp drifted from policy pin" >&2
+    exit 2
+}
+[ "$(sha "$PATCH")" = "$PATCH_SHA" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=helper patch drifted from policy pin" >&2
+    exit 2
+}
+
+rm -rf "$OUT"
+mkdir -p "$OUT/artifacts" "$OUT/work"
+cp "$SRC/$HELPER_REL" "$OUT/work/COpenCombineHelpers.cpp"
+patch --batch --forward --fuzz=0 "$OUT/work/COpenCombineHelpers.cpp" "$PATCH" >/dev/null
+[ "$(sha "$OUT/work/COpenCombineHelpers.cpp")" = "$PATCHED_SHA" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=patched helper SHA drifted" >&2
+    exit 2
+}
+
+clang++-18 -target "$TARGET" -isysroot "$SYS" -stdlib=libc++ -std=c++17 -O2 \
+    -I "$HELPER_INCLUDE" \
+    -c "$OUT/work/COpenCombineHelpers.cpp" \
+    -o "$OUT/artifacts/COpenCombineHelpers.o"
+
+mapfile -d '' CORE_SOURCES < <(find "$SRC/Sources/OpenCombine" -name '*.swift' -print0 | sort -z)
+[ "${#CORE_SOURCES[@]}" -eq "$CORE_COUNT" ] || {
+    echo "CANNOT_X86_OPENCOMBINE reason=OpenCombine source count ${#CORE_SOURCES[@]} != policy $CORE_COUNT" >&2
+    exit 2
+}
+
+COMMON_SWIFT=(
+    -parse-as-library -O -wmo
+    -target "$TARGET" -sdk "$SYS"
+    -Xfrontend -disable-implicit-string-processing-module-import
+    -Xcc -fmodule-map-file="$HELPER_INCLUDE/module.modulemap"
+    -Xcc -I"$HELPER_INCLUDE"
+    -module-name OpenCombine
+    -module-cache-path "$OUT/work/modcache"
+)
+swiftc -emit-module -emit-module-path "$OUT/artifacts/OpenCombine.swiftmodule" \
+    -emit-object -o "$OUT/artifacts/OpenCombine.o" \
+    "${COMMON_SWIFT[@]}" "${CORE_SOURCES[@]}"
+
+phase2_is_x86_macho "$OUT/artifacts/OpenCombine.o" || {
+    echo "CANNOT_X86_OPENCOMBINE reason=OpenCombine.o is not X86_64 Mach-O" >&2
+    file "$OUT/artifacts/OpenCombine.o" >&2
+    exit 2
+}
+
+{
+    echo "x86_64 OpenCombine cold-build"
+    echo "target $TARGET"
+    echo "object $(sha "$OUT/artifacts/OpenCombine.o")"
+    echo "module $(sha "$OUT/artifacts/OpenCombine.swiftmodule")"
+    echo "arm64 durable object SHA still stands in export/artifacts (untouched)"
+} > "$OUT/RESULT.txt"
+
+echo "PASS: x86 OpenCombine at $OUT/artifacts (arm64 export/ untouched)"

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -1,0 +1,45 @@
+# scripts/x86/common.inc -- helpers for the PHASE 2 runner. Sourced, not executed.
+#
+# Marker grammar (one line, parseable, never a silent skip):
+#   ENV_PREPARE <name> satisfied
+#   ENV_PREPARE <name> cold-built
+#   ENV_PREPARE <name> CANNOT_<MARKER> reason=<single-line>
+# A CANNOT line is a refusal, not a skip. Callers must not treat it as success.
+
+if [ -n "${PHASE2_COMMON_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+PHASE2_COMMON_INC=1
+
+phase2_prepare() {
+    printf 'ENV_PREPARE %s %s\n' "$1" "$2"
+}
+
+phase2_cannot() {
+    # phase2_cannot <name> <MARKER> <reason>
+    printf 'ENV_PREPARE %s CANNOT_%s reason=%s\n' "$1" "$2" "$3"
+}
+
+phase2_macho_cpu() {
+    # Print ARM64 or X86_64 from llvm-otool -hv, or EMPTY.
+    # Column 2 is cputype (X86_64 / ARM64); column 3 is cpusubtype (ALL).
+    local f=$1
+    [ -f "$f" ] || { printf 'EMPTY\n'; return 0; }
+    llvm-otool-18 -hv "$f" 2>/dev/null \
+        | awk '/MH_MAGIC_64/ { print $2; found=1 } END { if (!found) print "EMPTY" }' \
+        | head -n 1
+}
+
+phase2_is_x86_macho() {
+    llvm-otool-18 -hv "$1" 2>/dev/null | grep -Eq 'MH_MAGIC_64[[:space:]]+X86_64'
+}
+
+phase2_is_arm64_macho() {
+    llvm-otool-18 -hv "$1" 2>/dev/null | grep -Eq 'MH_MAGIC_64[[:space:]]+ARM64'
+}
+
+phase2_is_elf_x86_loader() {
+    local f=$1
+    [ -x "$f" ] || return 1
+    file -b "$f" | grep -q 'ELF 64-bit LSB pie executable, x86-64'
+}

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -1,0 +1,846 @@
+#!/usr/bin/env bash
+# phase2.sh -- one operator command: take a provisioned x86_64 Linux openuikit
+# tree from PR #7's phase-1 state to the real-app ladder under the ported loader.
+#
+#   bash scripts/x86/phase2.sh /opt/openuikit/x86-verify/openuikit
+#
+# Idempotent. Prints ENV_PREPARE satisfied/cold-built/CANNOT lines and a final
+# RUNG_SCOREBOARD with the committed runners' denominators. Never fakes success,
+# never overwrites arm64 scratch/sysroot_fe4 or scratch/mrroot_full, never
+# rewrites durable arm64 OpenCombine object SHAs.
+#
+# Measure first: libswiftCore-for-x86 is the likeliest hard wall. That
+# measurement runs before any later Swift guest work so a missing stdlib is
+# reported, not discovered after a half-built FE tree.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=common.inc
+. "$HERE/common.inc"
+
+usage() {
+    echo "usage: bash scripts/x86/phase2.sh /opt/openuikit/x86-verify/openuikit" >&2
+    exit 2
+}
+
+[ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] && usage
+[ $# -eq 1 ] || usage
+
+W=$(cd "$1" && pwd)
+[ -f "$W/machorun/scripts/build.sh" ] || {
+    echo "phase2: $W is not an openuikit tree (missing machorun/scripts/build.sh)" >&2
+    exit 2
+}
+[ -f "$W/full/scripts/guest_arch.inc" ] || {
+    echo "phase2: $W is missing full/scripts/guest_arch.inc (need PR #7 phase 1)" >&2
+    exit 2
+}
+
+export W
+export CC="${CC:-clang-18}"
+export DARWIN_CLANG="${DARWIN_CLANG:-clang-18}"
+export PATH="/usr/lib/llvm-18/bin:${PATH:-}"
+
+# full/ first (and only): macos15 TARGET, SYSROOT_SUFFIX, OPENCOMBINE_EXPORT_SUFFIX.
+# machorun/scripts/guest_arch.inc is a different triple (macos11 / DARWIN_TARGET)
+# and is sourced by the loader recipes themselves. Do not let it clobber these.
+# shellcheck disable=SC1091
+. "$W/full/scripts/guest_arch.inc"
+
+MACHORUN=$W/machorun
+SYS=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
+ARM_SYS=$W/scratch/sysroot_fe4
+MRROOT=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
+ARM_MRROOT=$W/scratch/mrroot_full
+OPENCOMBINE_ROOT=$W/scratch/opencombine-core-durable-20260828-r2
+SF=$W/scratch/swift-foundation
+SC=$W/scratch/swift-collections
+FOCUS_REPO=$W/scratch/ladder-corpus/focus-ios/focus-ios
+UD_SMOKE_CHECKS=14
+UD_RUNNER=$W/foundation-macho/tests/ud_guest_runner.swift
+
+CANNOT_N=0
+SATISFIED_N=0
+COLT_N=0
+declare -A ITEM_STATUS=()
+
+note() {
+    local name=$1 status=$2
+    ITEM_STATUS[$name]=$status
+    case "$status" in
+        satisfied) SATISFIED_N=$((SATISFIED_N + 1)); phase2_prepare "$name" satisfied ;;
+        cold-built) COLT_N=$((COLT_N + 1)); phase2_prepare "$name" cold-built ;;
+        CANNOT_*)
+            CANNOT_N=$((CANNOT_N + 1))
+            phase2_prepare "$name" "$status${3:+ reason=$3}"
+            ;;
+        *) phase2_prepare "$name" "$status${3:+ reason=$3}" ;;
+    esac
+}
+
+cannot() {
+    # cannot <name> <MARKER> <reason>
+    ITEM_STATUS[$1]=CANNOT_$2
+    CANNOT_N=$((CANNOT_N + 1))
+    phase2_cannot "$1" "$2" "$3"
+}
+
+have() { [ -e "$1" ]; }
+
+# ---------------------------------------------------------------------------
+echo "==== PHASE 2  host=$(uname -m)  W=$W  TARGET=$TARGET ===="
+
+# 0. Host + toolchain
+if [ "$(uname -m)" != x86_64 ]; then
+    cannot host-arch HOST_NOT_X86_64 "uname -m is $(uname -m); this runner is the x86_64 operator path"
+    echo "RUNG_SCOREBOARD a=CANNOT/host b=CANNOT/host c=CANNOT/host"
+    echo "denominators: a 0/$UD_SMOKE_CHECKS smoke (ud_guest_runner.swift)  scoreboard=committed run_ud_guest.sh  persist=committed run_ud_persist.sh; b widget+onboarding source-preservation from full/swiftui; c windows=1 turns=3 from build_and_run_reminder_scene_guest.sh"
+    exit 2
+fi
+note host-arch satisfied
+
+missing_tools=()
+for t in clang-18 clang++-18 ld64.lld-18 llvm-otool-18 llvm-nm-18 swiftc git python3 perl patch file sha256sum; do
+    command -v "$t" >/dev/null || missing_tools+=("$t")
+done
+if [ "${#missing_tools[@]}" -ne 0 ]; then
+    cannot toolchain MISSING_TOOLS "missing: ${missing_tools[*]}"
+    echo "RUNG_SCOREBOARD a=CANNOT/toolchain b=CANNOT/toolchain c=CANNOT/toolchain"
+    echo "denominators: a 0/$UD_SMOKE_CHECKS smoke; b 0/2 guests; c 0/1 scene"
+    exit 2
+fi
+swift_ver=$(swiftc --version | sed -n '1p')
+case "$swift_ver" in
+    *6.2.4*) note toolchain satisfied ;;
+    *) cannot toolchain SWIFT_VERSION "swiftc is '$swift_ver', need Swift 6.2.4" ; exit 2 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 1. MEASURE libswiftCore-for-x86 FIRST. Do not spend the rest of the ladder
+#    pretending a later Swift guest can run without it.
+echo "==== measure libswiftCore-for-x86 (before any other Swift guest work) ===="
+artifacts=$W/swiftcore-macho/artifacts
+x86_core=$artifacts/swift-macosx/x86_64/libswiftCore.dylib
+x86_mod=$artifacts/swift-macosx/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
+arm_core=$artifacts/swift-macosx/arm64/libswiftCore.dylib
+measure_log=$W/scratch/phase2-libswiftcore-x86.txt
+mkdir -p "$W/scratch"
+{
+    echo "measured_at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "host $(uname -m)"
+    echo "swiftc $swift_ver"
+    echo "artifacts $artifacts"
+    echo "arm64_core $( [ -f "$arm_core" ] && file -b "$arm_core" || echo ABSENT )"
+    echo "x86_64_core $( [ -f "$x86_core" ] && file -b "$x86_core" || echo ABSENT )"
+    echo "x86_64_swiftmodule $( [ -f "$x86_mod" ] && echo PRESENT || echo ABSENT )"
+    echo "stdlib_source ABSENT (no swiftcore-macho/swift, scratch/swift, /opt/swift-source)"
+    echo "configure_sh_pins SWIFT_HOST_VARIANT_ARCH=aarch64 SWIFT_SDK_OSX_ARCHITECTURES=arm64 SWIFT_DARWIN_SUPPORTED_ARCHS=arm64 SWIFT_HOST_TRIPLE=aarch64-unknown-linux-gnu"
+    echo "cmake_lists $( [ -f "$W/swiftcore-macho/CMakeLists.txt" ] && echo PRESENT || echo ABSENT -- source not vendored )"
+} > "$measure_log"
+
+probe_dir=$(mktemp -d)
+printf 'public func ping() -> Int { 1 }\n' > "$probe_dir/t.swift"
+set +e
+swiftc -target "$TARGET" -sdk "$ARM_SYS" \
+    -runtime-compatibility-version none -parse-as-library -module-name T \
+    -emit-object -o "$probe_dir/t.o" "$probe_dir/t.swift" \
+    >"$probe_dir/out" 2>"$probe_dir/err"
+probe_rc=$?
+set -e
+{
+    echo "swiftc_x86_against_arm64_sysroot rc=$probe_rc"
+    echo "stderr_head $(head -n 3 "$probe_dir/err" | tr '\n' ' | ')"
+} >> "$measure_log"
+rm -rf "$probe_dir"
+
+LIBSWIFTCORE_X86=0
+if [ -f "$x86_core" ] && phase2_is_x86_macho "$x86_core" && [ -f "$x86_mod" ]; then
+    LIBSWIFTCORE_X86=1
+    note libswiftCore-x86 satisfied
+    echo "  (x86_64 libswiftCore + swiftmodule present under artifacts/)"
+else
+    cannot libswiftCore-x86 BUILD_LIBSWIFTCORE_X86 \
+        "no x86_64 slice in swiftcore-macho/artifacts (only arm64/libswiftCore.dylib + Swift.swiftmodule/arm64-apple-macos.*); stdlib source is not in this tree; configure.sh hardcodes aarch64-host/arm64-Darwin; swiftc -target $TARGET against sysroot_fe4 fails looking for x86_64-apple-macos _Concurrency/Swift modules (found: arm64-apple-macos). Cross-building libswiftCore is the CMake+Ninja stdlib-only recipe in swiftcore-macho/docs/BUILD_LOG.md, historically on a Graviton box against a full swift.org 6.2.4 checkout. Do not stage the arm64 dylib under an x86 name. measurement=$measure_log"
+    cat "$measure_log" | sed 's/^/  /'
+fi
+
+# ---------------------------------------------------------------------------
+# 2. machorun substrate: loader, darwin, objc4, quartz, tbd
+echo "==== machorun substrate (build.sh all, objc4, quartz, tbd) ===="
+
+ensure_loader() {
+    local bin=$MACHORUN/build/machorun
+    if phase2_is_elf_x86_loader "$bin"; then
+        note machorun-loader satisfied
+        return 0
+    fi
+    echo "== cold-build loader (CC=$CC)"
+    sh "$MACHORUN/scripts/build.sh" loader
+    if phase2_is_elf_x86_loader "$bin"; then
+        note machorun-loader cold-built
+        return 0
+    fi
+    cannot machorun-loader BUILD_LOADER "scripts/build.sh loader did not produce an x86-64 ELF PIE at $bin"
+    return 1
+}
+
+ensure_darwin() {
+    local dylib=$MACHORUN/darwin/usr/lib/libSystem.B.dylib
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
+        note machorun-darwin satisfied
+        return 0
+    fi
+    echo "== cold-build darwin userland (x86_64-apple-macos)"
+    sh "$MACHORUN/scripts/build.sh" darwin
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
+        note machorun-darwin cold-built
+        return 0
+    fi
+    cannot machorun-darwin BUILD_DARWIN "libSystem.B.dylib is not X86_64 Mach-O after build.sh darwin ($(file -b "$dylib" 2>/dev/null || echo missing))"
+    return 1
+}
+
+ensure_objc4() {
+    local dylib=$MACHORUN/darwin/usr/lib/libobjc.A.dylib
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
+        note machorun-objc4 satisfied
+        return 0
+    fi
+    echo "== cold-build objc4 (unblocks the objc fixture CANNOT_BUILD_LIBOBJC_X86)"
+    bash "$MACHORUN/scripts/build_objc4.sh"
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
+        note machorun-objc4 cold-built
+        return 0
+    fi
+    cannot machorun-objc4 BUILD_LIBOBJC_X86 "libobjc.A.dylib is not X86_64 Mach-O after build_objc4.sh"
+    return 1
+}
+
+ensure_quartz() {
+    local dylib=$MACHORUN/darwin/usr/lib/libquartz.dylib
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
+        note machorun-quartz satisfied
+        return 0
+    fi
+    echo "== cold-build quartz"
+    bash "$MACHORUN/scripts/build_quartz.sh"
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
+        note machorun-quartz cold-built
+        return 0
+    fi
+    cannot machorun-quartz BUILD_QUARTZ_X86 "libquartz.dylib is not X86_64 Mach-O after build_quartz.sh"
+    return 1
+}
+
+ensure_tbd() {
+    local tbd=$MACHORUN/sdk/usr/lib/libSystem.tbd
+    if [ -s "$tbd" ] && grep -q x86_64 "$tbd" && [ -x "$MACHORUN/build/machorun" ]; then
+        # Idempotent: a non-empty x86_64-macos tbd plus a live loader is enough.
+        if grep -q 'x86_64-macos' "$tbd" 2>/dev/null || grep -q x86_64 "$tbd"; then
+            note machorun-tbd satisfied
+            return 0
+        fi
+    fi
+    if ! phase2_is_elf_x86_loader "$MACHORUN/build/machorun"; then
+        cannot machorun-tbd GENERATE_TBD "gen_tbd.sh CHECK 1 needs the host ELF loader; loader is missing"
+        return 1
+    fi
+    echo "== cold-generate .tbd (CHECK 1 against this loader)"
+    # CHECK 4 scans every dylib under darwin/usr/lib. An arm64 staged
+    # libswiftcompat beside a freshly built x86 libSystem is a mixed-slice
+    # coin toss, not a generated stub. Park arm64 dylibs beside (do not
+    # delete) so the x86 .tbd projection is honest.
+    park=$MACHORUN/darwin/usr/lib-arm64-park
+    if [ -d "$MACHORUN/darwin/usr/lib" ]; then
+        mkdir -p "$park"
+        while IFS= read -r -d '' d; do
+            phase2_is_arm64_macho "$d" || continue
+            rel=${d#"$MACHORUN/darwin/usr/lib/"}
+            mkdir -p "$park/$(dirname "$rel")"
+            mv "$d" "$park/$rel"
+            echo "  parked arm64 $rel -> darwin/usr/lib-arm64-park"
+        done < <(find "$MACHORUN/darwin/usr/lib" -type f -name '*.dylib' -print0)
+    fi
+    set +e
+    sh "$MACHORUN/scripts/build.sh" tbd
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && [ -s "$tbd" ]; then
+        note machorun-tbd cold-built
+        return 0
+    fi
+    tbd_state=missing
+    [ -s "$tbd" ] && tbd_state=present
+    cannot machorun-tbd GENERATE_TBD "build.sh tbd exit $st; $tbd $tbd_state. CHECK 1 needs this loader's exports; CHECK 4 refuses duplicate symbols across dylibs (arm64 libswiftcompat leftover beside x86 libSystem is a mixed-arch wall, not a faked tbd)."
+    return 1
+}
+
+ensure_loader || true
+ensure_darwin || true
+ensure_objc4 || true
+ensure_quartz || true
+ensure_tbd || true
+
+# ---------------------------------------------------------------------------
+# 3. x86 sysroot beside arm64 sysroot_fe4
+echo "==== x86 sysroot (beside $ARM_SYS, never overwrite) ===="
+[ -d "$ARM_SYS" ] || echo "  note: arm64 sysroot_fe4 is absent; textual Darwin overlays cannot be copied"
+SYSROOT_OK=0
+SYSROOT_HEADERS=0
+sys_has_overlays=0
+if [ -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] || [ -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
+    sys_has_overlays=1
+fi
+if [ -d "$SYS/usr/include" ] && [ -f "$SYS/usr/lib/libSystem.B.dylib" ] \
+    && phase2_is_x86_macho "$SYS/usr/lib/libSystem.B.dylib" && [ "$sys_has_overlays" -eq 1 ]; then
+    note sysroot-fe4-x86 satisfied
+    SYSROOT_OK=1
+    SYSROOT_HEADERS=1
+elif [ -d "$SYS/usr/include" ] && [ -f "$SYS/usr/lib/libSystem.B.dylib" ] \
+    && phase2_is_x86_macho "$SYS/usr/lib/libSystem.B.dylib" && [ "$sys_has_overlays" -eq 0 ]; then
+    cannot sysroot-fe4-x86 STAGE_XCODE_DARWIN_OVERLAYS \
+        "headers+x86 dylibs already at $SYS; Darwin.swiftmodule/swiftinterface absent (Linux cannot materialize Apple's overlay interfaces; arm64 sysroot_fe4 also lacks them). FE compile needs canImport(Darwin)==true."
+    SYSROOT_HEADERS=1
+else
+    set +e
+    bash "$HERE/stage_fe_sysroot.sh"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && [ -d "$SYS/usr/include" ]; then
+        note sysroot-fe4-x86 cold-built
+        SYSROOT_OK=1
+        SYSROOT_HEADERS=1
+    elif [ "$st" -eq 3 ]; then
+        # Headers/dylibs staged; Darwin overlays missing. Partial tree exists.
+        if [ -d "$SYS/usr/include" ]; then
+            cannot sysroot-fe4-x86 STAGE_XCODE_DARWIN_OVERLAYS \
+                "headers+x86 dylibs staged at $SYS; Darwin.swiftmodule/swiftinterface absent (Linux cannot materialize Apple's overlay interfaces; arm64 sysroot_fe4 also lacks them). FE compile needs canImport(Darwin)==true."
+            SYSROOT_HEADERS=1
+        else
+            cannot sysroot-fe4-x86 STAGE_FE_SYSROOT "stage_fe_sysroot.sh exit 3 and $SYS missing"
+        fi
+    else
+        cannot sysroot-fe4-x86 STAGE_FE_SYSROOT "stage_fe_sysroot.sh exit $st"
+    fi
+fi
+# Never copy arm64 dylibs into the x86 sysroot.
+if [ -f "$SYS/usr/lib/libSystem.B.dylib" ] && phase2_is_arm64_macho "$SYS/usr/lib/libSystem.B.dylib"; then
+    cannot sysroot-fe4-x86 ARM64_DYLIB_IN_X86_SYSROOT "libSystem.B.dylib in $SYS is still arm64; refuse rather than link against it"
+    SYSROOT_OK=0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. FoundationEssentials + collections + cshims for x86
+echo "==== FoundationEssentials / collections / cshims ($TARGET) ===="
+FE_OK=0
+COL_OK=0
+CSHIMS_OK=0
+FE_OUT=$W/build/full${FULL_OUT_SUFFIX}/foundation
+
+try_collections() {
+    local out=$FE_OUT/collections
+    if [ -f "$out/OrderedCollections.o" ] && phase2_is_x86_macho "$out/OrderedCollections.o"; then
+        note collections-x86 satisfied
+        COL_OK=1
+        return 0
+    fi
+    [ -d "$SC" ] || { cannot collections-x86 PINNED_SWIFT_COLLECTIONS "no $SC"; return 1; }
+    [ "$SYSROOT_OK" -eq 1 ] || { cannot collections-x86 NEEDS_X86_SYSROOT "collections compile needs $SYS"; return 1; }
+    [ "$LIBSWIFTCORE_X86" -eq 1 ] || {
+        cannot collections-x86 BUILD_LIBSWIFTCORE_X86 "swiftc -target $TARGET cannot compile without an x86_64 Swift.swiftmodule (measured above)"
+        return 1
+    }
+    mkdir -p "$out"
+    set +e
+    W="$W" SC="$SC" SYS="$SYS" OUT="$out" TARGET="$TARGET" \
+        bash "$W/full/foundation/build_collections.sh"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && phase2_is_x86_macho "$out/OrderedCollections.o"; then
+        note collections-x86 cold-built
+        COL_OK=1
+        return 0
+    fi
+    cannot collections-x86 BUILD_COLLECTIONS "build_collections.sh exit $st"
+    return 1
+}
+
+try_cshims() {
+    local out=$FE_OUT/cshims
+    if [ -f "$out/uuid.o" ] && phase2_is_x86_macho "$out/uuid.o"; then
+        note cshims-x86 satisfied
+        CSHIMS_OK=1
+        return 0
+    fi
+    [ -d "$SF" ] || { cannot cshims-x86 PINNED_SWIFT_FOUNDATION "no $SF"; return 1; }
+    [ "$SYSROOT_HEADERS" -eq 1 ] || [ "$SYSROOT_OK" -eq 1 ] || {
+        cannot cshims-x86 NEEDS_X86_SYSROOT "cshims compile needs $SYS"
+        return 1
+    }
+    mkdir -p "$out"
+    set +e
+    W="$W" SF="$SF" SYS="$SYS" OUT="$out" TARGET="$TARGET" \
+        bash "$W/full/foundation/build_cshims.sh"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && [ -f "$out/uuid.o" ] && phase2_is_x86_macho "$out/uuid.o"; then
+        note cshims-x86 cold-built
+        CSHIMS_OK=1
+        return 0
+    fi
+    cannot cshims-x86 BUILD_CSHIMS "build_cshims.sh exit $st"
+    return 1
+}
+
+try_fe() {
+    local out=$FE_OUT/essentials
+    if [ -f "$out/FoundationEssentials.o" ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
+        note foundationessentials-x86 satisfied
+        FE_OK=1
+        return 0
+    fi
+    [ -d "$SF" ] || { cannot foundationessentials-x86 PINNED_SWIFT_FOUNDATION "no $SF"; return 1; }
+    [ "$SYSROOT_OK" -eq 1 ] || { cannot foundationessentials-x86 NEEDS_X86_SYSROOT "FE compile needs $SYS"; return 1; }
+    [ "$LIBSWIFTCORE_X86" -eq 1 ] || {
+        cannot foundationessentials-x86 BUILD_LIBSWIFTCORE_X86 "swiftc -target $TARGET cannot compile 202 FE files without x86_64 Swift/_Concurrency modules"
+        return 1
+    }
+    mkdir -p "$out"
+    set +e
+    W="$W" SF="$SF" SYS="$SYS" TARGET="$TARGET" \
+        COLLECTIONS="$FE_OUT/collections" \
+        bash "$W/full/foundation/build_fe.sh" \
+            -emit-module -emit-module-path "$out/FoundationEssentials.swiftmodule" \
+            -c -o "$out/FoundationEssentials.o"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
+        note foundationessentials-x86 cold-built
+        FE_OK=1
+        return 0
+    fi
+    cannot foundationessentials-x86 BUILD_FE "build_fe.sh exit $st"
+    return 1
+}
+
+try_cshims || true
+try_collections || true
+try_fe || true
+
+# ---------------------------------------------------------------------------
+# 5. OpenCombine for x86 beside the durable arm64 export/
+echo "==== OpenCombine x86 (beside $OPENCOMBINE_ROOT/export) ===="
+OC_OK=0
+oc_obj=$OPENCOMBINE_ROOT/export-x86_64/artifacts/OpenCombine.o
+if [ -f "$oc_obj" ] && phase2_is_x86_macho "$oc_obj"; then
+    note opencombine-x86 satisfied
+    OC_OK=1
+else
+    set +e
+    W="$W" SYS="$SYS" OPENCOMBINE_ROOT="$OPENCOMBINE_ROOT" \
+        bash "$HERE/build_opencombine.sh"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && [ -f "$oc_obj" ] && phase2_is_x86_macho "$oc_obj"; then
+        note opencombine-x86 cold-built
+        OC_OK=1
+    else
+        cannot opencombine-x86 X86_OPENCOMBINE \
+            "NEEDS_X86_OPENCOMBINE unresolved: x86 OpenCombine.o not produced (blocked by libswiftCore-x86=$LIBSWIFTCORE_X86 sysroot=$SYSROOT_OK). arm64 durable SHA in export/artifacts still stands; this runner writes only export-x86_64/"
+    fi
+fi
+# Arm64 pin must still be beside, never rewritten.
+if [ -f "$OPENCOMBINE_ROOT/export/artifacts/OpenCombine.o" ]; then
+    if phase2_is_x86_macho "$OPENCOMBINE_ROOT/export/artifacts/OpenCombine.o"; then
+        cannot opencombine-arm64-pin REWROTE_ARM64_OPENCOMBINE \
+            "export/artifacts/OpenCombine.o is no longer arm64; the durable pin was overwritten"
+    else
+        note opencombine-arm64-pin satisfied
+    fi
+else
+    echo "ENV_PREPARE opencombine-arm64-pin absent (durable export/ not on this tree; source pin remains; not a rewrite)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. mrroot_full-x86_64 beside mrroot_full
+echo "==== mrroot_full-x86_64 (beside $ARM_MRROOT) ===="
+MRROOT_OK=0
+[ "$MRROOT" != "$ARM_MRROOT" ] || {
+    cannot mrroot-x86 MRROOT_COLLIDES_ARM64 "x86 mrroot path equals arm64 path"
+}
+if [ -x "$MRROOT/machorun" ] && phase2_is_elf_x86_loader "$MRROOT/machorun" \
+    && [ -f "$MRROOT/darwin/usr/lib/libSystem.B.dylib" ] \
+    && phase2_is_x86_macho "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
+    && [ -f "$MRROOT/darwin/usr/lib/swift/libswiftCore.dylib" ]; then
+    if phase2_is_arm64_macho "$MRROOT/darwin/usr/lib/swift/libswiftCore.dylib"; then
+        cannot mrroot-x86 ARM64_SWIFTCORE_IN_X86_MRROOT \
+            "refusing to call this an x86 root: libswiftCore.dylib is still arm64"
+    elif phase2_is_x86_macho "$MRROOT/darwin/usr/lib/swift/libswiftCore.dylib"; then
+        note mrroot-x86 satisfied
+        MRROOT_OK=1
+    else
+        cannot mrroot-x86 MRROOT_SWIFTCORE_ARCH \
+            "libswiftCore.dylib in $MRROOT is neither X86_64 nor ARM64"
+    fi
+else
+    if ! phase2_is_elf_x86_loader "$MACHORUN/build/machorun"; then
+        cannot mrroot-x86 STAGE_MRROOT_LOADER "no x86 ELF loader to copy into $MRROOT"
+    elif [ "$LIBSWIFTCORE_X86" -ne 1 ]; then
+        # Stage what we can (loader + x86 darwin dylibs) but refuse to copy arm64 libswiftCore.
+        echo "== staging x86 mrroot without libswiftCore (honest partial; not MRROOT_OK)"
+        mkdir -p "$MRROOT/darwin/usr/lib/swift"
+        cp -f "$MACHORUN/build/machorun" "$MRROOT/machorun"
+        chmod a+x "$MRROOT/machorun"
+        if [ -d "$MACHORUN/darwin/usr/lib" ]; then
+            while IFS= read -r -d '' d; do
+                rel=${d#"$MACHORUN/darwin/usr/lib/"}
+                case "$rel" in
+                    swift/libswiftCore.dylib|swift/libswift_Concurrency.dylib) continue ;;
+                esac
+                if phase2_is_x86_macho "$d"; then
+                    mkdir -p "$MRROOT/darwin/usr/lib/$(dirname "$rel")"
+                    cp -a "$d" "$MRROOT/darwin/usr/lib/$rel"
+                fi
+            done < <(find "$MACHORUN/darwin/usr/lib" -type f -name '*.dylib' -print0)
+        fi
+        cannot mrroot-x86 BUILD_LIBSWIFTCORE_X86 \
+            "loader+x86 libSystem/objc/quartz staged at $MRROOT; libswiftCore.dylib omitted because only an arm64 artifact exists. build_full.sh would otherwise copy that arm64 dylib into an x86-named root."
+    else
+        echo "== cold-stage x86 mrroot from current machorun + x86 libswiftCore"
+        rm -rf "$MRROOT"
+        mkdir -p "$MRROOT/darwin/usr/lib/swift"
+        cp -f "$MACHORUN/build/machorun" "$MRROOT/machorun"
+        chmod a+x "$MRROOT/machorun"
+        cp -a "$MACHORUN/darwin/usr/lib/." "$MRROOT/darwin/usr/lib/"
+        cp -f "$x86_core" "$MRROOT/darwin/usr/lib/swift/libswiftCore.dylib"
+        if phase2_is_x86_macho "$MRROOT/darwin/usr/lib/swift/libswiftCore.dylib" \
+            && phase2_is_elf_x86_loader "$MRROOT/machorun"; then
+            note mrroot-x86 cold-built
+            MRROOT_OK=1
+        else
+            cannot mrroot-x86 STAGE_MRROOT "copy failed to produce x86 loader+libswiftCore"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 6b. Guest-visible /w layout (FocusWidgetGuestMain.swift fonts)
+echo "==== /w layout (guest-visible fonts path) ===="
+W_LAYOUT=0
+w_resolved=$(readlink -f /w 2>/dev/null || true)
+if [ -d /w ] && [ "$w_resolved" = "$W" ]; then
+    note host-w-layout satisfied
+    W_LAYOUT=1
+elif [ ! -e /w ] && ln -sfn "$W" /w 2>/dev/null; then
+    note host-w-layout cold-built
+    W_LAYOUT=1
+else
+    cannot host-w-layout HOST_W_LAYOUT \
+        "FocusWidgetGuestMain.swift opens /w/build/swiftui-guest/fonts; cannot ln -s $W /w (resolved=$(readlink -f /w 2>/dev/null || echo missing)). Widget argv already uses \$OUT; fonts still need this docker-era path. Operator: ln -sfn $W /w"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Rungs. Reuse committed gates. Never invent new denominators.
+echo "==== rungs (committed runners only) ===="
+
+actual_smoke=$(grep -c '^check(' "$UD_RUNNER" || true)
+[ "$actual_smoke" = "$UD_SMOKE_CHECKS" ] || {
+    echo "phase2: ud_guest_runner.swift has $actual_smoke check() calls, expected $UD_SMOKE_CHECKS" >&2
+    echo "        the denominator is the committed runner's, not this script's. refuse rather than invent." >&2
+    cannot rung-a-denominator SMOKE_DENOMINATOR "ud_guest_runner.swift check() count $actual_smoke != $UD_SMOKE_CHECKS"
+}
+
+RUNG_A=CANNOT
+RUNG_A_DETAIL=not-run
+RUNG_B=CANNOT
+RUNG_B_DETAIL=not-run
+RUNG_C=CANNOT
+RUNG_C_DETAIL=not-run
+
+find_existing_dir() {
+    local c
+    for c in "$@"; do
+        [ -n "$c" ] || continue
+        [ -d "$c" ] || continue
+        printf '%s\n' "$c"
+        return 0
+    done
+    return 1
+}
+
+find_existing_file() {
+    local c
+    for c in "$@"; do
+        [ -n "$c" ] || continue
+        [ -f "$c" ] || continue
+        printf '%s\n' "$c"
+        return 0
+    done
+    return 1
+}
+
+# Rung a: ud_guest smoke (14) + scoreboard + persist
+if [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] && [ "$LIBSWIFTCORE_X86" -eq 1 ]; then
+    echo "== rung a: foundation-macho run_ud_guest.sh + run_ud_persist.sh"
+    # The committed runners take a NAMED root and a binary. If this tree has
+    # not yet linked ud_guest for x86, refuse rather than invent a new linker.
+    ud_w=$W/scratch/ud-guest-x86_64
+    ud_r=$W/foundation-macho
+    ud_bin=$(find_existing_file \
+        "${UD_GUEST_BIN:-}" \
+        "$ud_w/bin/ud_guest" \
+        "$W/scratch/ud-guest/bin/ud_guest" \
+        "$ud_r/bin/ud_guest" || true)
+    ud_score=$(find_existing_file \
+        "${UD_SCORE_BIN:-}" \
+        "$ud_w/bin/ud_score_guest" \
+        "$W/scratch/ud-guest/bin/ud_score_guest" \
+        "$ud_r/bin/ud_score_guest" || true)
+    if [ -n "$ud_bin" ] && phase2_is_x86_macho "$ud_bin"; then
+        set +e
+        W=${UD_GUEST_W:-$ud_w} \
+            R=$ud_r \
+            BIN=$ud_bin \
+            MRUN=$MRROOT/machorun \
+            bash "$ud_r/scripts/run_ud_guest.sh" "$MRROOT" \
+            | tee "$W/scratch/phase2-rung-a-smoke.log"
+        smoke_rc=${PIPESTATUS[0]}
+        set -e
+        smoke_pass=$(grep -E 'guest runner: pass ' "$W/scratch/phase2-rung-a-smoke.log" | tail -1 || true)
+        if [ "$smoke_rc" -eq 0 ]; then
+            RUNG_A_DETAIL="smoke $UD_SMOKE_CHECKS/$UD_SMOKE_CHECKS ($smoke_pass)"
+            if [ -n "$ud_score" ] && phase2_is_x86_macho "$ud_score"; then
+                set +e
+                W=${UD_GUEST_W:-$ud_w} \
+                    R=$ud_r \
+                    BIN=$ud_score \
+                    MRUN=$MRROOT/machorun \
+                    bash "$ud_r/scripts/run_ud_persist.sh" "$MRROOT" \
+                    | tee "$W/scratch/phase2-rung-a-persist.log"
+                persist_rc=${PIPESTATUS[0]}
+                set -e
+                if [ "$persist_rc" -eq 0 ]; then
+                    RUNG_A=PASS
+                    note rung-a-ud_guest cold-built
+                else
+                    RUNG_A=FAIL
+                    cannot rung-a-ud_guest UD_PERSIST "run_ud_persist.sh exit $persist_rc"
+                fi
+            else
+                cannot rung-a-ud_guest UD_SCOREBOARD "smoke passed; ud_score_guest binary absent (committed build_ud_score_guest.sh). persist not faked."
+            fi
+        else
+            cannot rung-a-ud_guest UD_SMOKE "run_ud_guest.sh exit $smoke_rc (denominator $UD_SMOKE_CHECKS/$UD_SMOKE_CHECKS in ud_guest_runner.swift)"
+        fi
+    else
+        cannot rung-a-ud_guest UD_GUEST_BINARY \
+            "no x86_64 ud_guest Mach-O. Committed linker is foundation-macho/scripts/link_ud_guest.sh (objects in \$W/fe of a named foundation-macho work tree). Will not invent a second linker. Operator: stage CF+FE objects, link_ud_guest.sh, then re-run; or set UD_GUEST_BIN."
+        RUNG_A_DETAIL="no ud_guest binary"
+    fi
+else
+    cannot rung-a-ud_guest UD_GUEST_SUBSTRATE \
+        "needs x86 FE (fe=$FE_OK) + x86 mrroot with libswiftCore (mrroot=$MRROOT_OK libswiftCore=$LIBSWIFTCORE_X86). Committed runners: run_ud_guest.sh smoke $UD_SMOKE_CHECKS/$UD_SMOKE_CHECKS in tests/ud_guest_runner.swift; run_ud_persist.sh persist board. Denominators unchanged."
+    RUNG_A_DETAIL="blocked by substrate"
+fi
+
+# Rung b: Focus widget + onboarding. Same source-preservation contracts.
+FOCUS_PIN=a2832521c1daa0c23419c73705ae043ed60c9791
+if [ -d "$FOCUS_REPO/.git" ] && [ "$(git -C "$FOCUS_REPO" rev-parse HEAD)" = "$FOCUS_PIN" ]; then
+    note focus-pin satisfied
+else
+    cannot focus-pin FOCUS_PIN "Focus checkout is not $FOCUS_PIN at $FOCUS_REPO"
+fi
+
+find_widget_bundle() {
+    local c recorded
+    if [ -f "$W/scratch/phase2-focus-resources.path" ]; then
+        recorded=$(tr -d '\n' < "$W/scratch/phase2-focus-resources.path")
+        [ -d "$recorded/bundles/Focus_Widget.bundle" ] \
+            && [ -f "$recorded/bundles/Focus_Widget.bundle/resource-index.json" ] \
+            && { printf '%s\n' "$recorded/bundles/Focus_Widget.bundle"; return 0; }
+    fi
+    for c in \
+        "${FOCUS_WIDGET_BUNDLE:-}" \
+        "$W/scratch/focus-resources/bundles/Focus_Widget.bundle" \
+        "$W/scratch/focus-resources/Focus_Widget.bundle" \
+        "$W/scratch/ladder-corpus/focus-ios/bundles/Focus_Widget.bundle" \
+        "$W/scratch/ladder-corpus/focus-ios/Focus_Widget.bundle"
+    do
+        [ -n "$c" ] || continue
+        [ -d "$c" ] && [ -f "$c/resource-index.json" ] || continue
+        printf '%s\n' "$c"
+        return 0
+    done
+    return 1
+}
+
+find_onboarding_bundles_dir() {
+    local c recorded
+    if [ -f "$W/scratch/phase2-focus-resources.path" ]; then
+        recorded=$(tr -d '\n' < "$W/scratch/phase2-focus-resources.path")
+        if [ -d "$recorded/bundles/Focus_Onboarding.bundle" ] \
+            && [ -d "$recorded/bundles/Focus_Widget.bundle" ]; then
+            printf '%s\n' "$recorded/bundles"
+            return 0
+        fi
+    fi
+    for c in \
+        "${FOCUS_ONBOARDING_BUNDLES:-}" \
+        "$W/scratch/focus-resources/bundles" \
+        "$W/scratch/ladder-corpus/focus-ios/bundles"
+    do
+        [ -n "$c" ] || continue
+        [ -d "$c/Focus_Onboarding.bundle" ] && [ -d "$c/Focus_Widget.bundle" ] || continue
+        printf '%s\n' "$c"
+        return 0
+    done
+    return 1
+}
+
+try_normalize_focus_bundles() {
+    local marker=$W/scratch/phase2-focus-resources.path
+    local recorded out_parent out
+    if [ -f "$marker" ]; then
+        recorded=$(tr -d '\n' < "$marker")
+        if [ -d "$recorded/bundles/Focus_Widget.bundle" ] \
+            && [ -f "$recorded/bundles/Focus_Widget.bundle/resource-index.json" ]; then
+            return 0
+        fi
+    fi
+    [ "${ITEM_STATUS[focus-pin]:-}" = satisfied ] || return 1
+    [ -f "$W/full/focus-ios/onboarding-resources-proof.json" ] || return 1
+    # Committed prove() refuses output inside the policy/source git tops and
+    # requires a 0700 parent. Use /tmp, never $W/scratch.
+    out_parent=$(mktemp -d /tmp/focus-resources-x86.XXXXXX)
+    chmod 0700 "$out_parent"
+    out=$out_parent/proof
+    echo "== committed onboarding_resources_proof.py prove -> $out"
+    set +e
+    python3 -B "$W/full/focus-ios/onboarding_resources_proof.py" prove \
+        "$FOCUS_REPO" \
+        "$W/full/focus-ios/onboarding-resources-proof.json" \
+        "$out"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && [ -d "$out/bundles/Focus_Widget.bundle" ]; then
+        printf '%s\n' "$out" > "$marker"
+        return 0
+    fi
+    return 1
+}
+
+if [ "$OC_OK" -eq 1 ] && [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] \
+    && [ "$LIBSWIFTCORE_X86" -eq 1 ] && [ "${ITEM_STATUS[focus-pin]:-}" = satisfied ]; then
+    echo "== rung b: full/swiftui Focus widget + onboarding (x86, source pins unchanged)"
+    widget_bundle=$(find_widget_bundle || true)
+    if [ -z "$widget_bundle" ]; then
+        try_normalize_focus_bundles || true
+        widget_bundle=$(find_widget_bundle || true)
+    fi
+    if [ -z "$widget_bundle" ]; then
+        cannot rung-b-focus FOCUS_BUNDLE \
+            "no normalized Focus_Widget.bundle; committed full/focus-ios/onboarding_resources_proof.py prove did not emit bundles/Focus_Widget.bundle (needs Focus pin + pdftocairo; output must be outside the git top). Operator: set FOCUS_WIDGET_BUNDLE. NEEDS_X86_OPENCOMBINE is resolved by export-x86_64 (arm64 export/ untouched)."
+        RUNG_B_DETAIL="no Focus_Widget.bundle"
+    else
+        echo "== build_focus_widget_guest.sh $widget_bundle"
+        set +e
+        W="$W" UIKIT="$W/uikit" MACHORUN="$MACHORUN" OPENCOMBINE_ROOT="$OPENCOMBINE_ROOT" \
+            bash "$W/full/swiftui/build_focus_widget_guest.sh" "$widget_bundle" \
+            | tee "$W/scratch/phase2-rung-b-widget.log"
+        widget_rc=${PIPESTATUS[0]}
+        set -e
+        onboard_dir=$(find_onboarding_bundles_dir || true)
+        onboard_rc=2
+        if [ "$widget_rc" -eq 0 ] && [ -n "$onboard_dir" ]; then
+            echo "== build_focus_onboarding_guest.sh $onboard_dir"
+            set +e
+            W="$W" UIKIT="$W/uikit" MACHORUN="$MACHORUN" OPENCOMBINE_ROOT="$OPENCOMBINE_ROOT" \
+                bash "$W/full/swiftui/build_focus_onboarding_guest.sh" "$onboard_dir" \
+                | tee "$W/scratch/phase2-rung-b-onboarding.log"
+            onboard_rc=${PIPESTATUS[0]}
+            set -e
+        elif [ "$widget_rc" -eq 0 ]; then
+            cannot rung-b-focus FOCUS_ONBOARDING_BUNDLE \
+                "widget guest passed; no Focus_Onboarding.bundle directory beside it (committed build_focus_onboarding_guest.sh). Set FOCUS_ONBOARDING_BUNDLES."
+            RUNG_B_DETAIL="widget ok; onboarding bundle missing"
+        fi
+        if [ "$widget_rc" -eq 0 ] && [ "$onboard_rc" -eq 0 ]; then
+            RUNG_B=PASS
+            RUNG_B_DETAIL="widget+onboarding under $OTOOL_CPU loader"
+            note rung-b-focus cold-built
+        elif [ "$widget_rc" -ne 0 ]; then
+            cannot rung-b-focus FOCUS_WIDGET_GUEST \
+                "build_focus_widget_guest.sh exit $widget_rc (source-preservation + otool $OTOOL_CPU unchanged; see scratch/phase2-rung-b-widget.log)"
+            RUNG_B_DETAIL="widget guest failed"
+        elif [ "$onboard_rc" -ne 0 ] && [ -n "$onboard_dir" ]; then
+            cannot rung-b-focus FOCUS_ONBOARDING_GUEST \
+                "build_focus_onboarding_guest.sh exit $onboard_rc (see scratch/phase2-rung-b-onboarding.log)"
+            RUNG_B_DETAIL="onboarding guest failed"
+        fi
+    fi
+else
+    cannot rung-b-focus SWIFTUI_SUBSTRATE \
+        "needs x86 OpenCombine.o (oc=$OC_OK; else NEEDS_X86_OPENCOMBINE), x86 FE (fe=$FE_OK), x86 mrroot (mrroot=$MRROOT_OK), x86 libswiftCore ($LIBSWIFTCORE_X86), Focus pin $FOCUS_PIN. Source-preservation contracts in full/swiftui/*_guest.sh are unchanged; arm64 object SHAs are not rewritten."
+    RUNG_B_DETAIL="blocked by substrate"
+fi
+
+# Rung c: Reminder scene -- one active UIWindow + three paced turns.
+reminder_inv=$(find_existing_file \
+    "${REMINDER_INVENTORY:-}" \
+    "$W/scratch/ladder-corpus/reminder/Reminder.project-inventory.json" \
+    "$W/scratch/ladder-corpus/Reminder/Reminder.project-inventory.json" \
+    "$W/scratch/Reminder.project-inventory.json" || true)
+reminder_src=$(find_existing_dir \
+    "${REMINDER_SOURCE_ROOT:-}" \
+    "$W/scratch/ladder-corpus/reminder/source" \
+    "$W/scratch/ladder-corpus/reminder" \
+    "$W/scratch/ladder-corpus/Reminder" || true)
+if [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] && [ "$LIBSWIFTCORE_X86" -eq 1 ] \
+    && [ -n "$reminder_inv" ] && [ -n "$reminder_src" ]; then
+    echo "== rung c: full/xcodeplan/build_and_run_reminder_scene_guest.sh"
+    set +e
+    UIKIT_CHECKOUT="${UIKIT_CHECKOUT:-$W/uikit}" \
+    MACHORUN_CHECKOUT="${MACHORUN_CHECKOUT:-$MACHORUN}" \
+    OPENUIKIT_HOST_TURNS=3 \
+        bash "$W/full/xcodeplan/build_and_run_reminder_scene_guest.sh" \
+            "$reminder_inv" "$reminder_src" \
+        | tee "$W/scratch/phase2-rung-c-reminder.log"
+    rem_rc=${PIPESTATUS[0]}
+    set -e
+    rem_log=$W/scratch/phase2-rung-c-reminder.log
+    if [ "$rem_rc" -eq 0 ] \
+        && grep -Fxq "REMINDER_UNCHANGED_WILL_CONNECT_OK" "$rem_log" \
+        && grep -Fxq "PORTABLE_UIKIT_HOST_ACTIVE windows=1" "$rem_log" \
+        && grep -Fxq "PORTABLE_UIKIT_HOST_LOOP_OK turns=3 paced=true" "$rem_log"; then
+        RUNG_C=PASS
+        RUNG_C_DETAIL="windows=1 turns=3 paced=true"
+        note rung-c-reminder cold-built
+    else
+        cannot rung-c-reminder REMINDER_SCENE \
+            "build_and_run_reminder_scene_guest.sh exit $rem_rc; success bar is REMINDER_UNCHANGED_WILL_CONNECT_OK + PORTABLE_UIKIT_HOST_ACTIVE windows=1 + PORTABLE_UIKIT_HOST_LOOP_OK turns=3 paced=true (committed inner script, not invented here)"
+        RUNG_C_DETAIL="scene guest failed"
+    fi
+elif [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] && [ "$LIBSWIFTCORE_X86" -eq 1 ]; then
+    cannot rung-c-reminder REMINDER_INVENTORY \
+        "substrate ready enough to invoke full/xcodeplan/build_and_run_reminder_scene_guest.sh, but Reminder 22-source inventory + source root are absent. Looked at scratch/ladder-corpus/reminder and REMINDER_INVENTORY/REMINDER_SOURCE_ROOT. Success bar remains: REMINDER_UNCHANGED_WILL_CONNECT_OK + PORTABLE_UIKIT_HOST_ACTIVE windows=1 + PORTABLE_UIKIT_HOST_LOOP_OK turns=3 paced=true."
+    RUNG_C_DETAIL="needs Reminder inventory json + source root"
+else
+    cannot rung-c-reminder REMINDER_SUBSTRATE \
+        "needs x86 FE+mrroot+libswiftCore (fe=$FE_OK mrroot=$MRROOT_OK libswiftCore=$LIBSWIFTCORE_X86) plus Reminder 22-source inventory. Success bar: 1 UIWindow + 3 paced turns under the ported loader. Denominator from the committed inner script, not invented here."
+    RUNG_C_DETAIL="blocked by substrate"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "==== RUNG_SCOREBOARD ===="
+echo "RUNG_SCOREBOARD a=$RUNG_A/$RUNG_A_DETAIL  b=$RUNG_B/$RUNG_B_DETAIL  c=$RUNG_C/$RUNG_C_DETAIL"
+echo "denominators: a smoke $UD_SMOKE_CHECKS/$UD_SMOKE_CHECKS (foundation-macho/tests/ud_guest_runner.swift check() calls)  scoreboard=committed run_ud_guest.sh/build_ud_score_guest.sh  persist=committed run_ud_persist.sh; b widget+onboarding source-preservation + otool $OTOOL_CPU from full/swiftui/build_focus_{widget,onboarding}_guest.sh; c windows=1 turns=3 paced=true from full/xcodeplan/build_and_run_reminder_scene_guest.sh"
+echo "ENV_PREPARE_SUMMARY satisfied=$SATISFIED_N cold-built=$COLT_N CANNOT=$CANNOT_N libswiftCore-x86=$LIBSWIFTCORE_X86"
+echo "arm64 trees left untouched: $ARM_SYS $ARM_MRROOT $OPENCOMBINE_ROOT/export"
+
+if [ "$CANNOT_N" -gt 0 ]; then
+    echo "phase2: $CANNOT_N CANNOT line(s); refusing overall success." >&2
+    exit 2
+fi
+echo "phase2: all ENV_PREPARE items satisfied or cold-built; rungs passed."
+exit 0

--- a/scripts/x86/stage_fe_sysroot.sh
+++ b/scripts/x86/stage_fe_sysroot.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Linux sibling of full/foundation/stage_fe_sysroot.sh (which stays Darwin-only
+# because it reads Xcode). Stages scratch/sysroot_fe4-x86_64 BESIDE the arm64
+# tree. Never writes scratch/sysroot_fe4. Never copies an arm64 Mach-O into the
+# x86 sysroot under a production name.
+#
+# Textual Darwin overlays (*.swiftinterface, apinotes) are copied FROM the
+# existing arm64 sysroot_fe4 when present -- they are SDK text, not objects.
+# Arch-specific Swift.swiftmodule slices and dylibs are not.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=common.inc
+. "$HERE/common.inc"
+
+W=${W:?set W to the openuikit tree}
+# shellcheck disable=SC1091
+. "$W/full/scripts/guest_arch.inc"
+MACHORUN=${MACHORUN:-$W/machorun}
+ARM_SYS=${ARM_SYS:-$W/scratch/sysroot_fe4}
+SYS=${SYS:-$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}}
+OBJC4=${OBJC4:-$MACHORUN/vendor/objc4/runtime}
+
+if [ "$ARCH" != x86_64 ]; then
+    echo "stage_fe_sysroot_x86: this sibling is the x86_64 Linux path; arm64 keeps full/foundation/stage_fe_sysroot.sh" >&2
+    exit 2
+fi
+case "$SYS" in
+    *-x86_64) ;;
+    *)
+        echo "stage_fe_sysroot_x86: refusing to write unsuffixed sysroot $SYS (arm64 tree must stay)" >&2
+        exit 2
+        ;;
+esac
+[ "$SYS" != "$ARM_SYS" ] || {
+    echo "stage_fe_sysroot_x86: SYS equals the arm64 sysroot; refuse" >&2
+    exit 2
+}
+
+stage_absent() {
+    local rel=$1 src=$2 label=$3
+    if [ -e "$SYS/usr/include/$rel" ]; then
+        echo "  REFUSED (already present, would shadow): $rel" >&2
+        return 0
+    fi
+    [ -f "$src/$rel" ] || return 0
+    mkdir -p "$(dirname "$SYS/usr/include/$rel")"
+    cp "$src/$rel" "$SYS/usr/include/$rel"
+    echo "  + $rel   [$label]"
+}
+
+copy_if_x86_macho() {
+    local src=$1 dest=$2
+    [ -f "$src" ] || return 0
+    if phase2_is_arm64_macho "$src"; then
+        echo "  skip arm64 Mach-O $(basename "$src") (would poison the x86 sysroot)" >&2
+        return 0
+    fi
+    if ! phase2_is_x86_macho "$src"; then
+        echo "  skip non-x86 $(basename "$src"): $(file -b "$src")" >&2
+        return 0
+    fi
+    mkdir -p "$(dirname "$dest")"
+    cp -a "$src" "$dest"
+}
+
+rm -rf "$SYS"
+mkdir -p "$SYS/usr/include" "$SYS/usr/lib/swift"
+
+echo "== headers from machorun/sdk (not Xcode)"
+cp -R "$MACHORUN/sdk/usr/include/." "$SYS/usr/include/"
+
+echo "== x86_64 dylibs from machorun/darwin (arm64 copies refused)"
+if [ -d "$MACHORUN/darwin/usr/lib" ]; then
+    while IFS= read -r -d '' dylib; do
+        rel=${dylib#"$MACHORUN/darwin/usr/lib/"}
+        copy_if_x86_macho "$dylib" "$SYS/usr/lib/$rel"
+    done < <(find "$MACHORUN/darwin/usr/lib" -type f \( -name '*.dylib' -o -name '*.so' \) -print0)
+fi
+
+echo "== .tbd from machorun/sdk (generated against the x86 loader + dylibs)"
+if [ -d "$MACHORUN/sdk/usr/lib" ]; then
+    while IFS= read -r -d '' tbd; do
+        [ -s "$tbd" ] || {
+            echo "stage_fe_sysroot_x86: empty .tbd is a linker lie: $tbd" >&2
+            exit 2
+        }
+        cp -f "$tbd" "$SYS/usr/lib/$(basename "$tbd")"
+    done < <(find "$MACHORUN/sdk/usr/lib" -maxdepth 1 -type f -name '*.tbd' -print0)
+    if [ -d "$MACHORUN/sdk/usr/lib/swift" ]; then
+        mkdir -p "$SYS/usr/lib/swift"
+        while IFS= read -r -d '' tbd; do
+            [ -s "$tbd" ] || {
+                echo "stage_fe_sysroot_x86: empty .tbd is a linker lie: $tbd" >&2
+                exit 2
+            }
+            cp -f "$tbd" "$SYS/usr/lib/swift/$(basename "$tbd")"
+        done < <(find "$MACHORUN/sdk/usr/lib/swift" -maxdepth 1 -type f -name '*.tbd' -print0 2>/dev/null || true)
+    fi
+fi
+
+echo "== Swift.swiftmodule: only an x86_64-apple-macos slice, never the arm64 one under this name"
+artifacts=$W/swiftcore-macho/artifacts
+x86_core=$artifacts/swift-macosx/x86_64/libswiftCore.dylib
+x86_mod=$artifacts/swift-macosx/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
+if [ -f "$x86_core" ] && phase2_is_x86_macho "$x86_core"; then
+    mkdir -p "$SYS/usr/lib/swift"
+    cp -f "$x86_core" "$SYS/usr/lib/swift/libswiftCore.dylib"
+    echo "  + libswiftCore.dylib (x86_64)"
+else
+    echo "  no x86_64 libswiftCore.dylib in swiftcore-macho/artifacts (measured wall)"
+fi
+if [ -f "$x86_mod" ]; then
+    mkdir -p "$SYS/usr/lib/swift/Swift.swiftmodule"
+    for f in "$artifacts/swift-macosx/Swift.swiftmodule"/x86_64-apple-macos.*; do
+        [ -f "$f" ] || continue
+        cp -f "$f" "$SYS/usr/lib/swift/Swift.swiftmodule/$(basename "$f")"
+    done
+    echo "  + Swift.swiftmodule/x86_64-apple-macos.*"
+else
+    echo "  no x86_64-apple-macos.swiftmodule (arm64 slice is not a substitute)"
+fi
+
+echo "== ObjectiveC Clang module"
+mkdir -p "$SYS/usr/include/objc"
+for h in NSObject.h NSObjCRuntime.h Protocol.h; do
+    [ -f "$OBJC4/$h" ] && cp "$OBJC4/$h" "$SYS/usr/include/objc/$h"
+done
+cat > "$SYS/usr/include/module.modulemap" <<'EOF'
+module ObjectiveC [system] {
+  header "objc/objc.h"
+  header "objc/objc-api.h"
+  header "objc/runtime.h"
+  header "objc/message.h"
+  export *
+  module NSObject  { header "objc/NSObject.h"      export * }
+  module Protocol  { header "objc/Protocol.h"      export * }
+  module Runtime   { header "objc/NSObjCRuntime.h" export * }
+}
+EOF
+if [ -f "$OBJC4/Module/ObjectiveC.apinotes" ]; then
+    cp "$OBJC4/Module/ObjectiveC.apinotes" "$SYS/usr/include/ObjectiveC.apinotes"
+fi
+bash "$W/full/foundation/stage_objc_platform_headers.sh" "$SYS/usr/include"
+
+echo "== sdk-gaps (file-by-file, refuse shadowing -- same rule as the Darwin recipe)"
+gaps=$W/full/sdk-gaps/usr/include
+if [ -d "$gaps" ]; then
+    while IFS= read -r -d '' gap; do
+        rel=${gap#"$gaps"/}
+        stage_absent "$rel" "$gaps" "sdk-gap"
+    done < <(find "$gaps" -type f -print0)
+fi
+
+echo "== textual Darwin overlays from the arm64 sysroot, if any (no dylibs, no arm64 .swiftmodule slices)"
+OVERLAYS_COPIED=0
+if [ -d "$ARM_SYS/usr/lib/swift" ]; then
+    while IFS= read -r -d '' item; do
+        rel=${item#"$ARM_SYS/usr/lib/swift/"}
+        case "$rel" in
+            *.dylib|*.tbd|*.a) continue ;;
+            */arm64-apple-macos.*|arm64-apple-macos.*) continue ;;
+            */arm64e-apple-macos.*|arm64e-apple-macos.*) continue ;;
+        esac
+        case "$(file -b "$item")" in
+            Mach-O*) continue ;;
+        esac
+        dest="$SYS/usr/lib/swift/$rel"
+        mkdir -p "$(dirname "$dest")"
+        cp -a "$item" "$dest"
+        OVERLAYS_COPIED=$((OVERLAYS_COPIED + 1))
+    done < <(find "$ARM_SYS/usr/lib/swift" -type f -print0)
+fi
+if [ -f "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" ]; then
+    cp "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" \
+        "$SYS/usr/include/_DarwinFoundation2.apinotes"
+    OVERLAYS_COPIED=$((OVERLAYS_COPIED + 1))
+fi
+
+if ! grep -q 'vm_copy' "$SYS/usr/include/mach/vm_map.h" 2>/dev/null; then
+    cat >> "$SYS/usr/include/mach/vm_map.h" <<'EOF'
+/* APPENDED by scripts/x86/stage_fe_sysroot.sh -- MEASUREMENT ONLY. */
+extern kern_return_t vm_copy(vm_map_t target_task, vm_address_t source_address,
+                             vm_size_t size, vm_address_t dest_address);
+EOF
+fi
+
+empty_tbd=$(find "$SYS" -name '*.tbd' -size 0 -print -quit)
+[ -z "$empty_tbd" ] || {
+    echo "stage_fe_sysroot_x86: empty .tbd is a linker lie: $empty_tbd" >&2
+    exit 2
+}
+
+echo "== $SYS"
+echo "  usr/include : $(find "$SYS/usr/include" -type f | wc -l | tr -d ' ') headers"
+echo "  textual overlays copied from arm64 sysroot: $OVERLAYS_COPIED"
+if [ ! -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] \
+    && [ ! -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
+    echo "  CANNOT_STAGE_XCODE_DARWIN_OVERLAYS: no Darwin.swiftmodule/swiftinterface in $ARM_SYS (Linux cannot materialize Apple's overlay interfaces)"
+    exit 3
+fi
+echo "  Darwin overlays: present (textual, from $ARM_SYS)"

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Static teeth for the x86_64 PHASE 2 runner. Does not execute guests.
+# Run from the openuikit tree: bash scripts/x86/test_phase2.sh
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)
+pass=0
+fail=0
+
+die_test() {
+    echo "FAIL: $*" >&2
+    fail=$((fail + 1))
+}
+ok() {
+    echo "PASS: $*"
+    pass=$((pass + 1))
+}
+
+expect_file() {
+    local f=$1
+    [ -f "$f" ] && ok "present $f" || die_test "missing $f"
+}
+
+expect_grep() {
+    local needle=$1 file=$2 label=$3
+    if grep -q -- "$needle" "$file"; then
+        ok "$label"
+    else
+        die_test "$label (missing in $file: $needle)"
+    fi
+}
+
+expect_not_grep() {
+    local needle=$1 file=$2 label=$3
+    if grep -q -- "$needle" "$file"; then
+        die_test "$label (forbidden in $file: $needle)"
+    else
+        ok "$label"
+    fi
+}
+
+PHASE2=$ROOT/scripts/x86/phase2.sh
+COMMON=$ROOT/scripts/x86/common.inc
+STAGE=$ROOT/scripts/x86/stage_fe_sysroot.sh
+OC=$ROOT/scripts/x86/build_opencombine.sh
+GUEST=$ROOT/full/scripts/guest_arch.inc
+WIDGET=$ROOT/full/swiftui/build_focus_widget_guest.sh
+ONBOARD=$ROOT/full/swiftui/build_focus_onboarding_guest.sh
+REMINDER=$ROOT/full/xcodeplan/build_and_run_reminder_scene_guest.sh
+UD_RUNNER=$ROOT/foundation-macho/tests/ud_guest_runner.swift
+BUILD_FULL=$ROOT/full/scripts/build_full.sh
+
+expect_file "$PHASE2"
+expect_file "$COMMON"
+expect_file "$STAGE"
+expect_file "$OC"
+expect_file "$GUEST"
+
+echo "== bash -n"
+for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh"; do
+    if bash -n "$s"; then
+        ok "bash -n $(basename "$s")"
+    else
+        die_test "bash -n $(basename "$s")"
+    fi
+done
+
+echo "== operator command + marker grammar"
+expect_grep 'bash scripts/x86/phase2.sh /opt/openuikit/x86-verify/openuikit' "$PHASE2" \
+    "operator one-command path"
+expect_grep 'ENV_PREPARE' "$COMMON" "ENV_PREPARE helper"
+expect_grep 'Column 2 is cputype' "$COMMON" "x86 Mach-O check documents cputype column"
+expect_grep 'RUNG_SCOREBOARD' "$PHASE2" "RUNG_SCOREBOARD"
+expect_grep 'ENV_PREPARE_SUMMARY' "$PHASE2" "ENV_PREPARE_SUMMARY"
+expect_grep 'never overwrite' "$PHASE2" "arm64 overwrite refusal in header"
+
+echo "== denominators (committed runners, not invented)"
+smoke=$(grep -c '^check(' "$UD_RUNNER" || true)
+if [ "$smoke" = 14 ]; then
+    ok "ud_guest_runner.swift has 14 check() calls"
+else
+    die_test "ud_guest_runner.swift check() count is $smoke, not 14"
+fi
+expect_grep 'UD_SMOKE_CHECKS=14' "$PHASE2" "phase2 hard-codes the committed 14"
+expect_grep 'windows=1 turns=3 paced=true' "$PHASE2" "reminder success bar in scoreboard"
+expect_grep 'PORTABLE_UIKIT_HOST_ACTIVE windows=1' "$PHASE2" "reminder window marker"
+expect_grep 'PORTABLE_UIKIT_HOST_LOOP_OK turns=3 paced=true' "$PHASE2" "reminder turns marker"
+
+echo "== libswiftCore measured first"
+# The measure section must appear before FoundationEssentials / OpenCombine / rungs.
+awk '
+    /measure libswiftCore-for-x86/ { m=NR }
+    /FoundationEssentials \/ collections/ { fe=NR }
+    /OpenCombine x86/ { oc=NR }
+    /==== rungs/ { r=NR }
+    END {
+        if (!m) { print "NO_MEASURE"; exit 1 }
+        if (!(m<fe && m<oc && m<r)) { print "ORDER m="m" fe="fe" oc="oc" r="r; exit 1 }
+        print "OK"
+    }
+' "$PHASE2" | grep -q OK && ok "libswiftCore measured before FE/OpenCombine/rungs" \
+    || die_test "libswiftCore measurement is not first"
+
+expect_grep 'BUILD_LIBSWIFTCORE_X86' "$PHASE2" "canonical libswiftCore CANNOT marker"
+expect_grep 'Do not stage the arm64 dylib under an x86 name' "$PHASE2" \
+    "refuse renaming arm64 libswiftCore"
+
+echo "== x86 trees beside arm64, never on top"
+expect_grep 'scratch/sysroot_fe4-x86_64' "$STAGE" "x86 sysroot suffix in stager"
+expect_grep 'refusing to write unsuffixed sysroot' "$STAGE" "stager refuses unsuffixed SYS"
+expect_grep 'skip arm64 Mach-O' "$STAGE" "stager skips arm64 dylibs"
+expect_grep 'export-x86_64' "$OC" "OpenCombine x86 export beside durable export/"
+expect_grep 'Never writes scratch/opencombine-core-durable' "$OC" \
+    "OpenCombine does not rewrite durable export/"
+expect_grep 'SYSROOT_SUFFIX' "$GUEST" "guest_arch SYSROOT_SUFFIX"
+expect_grep 'OPENCOMBINE_EXPORT_SUFFIX' "$GUEST" "guest_arch OPENCOMBINE_EXPORT_SUFFIX"
+expect_grep 'sysroot_fe4${FULL_OUT_SUFFIX}' "$BUILD_FULL" "build_full SYS suffix"
+expect_grep 'require_macho_cpu "$swift_core_target"' "$BUILD_FULL" \
+    "build_full refuses foreign libswiftCore"
+expect_grep 'NEEDS_X86_OPENCOMBINE' "$WIDGET" "widget keeps NEEDS_X86_OPENCOMBINE"
+expect_grep 'export${FULL_OUT_SUFFIX}/artifacts' "$WIDGET" "widget OpenCombine suffix"
+expect_grep 'export${FULL_OUT_SUFFIX}/artifacts' "$ONBOARD" "onboarding OpenCombine suffix"
+expect_grep 'EXPECTED_OPENCOMBINE_OBJECT_SHA=96558e7d31c10c4bc769e9774977b74c58dc6ee83cfbd4fca8bf17229424a914' \
+    "$WIDGET" "arm64 OpenCombine object SHA still stands"
+expect_grep 'if \[ "$ARCH" = arm64 \]; then' "$WIDGET" \
+    "widget hashes OpenCombine.o only on arm64"
+
+echo "== reminder: x86-on-x86 must not refuse; native path skips docker"
+expect_grep 'x86_64 guests on an x86_64 host are the phase-2 path' "$REMINDER" \
+    "reminder documents x86-on-x86"
+expect_not_grep 'if \[ "$(uname -m)" != aarch64 \] && \[ "$(uname -m)" != arm64 \]; then' \
+    "$REMINDER" "reminder no longer refuses every non-aarch64 host"
+expect_grep 'if \[ "$ARCH" = x86_64 \] && \[ "$(uname -m)" = x86_64 \]' "$REMINDER" \
+    "reminder native x86 skip-docker"
+expect_grep 'if \[ "$ARCH" = arm64 \] && \[ "$(uname -m)" != aarch64 \]' \
+    "$ROOT/full/frameworks/run_core_guest_package_docker.sh" \
+    "core-package docker wrapper does not refuse x86-on-x86"
+expect_grep 'sysroot_fe4${FULL_OUT_SUFFIX}' "$REMINDER" "reminder SYS suffix"
+expect_grep 'local uikit=${UIKIT:-/uikit}' "$REMINDER" "reminder UIKIT override"
+
+echo "== phase2 does not source machorun guest_arch (macos11 must not clobber macos15)"
+if grep -n 'machorun/scripts/guest_arch.inc' "$PHASE2" | grep -v '^#' >/dev/null; then
+    # A comment is fine; an actual source is not.
+    if grep -E '^[[:space:]]*\. .*/machorun/scripts/guest_arch.inc' "$PHASE2" >/dev/null; then
+        die_test "phase2 sources machorun guest_arch.inc (would clobber TARGET)"
+    else
+        ok "phase2 does not source machorun guest_arch.inc"
+    fi
+else
+    ok "phase2 does not mention machorun guest_arch.inc"
+fi
+expect_grep 'full/scripts/guest_arch.inc' "$PHASE2" "phase2 sources full/ guest_arch"
+
+echo "== usage refuse"
+set +e
+out=$(bash "$PHASE2" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -q 'usage: bash scripts/x86/phase2.sh'; then
+    ok "phase2 with no args exits 2 with usage"
+else
+    die_test "phase2 no-args rc=$rc out=$(echo "$out" | head -2)"
+fi
+
+echo
+echo "test_phase2: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Phase 2 of the machorun x86_64 port: one operator command that takes a provisioned x86_64 Linux host from PR #7's landed phase-1 state to the real-app ladder under the ported loader.

```bash
bash scripts/x86/phase2.sh /opt/openuikit/x86-verify/openuikit
```

Idempotent. Prints `ENV_PREPARE <name> satisfied|cold-built|CANNOT_<MARKER>` lines and a final `RUNG_SCOREBOARD` whose denominators are the committed runners' (never invented here):

- **a.** `foundation-macho/tests/ud_guest_runner.swift` — **14** `check()` calls; `run_ud_guest.sh` / `run_ud_persist.sh`
- **b.** Focus widget + onboarding source-preservation + `otool $OTOOL_CPU` from `full/swiftui/build_focus_{widget,onboarding}_guest.sh`
- **c.** Reminder `windows=1 turns=3 paced=true` from `full/xcodeplan/build_and_run_reminder_scene_guest.sh`

Exit 2 if any CANNOT. Never fakes success, never weakens a gate, never overwrites `scratch/sysroot_fe4`, `scratch/mrroot_full`, or durable `opencombine-…/export/`. x86 outputs land **beside**: `sysroot_fe4-x86_64`, `mrroot_full-x86_64`, `export-x86_64/`.

`machorun/` source is untouched (`EXPECTED_INREPO_MACHORUN_TREE` pin).

## Measure first: libswiftCore-for-x86

Measured on this Cursor x86_64 VM (Swift 6.2.4, clang-18) **before** any later Swift guest work:

- `swiftcore-macho/artifacts/swift-macosx/` has only **arm64** `libswiftCore.dylib` + `Swift.swiftmodule/arm64-apple-macos.*`
- No stdlib source (`swiftcore-macho/swift`, `scratch/swift`, `/opt/swift-source` absent; no CMakeLists)
- `configure.sh` hardcodes `SWIFT_HOST_VARIANT_ARCH=aarch64`, `SWIFT_SDK_OSX_ARCHITECTURES=arm64`
- `swiftc -target x86_64-apple-macos15.0 -sdk scratch/sysroot_fe4` fails: `could not find module '_Concurrency' for target 'x86_64-apple-macos'; found: arm64-apple-macos`

Cross-building libswiftCore is the CMake+Ninja stdlib-only recipe in `swiftcore-macho/docs/BUILD_LOG.md`. **Do not stage the arm64 dylib under an x86 name.** Until an x86_64 slice exists, rungs a/b/c CANNOT with `CANNOT_BUILD_LIBSWIFTCORE_X86`.

## In-VM (this Cursor x86_64 VM) vs operator host

| step | exercised in-VM (compile/link) | operator x86 host only (execution) |
|---|---|---|
| measure libswiftCore-x86 | yes — reports the wall | same measurement; pass only if an x86 slice is present |
| `build.sh` loader + darwin | yes — ELF PIE loader + `MH_MAGIC_64 X86_64` libSystem | same |
| `build_objc4.sh` / `build_quartz.sh` | yes — unblocks the `objc` fixture | same |
| `build.sh tbd` | yes — after parking leftover arm64 staged swift dylibs beside `darwin/usr/lib-arm64-park/` so CHECK 4 is not a mixed-slice coin toss | same |
| `scripts/x86/stage_fe_sysroot.sh` | headers + x86 dylibs at `scratch/sysroot_fe4-x86_64`; **CANNOT_STAGE_XCODE_DARWIN_OVERLAYS** (Linux cannot materialize Darwin.swiftinterface) | same, unless the host's arm64 `sysroot_fe4` already has textual Darwin overlays to copy |
| `_FoundationCShims` | yes — `uuid.o` is X86_64 Mach-O | same |
| FoundationEssentials / collections / OpenCombine / `build_full.sh` | **CANNOT** — no x86 Swift.swiftmodule | needs x86 libswiftCore + Darwin overlays |
| rung a `run_ud_guest.sh` | CANNOT — needs x86 FE + named MACHORUN_ROOT + `ud_guest` binary (committed `link_ud_guest.sh`, not a second linker) | smoke **14/14** + persist under the ported loader |
| rung b Focus widget + onboarding | scripts retargeted; `NEEDS_X86_OPENCOMBINE` resolved by building `export-x86_64/` (arm64 object SHA untouched). This VM has no Focus pin. | same gates under the ported loader; normalized bundles from committed `onboarding_resources_proof.py` or `FOCUS_WIDGET_BUNDLE` |
| rung c Reminder scene | inner script no longer refuses x86-on-x86; still needs Reminder 22-source inventory | one `UIWindow` + three paced turns (`OPENUIKIT_HOST_TURNS=3`) |

In-VM scoreboard after the compile/link pass (exit 2, as required — rungs were not faked):

```
RUNG_SCOREBOARD a=CANNOT/blocked by substrate  b=CANNOT/blocked by substrate  c=CANNOT/blocked by substrate
denominators: a smoke 14/14 …; b widget+onboarding … otool X86_64 …; c windows=1 turns=3 paced=true
ENV_PREPARE_SUMMARY satisfied=8 cold-built=0 CANNOT=11 libswiftCore-x86=0
```

Satisfied in-VM: host, toolchain, loader, darwin, objc4, quartz, tbd, cshims. Arm64 `scratch/sysroot_fe4` and `scratch/mrroot_full` left byte-identical (epoch mtime vs new `*-x86_64` trees).

## Closing PR #7's phase-2 walls (additive)

1. Linux sysroot sibling `scripts/x86/stage_fe_sysroot.sh` — writes `scratch/sysroot_fe4-x86_64` only; refuses arm64 dylibs; copies textual Darwin overlays from the arm64 sysroot when present.
2. OpenCombine `scripts/x86/build_opencombine.sh` — `export-x86_64/` beside durable `export/`. Source hashes from `policy.json` still apply. Focus/core-package hash OpenCombine.o only when `ARCH=arm64`.
3. Focus pin `a2832521c1daa0c23419c73705ae043ed60c9791` is checked, not rewritten.
4. `build_full.sh` `require_macho_cpu` refuses a foreign-slice libswiftCore / FE overlay in an x86-named root.
5. Reminder native x86-on-x86 skips docker; `UIKIT` defaults to the in-repo checkout.

Static tests: `bash scripts/x86/test_phase2.sh` (47/47). `python3 full/swiftui/test_focus_widget_guest.py` (20/20).

Operator extras: `FOCUS_WIDGET_BUNDLE`, `FOCUS_ONBOARDING_BUNDLES`, `REMINDER_INVENTORY`, `REMINDER_SOURCE_ROOT`, `UD_GUEST_BIN`. Guest harness fonts still open `/w/build/swiftui-guest/fonts`; the widget script stages fonts there and under `$W/build/swiftui-guest/fonts`; phase2 tries `ln -sfn $W /w` and CANNOT if it cannot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

