### PR TITLE
Link libSwiftUI against FoundationEssentials in Focus SwiftUI guest gates

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -525,7 +525,7 @@ for install_name in "${FOUNDATION_RUNTIME_INSTALL_NAMES[@]}"; do
 done
 "${LD[@]}" -dylib -dead_strip -install_name @rpath/libSwiftUI.dylib \
     -rpath @loader_path -L"$PACKAGE" \
-    -lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols \
+    -lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols -lFoundationEssentials \
     -L"$MRROOT/darwin/usr/lib" -L/usr/lib/swift -lswiftCore \
     "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
     -L/usr/lib -lSystem -lobjc "$MRROOT/darwin/usr/lib/libquartz.dylib" \

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -568,7 +568,7 @@ echo "== package OpenUIKit as SwiftUI's UI framework dependency"
 
 echo "== package reusable libSwiftUI.dylib"
 "${LD[@]}" -dylib -install_name @rpath/libSwiftUI.dylib -rpath @loader_path \
-    -L"$PACKAGE" -lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols \
+    -L"$PACKAGE" -lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols -lFoundationEssentials \
     -L"$MRROOT/darwin/usr/lib" \
     -L/usr/lib/swift -lswiftCore "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
     -L/usr/lib -lSystem -lobjc "$MRROOT/darwin/usr/lib/libquartz.dylib" \
