### PR TITLE
Fix phase2 focus-pin false CANNOT on nested corpus checkout

### DIFF
--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -78,7 +78,11 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    only when `ARCH=arm64`; on x86 they require `MH_MAGIC_64 X86_64` instead of
    rewriting the SHA (`NEEDS_X86_OPENCOMBINE` until the x86 `.o` exists).
 3. Focus pin `a2832521c1daa0c23419c73705ae043ed60c9791` is checked, not
-   rewritten. Normalized bundles come from the committed
+   rewritten. The probe resolves `git rev-parse --show-toplevel` from
+   `scratch/ladder-corpus/focus-ios/focus-ios` (app subtree; git root is the
+   parent) with explicit `safe.directory` on that path and its parents, and
+   a CANNOT line always names `expected=` and `observed=` (plus `git_error=`
+   if git itself failed). Normalized bundles come from the committed
    `onboarding_resources_proof.py` or `FOCUS_WIDGET_BUNDLE`.
 4. `build_full.sh` / mrroot refuse to copy an arm64 `libswiftCore.dylib` into
    an x86-named root (`require_macho_cpu`).

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -43,3 +43,61 @@ phase2_is_elf_x86_loader() {
     [ -x "$f" ] || return 1
     file -b "$f" | grep -q 'ELF 64-bit LSB pie executable, x86-64'
 }
+
+phase2_flatten() {
+    tr '\n\t\r' '   ' | sed 's/  */ /g; s/^ //; s/ $//'
+}
+
+# git -C that names the start path and its parents as safe.directory.
+# Host bootstrap may have skipped `git config --global safe.directory` when
+# $HOME was unset (dubious-ownership). Do not require a .git directory on
+# the start path: ladder-corpus/focus-ios is the git root, focus-ios/focus-ios
+# is the app subtree.
+phase2_git() {
+    local dir=$1
+    shift
+    local abs parent grand
+    abs=$(cd "$dir" && pwd) || return 1
+    parent=$(dirname "$abs")
+    grand=$(dirname "$parent")
+    git -c "safe.directory=$abs" \
+        -c "safe.directory=$parent" \
+        -c "safe.directory=$grand" \
+        -C "$abs" "$@"
+}
+
+# Probe Focus pin. One line, never silent:
+#   MATCH toplevel=... observed=<sha>
+#   MISMATCH start=... toplevel=... expected=<sha> observed=<sha>
+#   ERROR start=... expected=<sha> observed=ABSENT|ERROR git_error=...
+# Resolves the git root with rev-parse --show-toplevel before comparing HEAD.
+phase2_probe_focus_pin() {
+    local start=$1 expected=$2
+    local err toplevel observed
+    if [ ! -d "$start" ]; then
+        printf 'ERROR start=%s expected=%s observed=ABSENT git_error=not a directory\n' \
+            "$start" "$expected"
+        return 1
+    fi
+    err=$(mktemp)
+    if ! toplevel=$(phase2_git "$start" rev-parse --show-toplevel 2>"$err"); then
+        printf 'ERROR start=%s expected=%s observed=ERROR git_error=%s\n' \
+            "$start" "$expected" "$(phase2_flatten < "$err")"
+        rm -f "$err"
+        return 1
+    fi
+    if ! observed=$(phase2_git "$toplevel" rev-parse HEAD 2>"$err"); then
+        printf 'ERROR start=%s toplevel=%s expected=%s observed=ERROR git_error=%s\n' \
+            "$start" "$toplevel" "$expected" "$(phase2_flatten < "$err")"
+        rm -f "$err"
+        return 1
+    fi
+    rm -f "$err"
+    if [ "$observed" = "$expected" ]; then
+        printf 'MATCH toplevel=%s observed=%s\n' "$toplevel" "$observed"
+        return 0
+    fi
+    printf 'MISMATCH start=%s toplevel=%s expected=%s observed=%s\n' \
+        "$start" "$toplevel" "$expected" "$observed"
+    return 1
+}

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -645,11 +645,15 @@ fi
 
 # Rung b: Focus widget + onboarding. Same source-preservation contracts.
 FOCUS_PIN=a2832521c1daa0c23419c73705ae043ed60c9791
