### PR TITLE
Classify SwiftUI foreign-type conformances by protocol module

### DIFF
--- a/full/swiftui/focus_widget_guest_attest.pl
+++ b/full/swiftui/focus_widget_guest_attest.pl
@@ -489,6 +489,71 @@ sub objc_classifier_selftest {
         ' negatives=', scalar(@negative), "\n";
 }
 
+sub conformance_classifier_selftest {
+    my (@args) = @_;
+    my $demangle = 'swift-demangle';
+    GetOptionsFromArray(\@args, 'demangle=s' => \$demangle)
+        or fail('invalid conformance-classifier-selftest options');
+    fail('conformance-classifier-selftest takes no positional arguments') if @args;
+    fail('conformance-classifier-selftest requires --demangle')
+        unless defined($demangle) && length $demangle;
+
+    my %definition_owner = (
+        SwiftUI => 'libSwiftUI',
+        OpenUIKit => 'libOpenUIKit',
+        OpenCoreGraphics => 'libOpenCoreGraphics',
+        Combine => 'libCombine',
+        OpenCombine => 'libOpenCombine',
+    );
+
+    # Authority reverse-ownership failure on main 8e12b714: libSwiftUI
+    # defines this Mc for `extension CGFloat: _OpenVectorArithmetic`.
+    my @positive = (
+        [
+            '_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADMc',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
+        [
+            '_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADWP',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
+        [
+            '_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADWp',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
+    );
+    for my $fixture (@positive) {
+        my ($symbol, $expected_module, $defining_image) = @$fixture;
+        my ($actual) = classify_framework_symbol($demangle, $symbol);
+        fail("conformance classifier expected $expected_module for $symbol, got "
+            . (defined $actual ? $actual : 'undef'))
+            unless defined($actual) && $actual eq $expected_module;
+        fail("reverse ownership rejected defining image $defining_image for $symbol")
+            unless $definition_owner{$actual} eq $defining_image;
+    }
+
+    # Nominal type descriptor for the same foreign CGFloat: still owned by
+    # OpenCoreGraphics. libSwiftUI defining it must keep failing.
+    my @negative = (
+        [ '_$s16OpenCoreGraphics7CGFloatVMn', 'OpenCoreGraphics', 'libSwiftUI' ],
+    );
+    for my $fixture (@negative) {
+        my ($symbol, $expected_module, $wrong_image) = @$fixture;
+        my ($actual) = classify_framework_symbol($demangle, $symbol);
+        fail("foreign classifier expected $expected_module for $symbol, got "
+            . (defined $actual ? $actual : 'undef'))
+            unless defined($actual) && $actual eq $expected_module;
+        fail("reverse ownership failed to reject $wrong_image defining $actual symbol $symbol")
+            if $definition_owner{$actual} eq $wrong_image;
+    }
+
+    print 'CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=', scalar(@positive),
+        ' negatives=', scalar(@negative), "\n";
+}
+
 sub prefixed_swift_module {
     my ($symbol) = @_;
     return 'SwiftUI' if $symbol =~ /^_?\$s7SwiftUI/;
@@ -507,8 +572,33 @@ sub framework_tokens {
         qw(SwiftUI OpenUIKit OpenCoreGraphics Combine OpenCombine);
 }
 
+# Protocol-conformance descriptors (`Mc`) and witness tables (`WP` / `Wp`)
+# mangle the conforming TYPE's module first. The module that emitted the
+# symbol is the one that declared the conformance; classify by the PROTOCOL
+# module from swift-demangle, not by slicing the mangled name. Reverse
+# ownership then treats a matching defining dylib as the symbol's owner.
+sub conformance_protocol_module {
+    my ($demangle, $symbol) = @_;
+    return (undef, undef) unless $symbol =~ /(?:Mc|WP|Wp)\z/;
+    my $expanded = capture_command($demangle, '--compact', $symbol);
+    $expanded =~ s/[\r\n]+\z//;
+    fail("demangler returned multiple lines for $symbol") if $expanded =~ /[\r\n]/;
+    my $modules = join('|', map { quotemeta($_->[0]) } @FRAMEWORK_MODULES);
+    if ($expanded =~
+        /^(?:protocol conformance descriptor|protocol witness table(?: pattern)?) for .+ : ($modules)\./)
+    {
+        return ($1, $expanded);
+    }
+    return (undef, $expanded);
+}
+
 sub classify_framework_symbol {
     my ($demangle, $symbol) = @_;
+    my ($conformance_module, $conformance_expanded) =
+        conformance_protocol_module($demangle, $symbol);
+    return ($conformance_module, $conformance_expanded)
+        if defined $conformance_module;
+
     my $prefix = prefixed_swift_module($symbol);
     return ($prefix, undef) if defined $prefix;
 
@@ -708,6 +798,8 @@ if ($command eq 'inventory') {
     provider_command(@ARGV);
 } elsif ($command eq 'objc-classifier-selftest') {
     objc_classifier_selftest(@ARGV);
+} elsif ($command eq 'conformance-classifier-selftest') {
+    conformance_classifier_selftest(@ARGV);
 } else {
-    fail('usage: focus_widget_guest_attest.pl inventory|closure|providers|objc-classifier-selftest [options]');
+    fail('usage: focus_widget_guest_attest.pl inventory|closure|providers|objc-classifier-selftest|conformance-classifier-selftest [options]');
 }

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -511,6 +511,9 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
         self.assertIn("unclassified framework-bearing symbol", helper)
         self.assertIn("associated type descriptor", helper)
         self.assertIn("extension in", helper)
+        self.assertIn("protocol conformance descriptor", helper)
+        self.assertIn("protocol witness table", helper)
+        self.assertIn("conformance_protocol_module", helper)
         self.assertIn("^_OBJC_(?:CLASS|METACLASS)_\\$__TtC", helper)
         self.assertIn("^_OBJC_IVAR_\\$__TtC", helper)
         self.assertIn("for (1 .. $nested_count + 2)", helper)
@@ -529,6 +532,26 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
             result.stdout,
             "OBJC_CLASSIFIER_SELFTEST_OK positives=7 negatives=13\n",
         )
+
+    def test_conformance_descriptors_are_owned_by_the_protocol_module(self) -> None:
+        helper = ATTEST.read_text()
+        exact = (
+            "_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADMc"
+        )
+        self.assertIn(exact, helper)
+        self.assertIn("_$s16OpenCoreGraphics7CGFloatVMn", helper)
+        self.assertIn("conformance-classifier-selftest", helper)
+        result = subprocess.run(
+            ["perl", str(ATTEST), "conformance-classifier-selftest"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.stdout,
+            "CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=3 negatives=1\n",
+        )
+        self.assertEqual(result.stderr, "")
 
     def test_adversarial_resume_matrix_covers_reviewed_tamper_classes(self) -> None:
         text = ADVERSARIAL.read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The ARM64 Focus widget gate on main `8e12b714` now passes every compile/link/closure step and dies in `focus_widget_guest_attest.pl`:

```
focus_widget_guest_attest: reverse ownership violation: libSwiftUI defines OpenCoreGraphics symbol _$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADMc
```

That `Mc` is the protocol-conformance descriptor for `extension CGFloat: _OpenVectorArithmetic` in `uikit/Sources/SwiftUI/Compatibility.swift`. Swift emits the conformance in the module that declared it (SwiftUI). The mangling leads with the conforming **type** module (`OpenCoreGraphics`), so prefix classification treated a legitimate local protocol conformance as a foreign OpenCoreGraphics definition.

This change classifies `Mc` / `WP` / `Wp` by the **protocol** module from `swift-demangle --compact`, not by slicing the mangled name. When that protocol module's defining dylib is the image under audit, reverse-ownership accepts the symbol. Nominal types and functions still use the type-module rule: `_$s16OpenCoreGraphics7CGFloatVMn` defined by `libSwiftUI` still fails.

No pin hashes or refusal strings change. No sibling attest script implements reverse-ownership (only this Perl helper does). Canonical branch: `cursor/swiftui-conformance-ownership` (`dc4048f1`).

## Demangle of the authority symbol

```
protocol conformance descriptor for OpenCoreGraphics.CGFloat : SwiftUI._OpenVectorArithmetic in SwiftUI
```

Witness-table siblings demangle to the same protocol module:

```
protocol witness table for OpenCoreGraphics.CGFloat : SwiftUI._OpenVectorArithmetic in SwiftUI
protocol witness table pattern for OpenCoreGraphics.CGFloat : SwiftUI._OpenVectorArithmetic in SwiftUI
```

## Site-by-site

### `full/swiftui/focus_widget_guest_attest.pl`

- `conformance_protocol_module` (L580): if the symbol ends in `Mc` / `WP` / `Wp`, run `swift-demangle --compact` and take the module of `Type : Module.Protocol`.
- `classify_framework_symbol` (L595) consults that helper **before** the type-module prefix, so reverse-ownership sees SwiftUI for the authority `Mc`.
- `conformance-classifier-selftest` (L492): exact authority `Mc` (+ `WP` / `Wp`) as positives owned by `libSwiftUI`; `_$s16OpenCoreGraphics7CGFloatVMn` as the negative (still OpenCoreGraphics, so `libSwiftUI` remains forbidden).

### `full/swiftui/test_focus_widget_guest.py`

- `test_conformance_descriptors_are_owned_by_the_protocol_module` runs the selftest (`positives=3 negatives=1`).
- Provider-gate source teeth also require `protocol conformance descriptor` / `protocol witness table` / `conformance_protocol_module`.

## Static results (this x86_64 VM)

- `perl -c full/swiftui/focus_widget_guest_attest.pl`: syntax OK
- `perl … conformance-classifier-selftest`: `CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=3 negatives=1`
- `python3 -m unittest full.swiftui.test_focus_widget_guest`: **22/22 OK** (was 21/21; one new test)

## ARM64 authority

This VM is x86_64. The gates already refuse execution with:

```
CURSOR_ENV_CANNOT_EXECUTE_ARM64 host=x86_64 machorun=arm64-linux-native split=compile-link-static-in-vm/execution-arm64-ec2/macos-oracle-local-only
```

The operator re-runs `full/swiftui/build_focus_widget_guest.sh` on the ARM64 EC2 authority. Compile/link/attest may proceed on this VM; execution cannot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