@@ -864,6 +864,7 @@ expected_swiftui_loads=$(printf '%s\n' \
     @rpath/libCombine.dylib \
     @rpath/libOpenCombine.dylib \
     @rpath/libSymbols.dylib \
+    @rpath/libFoundationEssentials.dylib \
     /usr/lib/swift/libswiftCore.dylib \
     /usr/lib/libswiftcompat.dylib \
     /usr/lib/libSystem.B.dylib \
@@ -1064,6 +1065,7 @@ expected_swiftui_inputs=$(printf '%s\n' \
     "$PACKAGE/libOpenCoreGraphics.dylib" \
     "$PACKAGE/libCombine.dylib" \
     "$PACKAGE/libSymbols.dylib" \
+    "$PACKAGE/libFoundationEssentials.dylib" \
     "$SYS/usr/lib/swift/libswiftCore.tbd" \
     "$SYS/usr/lib/libSystem.tbd" \
     "$SYS/usr/lib/libobjc.tbd" \

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -115,6 +115,14 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("compile the first-party Symbols value model while Foundation is hidden", text)
         self.assertIn("libSymbols Apple Symbols load count", text)
         self.assertIn("-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols", text)
+        swiftui_link = text.split(
+            "-install_name @rpath/libSwiftUI.dylib", 1
+        )[1].split("-install_name @rpath/libWidget.dylib", 1)[0]
+        self.assertIn(
+            "-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols "
+            "-lFoundationEssentials",
+            swiftui_link,
+        )
 
     def test_foundation_umbrella_preserves_one_essentials_provider(self) -> None:
         source = FOUNDATION.read_text()

--- a/full/swiftui/test_focus_package_guest.py
+++ b/full/swiftui/test_focus_package_guest.py
@@ -371,6 +371,10 @@ class FocusPackageGuestProofTests(unittest.TestCase):
         ):
             self.assertIn(f"lib{name}.dylib", text)
         self.assertIn("-lSymbols", text)
+        # Package copies the onboarding SwiftUI dylib; it does not relink it.
+        # Every SwiftUI-consuming link already passes -lFoundationEssentials.
+        self.assertNotIn("-install_name @rpath/libSwiftUI.dylib", text)
+        self.assertGreaterEqual(text.count("-lFoundationEssentials"), 6)
         self.assertIn("MH_MAGIC_64[[:space:]]+${OTOOL_CPU}", text)
         self.assertIn('PROBE_APP=$OUT/FocusPackageProbe.app', text)
         self.assertIn('"$PROBE_APP/Contents/MacOS/FocusPackageProbe"', text)

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -140,8 +140,24 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         self.assertIn('"guest LC_RPATH set"', text)
         self.assertIn("expected_openuikit_loads", text)
         self.assertIn("expected_swiftui_loads", text)
+        self.assertIn("expected_swiftui_inputs", text)
         self.assertIn("expected_symbols_loads", text)
         self.assertIn("expected_guest_loads", text)
+        swiftui_loads = text.split("expected_swiftui_loads=", 1)[1].split(
+            "expected_opencombine_loads=", 1
+        )[0]
+        self.assertIn("@rpath/libFoundationEssentials.dylib", swiftui_loads)
+        # FE's own Darwin/StringProcessing/Synchronization/errno loads stay on
+        # libFoundationEssentials, matching OpenUIKit's existing -lFoundationEssentials
+        # edge. The recursive runtime-closure manifest walks those at runtime.
+        self.assertNotIn("libswiftDarwin.dylib", swiftui_loads)
+        self.assertNotIn("libswift_StringProcessing.dylib", swiftui_loads)
+        self.assertNotIn("libswiftSynchronization.dylib", swiftui_loads)
+        self.assertNotIn("libswift_errno.dylib", swiftui_loads)
+        swiftui_inputs = text.split("expected_swiftui_inputs=", 1)[1].split(
+            "expected_opencombine_inputs=", 1
+        )[0]
+        self.assertIn('"$PACKAGE/libFoundationEssentials.dylib"', swiftui_inputs)
         self.assertIn("EXPECTED_PACKAGE_FILE_COUNT=101", text)
         self.assertIn("EXPECTED_PACKAGE_DIRECTORY_COUNT=12", text)
         self.assertIn('assert_exact_text "package top-level inventory"', text)
@@ -210,6 +226,11 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
             self.assertIn(dylib, text)
         self.assertIn("-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine", text)
         self.assertIn("-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols", text)
+        self.assertIn(
+            "-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols "
+            "-lFoundationEssentials",
+            text,
+        )
         self.assertIn("libSymbols Apple Symbols load count", text)
         self.assertIn("OPENCOMBINE_ROOT", text)
         self.assertIn("OpenCombine.o", helper)
@@ -245,6 +266,11 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         self.assertIn("run_missing_observation_control opencombine libOpenCombine.dylib", text)
         self.assertIn("run_missing_observation_control symbols libSymbols.dylib", text)
         self.assertIn("missing-$missing_name requester changed", text)
+        # Sibling copy lists already include FoundationEssentials (OpenUIKit and
+        # the guest load it too). A missing-FE control would be required-by
+        # libOpenUIKit, not libSwiftUI, so this change does not add one.
+        missing = text.split("run_missing_observation_control combine", 1)[1]
+        self.assertGreaterEqual(missing.count("libFoundationEssentials.dylib"), 3)
 
     def test_cross_process_pixels_and_packaged_artifacts_are_bracketed(self) -> None:
         text = BUILD.read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SwiftUI's `TextAttributes.swift` `#elseif canImport(FoundationEssentials)` attributed-text scopes (plus `Date` / `URL` / `AttributedString` / `FormatStyle` on the rest of the Foundation-hidden surface) make the SwiftUI module depend on FoundationEssentials. Measured failure on the ARM64 EC2 authority (main `9ce472a1`, after PR #8 and the two Foundation-visibility guards): `full/swiftui/build_focus_widget_guest.sh` now gets **past** SwiftUI compile — `swiftui.o` builds Foundation-hidden for the first time — and dies at `== package reusable libSwiftUI.dylib` with undefined FoundationEssentials symbols.

`libFoundationEssentials.dylib` is already packaged earlier in the same script. The reusable libSwiftUI link only passed `-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols`. This change is additive `-lFoundationEssentials` on that link (and the matching widget allowlists); existing pin hashes and refusal strings are unchanged. No package-file-count change (FE was already in the package).

Canonical branch for this change: `cursor/swiftui-foundationessentials-link` (`ec8176e0`). Same commit is on this PR's head.

## Undefined-symbol count

`ld64.lld-18 --error-limit=<value>` is confirmed present; **default is 20**.

This x86_64 VM cannot produce the authority `build/swiftui-guest/swiftui.o` (`CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST`: no Xcode Darwin overlays / FE module cache). So `--error-limit=0` was **not** re-run against the real object here.

**Authority floor (main `9ce472a1`, default cap): >20.** lld printed six named FoundationEssentials undefs referenced by `swiftui.o`, then `too many errors emitted, stopping now`. Named before truncation:

1. `_$s20FoundationEssentials4DateVMn`
2. `_$s20FoundationEssentials15AttributeScopesOMn`
3. `…AttributeScopeCodableConfigurationVMn` (reconstruction mangles `_$s20FoundationEssentials34AttributeScopeCodableConfigurationVMn`)
4. `…AttributeScopeMp` (reconstruction: `_$s20FoundationEssentials14AttributeScopeMp` — 14-char `AttributeScope`)
5. `…DecodingConfigurationProvidingMp` (reconstruction: `_$s20FoundationEssentials30DecodingConfigurationProvidingMp`)
6. `…EncodingConfigurationProvidingMp` (reconstruction: `_$s20FoundationEssentials30EncodingConfigurationProvidingMp`)

**Host reconstruction (not a substitute for the authority object):** `llvm-nm-18 -u` on a `-wmo` ELF compile of `TextAttributes.swift` plus Date/URL/AttributedString/FormatStyle probes against a declaration-only FoundationEssentials stub produced **14** distinct `FoundationEssentials` undefineds (nm has no 20-error cap). That surface is smaller than the complete SwiftUI directory WMO object (authority already shows `DateVMn` which the stub compile lowered as `Date.init()` instead). List:

```
_$s11FormatInput20FoundationEssentials0A5StylePTl
_$s20FoundationEssentials11FormatStyleTL
_$s20FoundationEssentials14AttributeScopeMp
_$s20FoundationEssentials14AttributeScopePAAE21decodingConfigurationAA0cd7CodableF0VvgZ
_$s20FoundationEssentials14AttributeScopePAAE21encodingConfigurationAA0cd7CodableF0VvgZ
_$s20FoundationEssentials15AttributeScopesO0A10AttributesOMn
_$s20FoundationEssentials15AttributeScopesOMn
_$s20FoundationEssentials16AttributedStringVACycfC
_$s20FoundationEssentials19AttributedStringKeyMp
_$s20FoundationEssentials30DecodingConfigurationProvidingMp
_$s20FoundationEssentials30EncodingConfigurationProvidingMp
_$s20FoundationEssentials34AttributeScopeCodableConfigurationVMn
_$s20FoundationEssentials3URLVACycfC
_$s20FoundationEssentials4DateVACycfC
```

**Count for the record: authority truncated at 20, real count >20; exact remainder needs `--error-limit=0` on the unfixed libSwiftUI link of the authority `swiftui.o`.** The additive `-lFoundationEssentials` resolves the whole FE set regardless of the remainder. Operator can capture the exact integer on ARM64 EC2 with the same argv as `== package reusable libSwiftUI.dylib`, plus `--error-limit=0`, without `-lFoundationEssentials`.

## Count pins

None. `EXPECTED_PACKAGE_FILE_COUNT=101`, `EXPECTED_PACKAGE_DIRECTORY_COUNT=12`, `EXPECTED_SYMBOLS_SWIFT_COUNT=1`, and every Focus/OpenCombine/font/resource SHA pin are unchanged. Refusal string unchanged:

```
CURSOR_ENV_CANNOT_EXECUTE_ARM64 host=x86_64 machorun=arm64-linux-native split=compile-link-static-in-vm/execution-arm64-ec2/macos-oracle-local-only
```

## Site-by-site edits

### `full/swiftui/build_focus_widget_guest.sh`

- **`-lFoundationEssentials` on `libSwiftUI`**: L571, same one-line `-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols -lFoundationEssentials` so existing test substrings still match.
- **Per-dylib recursive-runtime-closure allowlist**: `expected_swiftui_loads` gains `@rpath/libFoundationEssentials.dylib` L867. FE's own Darwin / `_StringProcessing` / `Synchronization` / `_errno` loads stay on `expected_foundationessentials_loads` (same as OpenUIKit's existing `-lFoundationEssentials` edge). The generated recursive closure walks those at runtime; it is not a second hardcoded SwiftUI load list.
- **Link-map object checks**: `expected_swiftui_inputs` gains `"$PACKAGE/libFoundationEssentials.dylib"` L1068.
- **`machorun: cannot find dylib` probe lists**: sibling copy lists already include `libFoundationEssentials.dylib` (L1240, L1273, L1346, L1350, L1354). No new missing-FE control: OpenUIKit already loads FE first, so a withheld-FE discriminator would be required-by `libOpenUIKit`, not `libSwiftUI`.