-if [ -d "$FOCUS_REPO/.git" ] && [ "$(git -C "$FOCUS_REPO" rev-parse HEAD)" = "$FOCUS_PIN" ]; then
-    note focus-pin satisfied
-else
-    cannot focus-pin FOCUS_PIN "Focus checkout is not $FOCUS_PIN at $FOCUS_REPO"
-fi
+# Do not require a .git directory on the app subtree. The corpus git root is
+# the parent (scratch/ladder-corpus/focus-ios); focus-ios/focus-ios is the
+# application checkout inside it.
+# Probe names expected and observed on every refusal (including git errors).
+focus_pin_probe=$(phase2_probe_focus_pin "$FOCUS_REPO" "$FOCUS_PIN" || true)
+case "$focus_pin_probe" in
+    MATCH*) note focus-pin satisfied ;;
+    *) cannot focus-pin FOCUS_PIN "$focus_pin_probe" ;;
+esac
 
 find_widget_bundle() {
     local c recorded

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -162,6 +162,76 @@ else
     die_test "phase2 no-args rc=$rc out=$(echo "$out" | head -2)"
 fi
 
+echo "== focus-pin probe (nested git root + expected/observed + git_error)"
+if grep -F '[ -d "$FOCUS_REPO/.git" ]' "$PHASE2" >/dev/null; then
+    die_test "phase2 still gates on FOCUS_REPO/.git (app subtree is not the git root)"
+else
+    ok "phase2 does not require a .git directory on the Focus app subtree"
+fi
+expect_grep 'rev-parse --show-toplevel' "$COMMON" \
+    "probe resolves git toplevel before comparing HEAD"
+expect_grep 'safe.directory=' "$COMMON" \
+    "probe sets explicit safe.directory"
+expect_grep 'expected=%s observed=' "$COMMON" \
+    "ERROR line names expected and observed"
+expect_grep 'expected=%s observed=%s' "$COMMON" \
+    "MISMATCH line names expected and observed"
+
+# shellcheck source=common.inc
+. "$COMMON"
+
+PIN=a2832521c1daa0c23419c73705ae043ed60c9791
+WORK=$(mktemp -d /tmp/phase2-focus-pin.XXXXXX)
+cleanup_focus_pin() { rm -rf "$WORK"; }
+trap cleanup_focus_pin EXIT
+mkdir -p "$WORK/focus-ios/focus-ios"
+# Empty global config: simulate the host where $HOME-driven safe.directory
+# was never set. The probe's -c safe.directory=*parents must still work.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+git -c safe.directory="$WORK/focus-ios" -c init.defaultBranch=main init "$WORK/focus-ios" >/dev/null 2>&1
+git -C "$WORK/focus-ios" \
+    -c safe.directory="$WORK/focus-ios" \
+    -c user.email=phase2@test -c user.name=phase2 \
+    commit --allow-empty -m pin >/dev/null 2>&1
+git -C "$WORK/focus-ios" \
+    -c safe.directory="$WORK/focus-ios" \
+    commit --allow-empty --amend --no-edit \
+    --date=1970-01-01T00:00:00Z >/dev/null 2>&1 || true
+# Nested app subtree has no .git of its own.
+[ ! -e "$WORK/focus-ios/focus-ios/.git" ] || die_test "fixture child unexpectedly has .git"
+HEAD=$(git -c safe.directory="$WORK/focus-ios" -C "$WORK/focus-ios" rev-parse HEAD)
+
+report=$(phase2_probe_focus_pin "$WORK/focus-ios/focus-ios" "$HEAD" || true)
+case "$report" in
+    MATCH*"observed=$HEAD"*) ok "nested git root MATCH observed=$HEAD" ;;
+    *) die_test "nested MATCH expected, got: $report" ;;
+esac
+
+mismatch=$(phase2_probe_focus_pin "$WORK/focus-ios/focus-ios" "$PIN" || true)
+case "$mismatch" in
+    MISMATCH*"expected=$PIN"*"observed=$HEAD"*)
+        ok "nested MISMATCH names expected=$PIN observed=$HEAD"
+        ;;
+    *) die_test "nested MISMATCH expected, got: $mismatch" ;;
+esac
+
+missing=$(phase2_probe_focus_pin "$WORK/absent" "$PIN" || true)
+case "$missing" in
+    ERROR*"expected=$PIN"*"observed=ABSENT"*)
+        ok "missing dir ERROR names expected and observed=ABSENT"
+        ;;
+    *) die_test "missing ERROR expected, got: $missing" ;;
+esac
+
+nogit=$(phase2_probe_focus_pin "$WORK" "$PIN" || true)
+case "$nogit" in
+    ERROR*"expected=$PIN"*"observed=ERROR"*"git_error="*)
+        ok "non-repo ERROR includes git_error instead of folding into not-at-pin"
+        ;;
+    *) die_test "non-repo ERROR expected, got: $nogit" ;;
+esac
+
 echo
 echo "test_phase2: pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Real-host PHASE 2 on x86 EC2 (PR #9 merged) scored `satisfied=3 cold-built=8 CANNOT=9` as designed, except one **false refusal**:

```
ENV_PREPARE focus-pin CANNOT_FOCUS_PIN reason=Focus checkout is not a2832521… at …/scratch/ladder-corpus/focus-ios/focus-ios
```

On that same host, `git rev-parse HEAD` in the Focus checkout printed `a2832521c1daa0c23419c73705ae043ed60c9791` with a clean status. The gate compared against something other than what git reports.

Two causes, both hiding evidence:

1. **Wrong directory level.** The check required `.git` on `scratch/ladder-corpus/focus-ios/focus-ios`. That path is the **app subtree**. The git root is the parent (`scratch/ladder-corpus/focus-ios`). `[ -d "$FOCUS_REPO/.git" ]` was false, so git never ran, and the CANNOT line never named an observed HEAD.
2. **Dubious ownership / missing `safe.directory`.** Host bootstrap skipped `git config --global safe.directory` when `$HOME` was unset. An empty `$(git …)` would also fold into “not at pin” with stderr discarded.

A refusal that hides its evidence is the failure mode this repo catalogues. A false CANNOT is cheaper than a false pass, but it still costs a run.

## What changed

`phase2_probe_focus_pin` (in `scripts/x86/common.inc`):

- **(a)** Runs git with explicit `-c safe.directory=` for the start path and its parents. If git fails, the CANNOT line prints `git_error=` (flattened stderr) instead of “not at pin”.
- **(b)** Every refusal names **both** `expected=` and `observed=` (`ABSENT` / `ERROR` / the SHA).
- **(c)** Resolves the git root with `git -C <path> rev-parse --show-toplevel` before comparing HEAD. Does not require `.git` on the app subtree.

`FOCUS_REPO` for widget/onboarding **source paths** is still `…/focus-ios/focus-ios`. Only the pin probe walks up to the git root. Pin SHA is unchanged: `a2832521c1daa0c23419c73705ae043ed60c9791`. No `machorun/` edits.

## Tests

`bash scripts/x86/test_phase2.sh` — nested fixture (git root at `focus-ios/`, app subtree `focus-ios/focus-ios` with no `.git`), `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_NOSYSTEM=1`:

- MATCH from the nested subtree
- MISMATCH names both SHAs
- missing dir → `observed=ABSENT`
- non-repo → `git_error=` instead of folding into not-at-pin

```
test_phase2: pass=56 fail=0
```

[phase2 focus-pin probe tests](https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_focus_pin_probe_tests.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