### `full/swiftui/build_focus_onboarding_guest.sh`

- **`-lFoundationEssentials` on `libSwiftUI`**: L528. Onboarding has no `expected_*_loads` / link-map allowlists. Guest link already passed `-lFoundationEssentials`.

The pre-existing `expected the complete seven-source SwiftUI directory` refusal is **unchanged**.

### `full/swiftui/build_focus_package_guest.sh`

Does **not** relink `libSwiftUI.dylib` (copies the onboarding package). Every SwiftUI-consuming link already passes `-lFoundationEssentials`. Static test now asserts that (`-install_name @rpath/libSwiftUI.dylib` absent; ≥6 `-lFoundationEssentials` consumer flags).

## Static results (this x86_64 VM)

- `bash -n`: **3/3** (`build_focus_widget_guest.sh`, `build_focus_onboarding_guest.sh`, `build_focus_package_guest.sh`).
- `python3 -m unittest full.swiftui.test_focus_widget_guest`: **21/21 OK**.
- `python3 -m unittest full.swiftui.test_focus_onboarding_guest`: **11/11 OK**.
- `python3 -m unittest full.swiftui.test_focus_package_guest`: **14/14** static teeth OK excluding the SnapKit-corpus attest. Full file is **14/15**; `test_resource_accessor_oracle_is_executable_and_fail_closed` errors because `scratch/xcodeplan-deps/SnapKit` is absent here (`cannot canonicalize an attest path`). Same failure against origin/main's package script.

## ARM64 authority

This VM is x86_64. The gates already refuse execution with:

```
CURSOR_ENV_CANNOT_EXECUTE_ARM64 host=x86_64 machorun=arm64-linux-native split=compile-link-static-in-vm/execution-arm64-ec2/macos-oracle-local-only
```

The operator runs `full/swiftui/build_focus_widget_guest.sh` on the ARM64 EC2 authority and reports back. Compile/link may proceed on this VM; execution cannot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

