### PR TITLE
Restage x86 sysroot from inputs; Darwin maps, os-module, canonical MC

### DIFF
--- a/full/foundation/build_os_module.sh
+++ b/full/foundation/build_os_module.sh
@@ -6,9 +6,10 @@ set -euo pipefail
 W=${W:-/w}
 SYS=${SYS:-$W/scratch/sysroot_fe4}
 OUT=${OUT:-$W/scratch/fe4_os}
+MC=${MC:-$W/scratch/modcache_fe4}
 mkdir -p "$OUT"
 swiftc -target "${TARGET:-arm64-apple-macos15.0}" -sdk "$SYS" \
-    -module-cache-path "$W/scratch/modcache_fe4" \
+    -module-cache-path "$MC" \
     -module-name os -wmo -parse-as-library \
     -runtime-compatibility-version none \
     -emit-module -emit-module-path "$OUT/os.swiftmodule" \

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -72,7 +72,7 @@ this host. One-command recipe: `docs/X86_64.md` §3 /
 | `build.sh` loader + darwin + tbd | yes | same |
 | `build_objc4.sh` / `build_quartz.sh` | yes — unblocks the `objc` fixture | same |
 | `scripts/x86/stage_fe_sysroot.sh` | headers + x86 dylibs + Darwin family modulemaps + x86 `libswiftCore`/`Swift.swiftmodule`/`_Builtin_float` into `usr/lib/swift`; restages when input shas change; `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` unless textual Darwin overlays exist in the arm64 `sysroot_fe4` | same |
-| FoundationEssentials / collections / OpenCombine / `build_full.sh` | x86 `libswiftCore` + `Swift.swiftmodule` are in artifacts; `_Concurrency` overlay is not (libdispatch wall). Darwin overlays still `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` | needs x86 libswiftCore + `_Concurrency` + Darwin overlays |
+| FoundationEssentials / collections / OpenCombine / `build_full.sh` | x86 `libswiftCore` + `Swift.swiftmodule` are in artifacts; `_Concurrency` overlay is not (libdispatch wall). `os-module-x86` is built into `build/full-x86_64/foundation/os` before `build_fe.sh`. `fe-imports` names missing `_Concurrency`/`_StringProcessing`/… instead of compiling 202 files | needs x86 libswiftCore + `_Concurrency` + `_StringProcessing` + Darwin overlays + os-module |
 | rung a `run_ud_guest.sh` | cannot run a real FE guest without x86 libswiftCore + named MACHORUN_ROOT + `ud_guest` binary | smoke 14/14 + persist under the ported loader |
 | rung b Focus widget + onboarding | scripts retargeted; `NEEDS_X86_OPENCOMBINE` resolved by `export-x86_64/` (arm64 SHA untouched) | same gates under the ported loader |
 | rung c Reminder scene | inner script no longer refuses x86-on-x86; still needs Reminder 22-source inventory | one `UIWindow` + three paced turns |
@@ -91,7 +91,8 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    `usr/lib/swift`. Idempotency keys on input shas (artifact, generator,
    overlay text) written to `.phase2-stage-inputs`; a sysroot staged before
    those inputs existed is restaged, and the CANNOT/cold-built line names
-   which input changed.
+   which input changed. Apple's `os.swiftmodule` is not copied (FE uses
+   `full/foundation/os-module`).
 2. OpenCombine: `scripts/x86/build_opencombine.sh` writes `export-x86_64/`.
    Source hashes from `policy.json` still apply. Object SHAs stay the arm64
    durable pin in `export/`. Focus/core-package scripts hash those objects
@@ -106,6 +107,13 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    `onboarding_resources_proof.py` or `FOCUS_WIDGET_BUNDLE`.
 4. `build_full.sh` / mrroot refuse to copy an arm64 `libswiftCore.dylib` into
    an x86-named root (`require_macho_cpu`).
-5. Guest harness fonts still open `/w/build/swiftui-guest/fonts`. The widget
+5. `os-module-x86` runs `full/foundation/build_os_module.sh` with
+   `TARGET=x86_64-apple-macos15.0` and `OUT=build/full-x86_64/foundation/os`
+   (beside arm64 `scratch/fe4_os`). `build_fe.sh` gets `OSMOD` so
+   `Calendar.swift:14 import os` resolves. Before that compile, `ENV_PREPARE
+   fe-imports` probes Darwin/os/Swift/_Builtin_float/_StringProcessing/_Concurrency
+   (required) and Synchronization (optional/`canImport`) in the x86 sysroot
+   and refuses in one line if any required module is absent.
+6. Guest harness fonts still open `/w/build/swiftui-guest/fonts`. The widget
    script stages fonts there and under `$W/build/swiftui-guest/fonts`; phase2
    tries `ln -sfn $W /w` and CANNOT if it cannot.

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -61,8 +61,13 @@ cshims).
 
 The configure hardcoding is gone: `swiftcore-macho/scripts/guest_arch.inc`
 keeps the arm64 argv as `SWIFTCORE_DARWIN_ARCH=arm64` and selects x86_64 on
-this host. One-command recipe: `docs/X86_64.md` §3 /
-`bash swiftcore-macho/scripts/build_stdlib.sh`.
+this host. One-command recipe: `docs/X86_64.md` §3:
+
+```bash
+NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
+  bash swiftcore-macho/scripts/build_stdlib.sh
+```
 
 ## In-VM (this Cursor x86_64 VM) vs operator host
 

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -71,7 +71,7 @@ this host. One-command recipe: `docs/X86_64.md` §3 /
 | measure libswiftCore-x86 | yes — reports the wall | same measurement; pass only if an x86 slice is present |
 | `build.sh` loader + darwin + tbd | yes | same |
 | `build_objc4.sh` / `build_quartz.sh` | yes — unblocks the `objc` fixture | same |
-| `scripts/x86/stage_fe_sysroot.sh` | headers + x86 dylibs; `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` unless textual Darwin overlays exist in the arm64 `sysroot_fe4` | same |
+| `scripts/x86/stage_fe_sysroot.sh` | headers + x86 dylibs + Darwin family modulemaps + x86 `libswiftCore`/`Swift.swiftmodule`/`_Builtin_float` into `usr/lib/swift`; restages when input shas change; `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` unless textual Darwin overlays exist in the arm64 `sysroot_fe4` | same |
 | FoundationEssentials / collections / OpenCombine / `build_full.sh` | x86 `libswiftCore` + `Swift.swiftmodule` are in artifacts; `_Concurrency` overlay is not (libdispatch wall). Darwin overlays still `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` | needs x86 libswiftCore + `_Concurrency` + Darwin overlays |
 | rung a `run_ud_guest.sh` | cannot run a real FE guest without x86 libswiftCore + named MACHORUN_ROOT + `ud_guest` binary | smoke 14/14 + persist under the ported loader |
 | rung b Focus widget + onboarding | scripts retargeted; `NEEDS_X86_OPENCOMBINE` resolved by `export-x86_64/` (arm64 SHA untouched) | same gates under the ported loader |
@@ -83,7 +83,15 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
 
 1. Linux sysroot sibling: `scripts/x86/stage_fe_sysroot.sh` writes
    `scratch/sysroot_fe4-x86_64` only. Copies textual Darwin overlays from the
-   arm64 sysroot when present; refuses arm64 dylibs.
+   arm64 sysroot when present; refuses arm64 dylibs. After the ObjectiveC
+   `module.modulemap` it runs `machorun/scripts/gen_darwin_modulemap.py` against
+   the x86 sysroot (Linux fallback: copy the pruned Darwin-family maps from the
+   arm64 sysroot) and stages `libswiftCore.dylib`, `Swift.swiftmodule/x86_64-apple-macos.*`,
+   and `_Builtin_float.swiftmodule/x86_64-apple-macos.*` into
+   `usr/lib/swift`. Idempotency keys on input shas (artifact, generator,
+   overlay text) written to `.phase2-stage-inputs`; a sysroot staged before
+   those inputs existed is restaged, and the CANNOT/cold-built line names
+   which input changed.
 2. OpenCombine: `scripts/x86/build_opencombine.sh` writes `export-x86_64/`.
    Source hashes from `policy.json` still apply. Object SHAs stay the arm64
    durable pin in `export/`. Focus/core-package scripts hash those objects

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -101,3 +101,159 @@ phase2_probe_focus_pin() {
         "$start" "$toplevel" "$expected" "$observed"
     return 1
 }
+
+# Idempotency for scratch/sysroot_fe4-x86_64 keys on INPUT content, not on the
+# output directory existing. A sysroot staged before x86 libswiftCore landed
+# would otherwise be reused while OpenCombine looks in usr/lib/swift and finds
+# nothing. Recipe bump forces a restage when the stager itself gains steps.
+PHASE2_SYSROOT_RECIPE=stage_fe_sysroot_x86.1
+PHASE2_SYSROOT_STAMP=.phase2-stage-inputs
+
+phase2_sha_or_absent() {
+    local f=$1
+    if [ -f "$f" ]; then
+        sha256sum "$f" | awk '{print $1}'
+    else
+        printf 'ABSENT\n'
+    fi
+}
+
+# Prefer the x86_64 Darwin.swiftinterface the overlays already ship; fall back
+# to the arm64 slice (same text family) or a loose Darwin.swiftinterface.
+phase2_arm_overlay_interface() {
+    local arm=$1 f
+    for f in \
+        "$arm/usr/lib/swift/Darwin.swiftmodule/x86_64-apple-macos.swiftinterface" \
+        "$arm/usr/lib/swift/Darwin.swiftmodule/arm64-apple-macos.swiftinterface" \
+        "$arm/usr/lib/swift/Darwin.swiftinterface"
+    do
+        if [ -f "$f" ]; then
+            printf '%s\n' "$f"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# phase2_sysroot_input_lines <libswiftCore> <Swift.swiftmodule> <_Builtin_float.swiftmodule>
+#                          <gen_darwin_modulemap.py> <Darwin.swiftinterface> <Darwin.modulemap>
+phase2_sysroot_input_lines() {
+    printf 'recipe=%s\n' "$PHASE2_SYSROOT_RECIPE"
+    printf 'libswiftCore=%s\n' "$(phase2_sha_or_absent "$1")"
+    printf 'Swift.swiftmodule=%s\n' "$(phase2_sha_or_absent "$2")"
+    printf '_Builtin_float.swiftmodule=%s\n' "$(phase2_sha_or_absent "$3")"
+    printf 'gen_darwin_modulemap.py=%s\n' "$(phase2_sha_or_absent "$4")"
+    printf 'Darwin.swiftinterface=%s\n' "$(phase2_sha_or_absent "$5")"
+    printf 'Darwin.modulemap=%s\n' "$(phase2_sha_or_absent "$6")"
+}
+
+phase2_write_sysroot_stamp() {
+    local dest=$1
+    shift
+    phase2_sysroot_input_lines "$@" > "$dest"
+}
+
+# Print "key old->new" (and stamp=ABSENT). Return 0 iff stamp matches expected.
+phase2_sysroot_stamp_diff() {
+    local stamp=$1
+    shift
+    local expected key val old changed=0
+    expected=$(phase2_sysroot_input_lines "$@")
+    if [ ! -f "$stamp" ]; then
+        printf 'stamp=ABSENT\n'
+        return 1
+    fi
+    while IFS='=' read -r key val; do
+        [ -n "$key" ] || continue
+        old=$(awk -F= -v k="$key" '$1==k { print substr($0, index($0,"=")+1); exit }' "$stamp")
+        [ -n "$old" ] || old=ABSENT
+        if [ "$old" != "$val" ]; then
+            printf '%s %s->%s\n' "$key" "$old" "$val"
+            changed=1
+        fi
+    done <<EOF
+$expected
+EOF
+    [ "$changed" -eq 0 ]
+}
+
+# phase2_sysroot_complete <sys> <need_core 0|1> <need_builtin 0|1>
+# Overlays + Darwin.modulemap + x86 libSystem, plus staged Swift pieces when
+# those artifacts exist. A tree that is only "headers and Darwin.swiftmodule"
+# is not complete once x86 libswiftCore is in-tree.
+phase2_sysroot_complete() {
+    local sys=$1 need_core=$2 need_bf=$3
+    [ -d "$sys/usr/include" ] || return 1
+    [ -f "$sys/usr/lib/libSystem.B.dylib" ] || return 1
+    phase2_is_x86_macho "$sys/usr/lib/libSystem.B.dylib" || return 1
+    { [ -d "$sys/usr/lib/swift/Darwin.swiftmodule" ] \
+        || [ -f "$sys/usr/lib/swift/Darwin.swiftinterface" ]; } || return 1
+    [ -f "$sys/usr/include/Darwin.modulemap" ] || return 1
+    if [ "$need_core" = 1 ]; then
+        [ -f "$sys/usr/lib/swift/libswiftCore.dylib" ] || return 1
+        phase2_is_x86_macho "$sys/usr/lib/swift/libswiftCore.dylib" || return 1
+    fi
+    if [ "$need_bf" = 1 ]; then
+        { [ -f "$sys/usr/lib/swift/_Builtin_float.swiftmodule/x86_64-apple-macos.swiftmodule" ] \
+            || [ -f "$sys/usr/lib/swift/_Builtin_float.swiftmodule/x86_64-apple-macos.swiftinterface" ]; } \
+            || return 1
+    fi
+    return 0
+}
+
+phase2_copy_darwin_modulemaps_from_arm() {
+    local sys=$1 arm=$2
+    local m base copied=0 line
+    [ -d "$arm/usr/include" ] || return 1
+    mkdir -p "$sys/usr/include"
+    for m in "$arm"/usr/include/*.modulemap; do
+        [ -f "$m" ] || continue
+        base=$(basename "$m")
+        [ "$base" = module.modulemap ] && continue
+        cp "$m" "$sys/usr/include/$base"
+        copied=$((copied + 1))
+    done
+    if [ -f "$arm/usr/include/module.modulemap" ] && [ -f "$sys/usr/include/module.modulemap" ]; then
+        while IFS= read -r line; do
+            grep -qxF "$line" "$sys/usr/include/module.modulemap" && continue
+            printf '%s\n' "$line" >> "$sys/usr/include/module.modulemap"
+        done < <(grep -E '^(extern module |// Appended by machorun)' \
+            "$arm/usr/include/module.modulemap" || true)
+    fi
+    echo "  copied $copied Darwin-family modulemaps from $arm"
+    [ "$copied" -gt 0 ]
+}
+
+# Mirror full/foundation/stage_fe_sysroot.sh: base module.modulemap is already
+# written; run gen_darwin_modulemap.py against THIS sysroot. The generator
+# reads Xcode, so on Linux it fails; then copy the pruned family from the arm64
+# sysroot (same headers, already generated on macOS). Print git/python errors
+# instead of folding them into "not at pin" / "overlays absent".
+phase2_install_darwin_modulemaps() {
+    local sys=$1 arm=$2 gen=$3
+    local err rc
+    mkdir -p "$sys/usr/include"
+    if [ -f "$gen" ]; then
+        err=$(mktemp)
+        set +e
+        python3 "$gen" "$sys" >"$err" 2>&1
+        rc=$?
+        set -e
+        if [ "$rc" -eq 0 ] && [ -f "$sys/usr/include/Darwin.modulemap" ]; then
+            echo "  Darwin family: generated by gen_darwin_modulemap.py against $sys"
+            rm -f "$err"
+            return 0
+        fi
+        echo "  gen_darwin_modulemap.py exit ${rc:-ABSENT} ($(phase2_flatten < "$err")); copying pruned maps from arm64 sysroot"
+        rm -f "$err"
+    else
+        echo "  gen_darwin_modulemap.py ABSENT at $gen; copying pruned maps from arm64 sysroot"
+    fi
+    phase2_copy_darwin_modulemaps_from_arm "$sys" "$arm" || true
+    if [ -f "$sys/usr/include/Darwin.modulemap" ]; then
+        echo "  Darwin.modulemap present"
+        return 0
+    fi
+    echo "  no Darwin.modulemap (generator needs Xcode; arm64 sysroot had none to copy)"
+    return 1
+}

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -257,3 +257,90 @@ phase2_install_darwin_modulemaps() {
     echo "  no Darwin.modulemap (generator needs Xcode; arm64 sysroot had none to copy)"
     return 1
 }
+
+# Swift overlay or local -I module for $name, requiring the guest module triple
+# (x86_64-apple-macos), never an arm64 slice under an x86 name.
+phase2_swift_module_present() {
+    local name=$1
+    local root=$2
+    local triple=${3:-${SWIFT_MODULE_TRIPLE:-x86_64-apple-macos}}
+    local dir
+    [ -n "$root" ] || return 1
+    if [ -d "$root/usr/lib/swift" ]; then
+        dir=$root/usr/lib/swift
+    else
+        dir=$root
+    fi
+    [ -f "$dir/$name.swiftmodule" ] && return 0
+    [ -f "$dir/$name.swiftinterface" ] && return 0
+    [ -f "$dir/$name.swiftmodule/$triple.swiftmodule" ] && return 0
+    [ -f "$dir/$name.swiftmodule/$triple.swiftinterface" ] && return 0
+    return 1
+}
+
+# FE import census before the 202-file compile. One line, never silent:
+#   MATCH present=... optional_absent=...
+#   MISSING present=... absent=... optional_absent=...
+# Required (compile fails if missing on the Darwin path): Darwin, os, Swift,
+# _Builtin_float, _StringProcessing (Regex in URLTemplate/RegexPatternCache;
+# build_fe.sh does not pass -disable-implicit-string-processing-module-import),
+# _Concurrency (Swift.swiftmodule / stdlib).
+# Optional (canImport-guarded in standalone FE): Synchronization.
+# os is the local module at OSMOD, not Apple's overlay.
+# phase2_probe_fe_imports <sysroot> [osmod]
+phase2_probe_fe_imports() {
+    local sys=$1 osmod=${2:-}
+    local triple=${SWIFT_MODULE_TRIPLE:-x86_64-apple-macos}
+    local present="" absent="" opt_absent=""
+    local name ok
+
+    _fe_add() {
+        local bucket=$1 item=$2
+        if [ -z "${!bucket}" ]; then
+            eval "$bucket=\$item"
+        else
+            eval "$bucket=\${!bucket},\$item"
+        fi
+    }
+
+    for name in Darwin os Swift _Builtin_float _StringProcessing _Concurrency; do
+        ok=0
+        case "$name" in
+            Darwin)
+                if phase2_swift_module_present Darwin "$sys" "$triple" \
+                    && [ -f "$sys/usr/include/Darwin.modulemap" ]; then
+                    ok=1
+                fi
+                ;;
+            os)
+                if phase2_swift_module_present os "$osmod" "$triple"; then
+                    ok=1
+                fi
+                ;;
+            *)
+                if phase2_swift_module_present "$name" "$sys" "$triple"; then
+                    ok=1
+                fi
+                ;;
+        esac
+        if [ "$ok" -eq 1 ]; then
+            _fe_add present "$name"
+        else
+            _fe_add absent "$name"
+        fi
+    done
+    name=Synchronization
+    if phase2_swift_module_present Synchronization "$sys" "$triple"; then
+        _fe_add present Synchronization
+    else
+        _fe_add opt_absent Synchronization
+    fi
+    unset -f _fe_add
+    if [ -n "$absent" ]; then
+        printf 'MISSING present=%s absent=%s optional_absent=%s\n' \
+            "${present:--}" "$absent" "${opt_absent:--}"
+        return 1
+    fi
+    printf 'MATCH present=%s optional_absent=%s\n' "$present" "${opt_absent:--}"
+    return 0
+}

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -114,6 +114,13 @@ case "$swift_ver" in
     *6.2.4*) note toolchain satisfied ;;
     *) cannot toolchain SWIFT_VERSION "swiftc is '$swift_ver', need Swift 6.2.4" ; exit 2 ;;
 esac
+# Overlay / stdlib scripts source swiftcore-macho/scripts/guest_arch.inc, which
+# used to look only at /opt/swift624 and /usr/bin. Export the toolchain we
+# actually found so SWIFT_TOOLCHAIN wins there.
+if [ -z "${SWIFT_TOOLCHAIN:-}" ]; then
+    SWIFT_TOOLCHAIN=$(cd "$(dirname "$(command -v swiftc)")/.." && pwd)
+    export SWIFT_TOOLCHAIN
+fi
 
 # ---------------------------------------------------------------------------
 # 1. MEASURE libswiftCore-for-x86 FIRST. Do not spend the rest of the ladder
@@ -283,35 +290,61 @@ ensure_tbd || true
 
 # ---------------------------------------------------------------------------
 # 3. x86 sysroot beside arm64 sysroot_fe4
+# Idempotency keys on INPUT shas (libswiftCore artifact, modulemap generator,
+# Darwin overlay text), not on the output directory existing. A sysroot staged
+# before x86 libswiftCore landed must restage; print which input changed.
 echo "==== x86 sysroot (beside $ARM_SYS, never overwrite) ===="
 [ -d "$ARM_SYS" ] || echo "  note: arm64 sysroot_fe4 is absent; textual Darwin overlays cannot be copied"
 SYSROOT_OK=0
 SYSROOT_HEADERS=0
-sys_has_overlays=0
-if [ -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] || [ -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
-    sys_has_overlays=1
-fi
-if [ -d "$SYS/usr/include" ] && [ -f "$SYS/usr/lib/libSystem.B.dylib" ] \
-    && phase2_is_x86_macho "$SYS/usr/lib/libSystem.B.dylib" && [ "$sys_has_overlays" -eq 1 ]; then
-    note sysroot-fe4-x86 satisfied
-    SYSROOT_OK=1
-    SYSROOT_HEADERS=1
-elif [ -d "$SYS/usr/include" ] && [ -f "$SYS/usr/lib/libSystem.B.dylib" ] \
-    && phase2_is_x86_macho "$SYS/usr/lib/libSystem.B.dylib" && [ "$sys_has_overlays" -eq 0 ]; then
-    cannot sysroot-fe4-x86 STAGE_XCODE_DARWIN_OVERLAYS \
-        "headers+x86 dylibs already at $SYS; Darwin.swiftmodule/swiftinterface absent (Linux cannot materialize Apple's overlay interfaces; arm64 sysroot_fe4 also lacks them). FE compile needs canImport(Darwin)==true."
-    SYSROOT_HEADERS=1
-else
+x86_bf=$artifacts/swift-macosx/_Builtin_float.swiftmodule/x86_64-apple-macos.swiftmodule
+gen_py=$MACHORUN/scripts/gen_darwin_modulemap.py
+overlay_if=$(phase2_arm_overlay_interface "$ARM_SYS" || true)
+arm_dmap=$ARM_SYS/usr/include/Darwin.modulemap
+stamp=$SYS/$PHASE2_SYSROOT_STAMP
+need_core=0
+need_bf=0
+[ -f "$x86_core" ] && phase2_is_x86_macho "$x86_core" && need_core=1
+[ -f "$x86_bf" ] && need_bf=1
+
+sysroot_input_changed() {
+    local diff
+    diff=$(phase2_sysroot_stamp_diff "$stamp" \
+        "$x86_core" "$x86_mod" "$x86_bf" "$gen_py" \
+        "${overlay_if:-}" "$arm_dmap" || true)
+    if [ -n "$diff" ]; then
+        printf '%s\n' "$diff"
+        return 0
+    fi
+    return 1
+}
+
+run_sysroot_stager() {
+    local st
     set +e
     bash "$HERE/stage_fe_sysroot.sh"
     st=$?
     set -e
     if [ "$st" -eq 0 ] && [ -d "$SYS/usr/include" ]; then
-        note sysroot-fe4-x86 cold-built
-        SYSROOT_OK=1
         SYSROOT_HEADERS=1
+        if phase2_sysroot_complete "$SYS" "$need_core" "$need_bf"; then
+            note sysroot-fe4-x86 cold-built
+            SYSROOT_OK=1
+        elif [ ! -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] \
+            && [ ! -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
+            cannot sysroot-fe4-x86 STAGE_XCODE_DARWIN_OVERLAYS \
+                "headers+x86 dylibs staged at $SYS; Darwin.swiftmodule/swiftinterface absent (Linux cannot materialize Apple's overlay interfaces; arm64 sysroot_fe4 also lacks them). FE compile needs canImport(Darwin)==true."
+        elif [ ! -f "$SYS/usr/include/Darwin.modulemap" ]; then
+            cannot sysroot-fe4-x86 DARWIN_CLANG_MODULEMAP \
+                "Darwin.swiftinterface is present but usr/include/Darwin.modulemap is not (underlying Objective-C module Darwin). Generator needs Xcode; arm64 sysroot_fe4 had no pruned maps to copy. FE fails with 'underlying Objective-C module Darwin not found' / '_DarwinFoundation1._errno'."
+        elif [ "$need_core" -eq 1 ] && { [ ! -f "$SYS/usr/lib/swift/libswiftCore.dylib" ] || ! phase2_is_x86_macho "$SYS/usr/lib/swift/libswiftCore.dylib"; }; then
+            cannot sysroot-fe4-x86 STAGE_LIBSWIFTCORE \
+                "x86 libswiftCore is in artifacts but was not staged into $SYS/usr/lib/swift"
+        else
+            cannot sysroot-fe4-x86 STAGE_FE_SYSROOT \
+                "stage_fe_sysroot.sh exit 0 but sysroot is incomplete at $SYS"
+        fi
     elif [ "$st" -eq 3 ]; then
-        # Headers/dylibs staged; Darwin overlays missing. Partial tree exists.
         if [ -d "$SYS/usr/include" ]; then
             cannot sysroot-fe4-x86 STAGE_XCODE_DARWIN_OVERLAYS \
                 "headers+x86 dylibs staged at $SYS; Darwin.swiftmodule/swiftinterface absent (Linux cannot materialize Apple's overlay interfaces; arm64 sysroot_fe4 also lacks them). FE compile needs canImport(Darwin)==true."
@@ -321,6 +354,41 @@ else
         fi
     else
         cannot sysroot-fe4-x86 STAGE_FE_SYSROOT "stage_fe_sysroot.sh exit $st"
+    fi
+}
+
+changed=$(sysroot_input_changed || true)
+if [ -z "$changed" ] && phase2_sysroot_complete "$SYS" "$need_core" "$need_bf"; then
+    note sysroot-fe4-x86 satisfied
+    SYSROOT_OK=1
+    SYSROOT_HEADERS=1
+elif [ -n "$changed" ]; then
+    echo "  re-stage sysroot-fe4-x86 (input changed: $(echo "$changed" | tr '\n' ' '))"
+    run_sysroot_stager
+elif phase2_sysroot_complete "$SYS" "$need_core" "$need_bf"; then
+    note sysroot-fe4-x86 satisfied
+    SYSROOT_OK=1
+    SYSROOT_HEADERS=1
+else
+    # Stamp matches but the tree is incomplete: restaging cannot invent overlays
+    # or Darwin.modulemap that the inputs do not provide. Name the hole.
+    SYSROOT_HEADERS=0
+    [ -d "$SYS/usr/include" ] && SYSROOT_HEADERS=1
+    if [ ! -d "$SYS/usr/include" ]; then
+        echo "  re-stage sysroot-fe4-x86 (no sysroot yet)"
+        run_sysroot_stager
+    elif [ ! -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] \
+        && [ ! -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
+        cannot sysroot-fe4-x86 STAGE_XCODE_DARWIN_OVERLAYS \
+            "headers+x86 dylibs already at $SYS; Darwin.swiftmodule/swiftinterface absent (Linux cannot materialize Apple's overlay interfaces; arm64 sysroot_fe4 also lacks them). FE compile needs canImport(Darwin)==true."
+    elif [ ! -f "$SYS/usr/include/Darwin.modulemap" ]; then
+        cannot sysroot-fe4-x86 DARWIN_CLANG_MODULEMAP \
+            "Darwin.swiftinterface is present at $SYS but usr/include/Darwin.modulemap is not. Inputs unchanged; generator needs Xcode and arm64 sysroot_fe4 has no pruned maps to copy."
+    elif [ "$need_core" -eq 1 ] && { [ ! -f "$SYS/usr/lib/swift/libswiftCore.dylib" ] || ! phase2_is_x86_macho "$SYS/usr/lib/swift/libswiftCore.dylib"; }; then
+        echo "  re-stage sysroot-fe4-x86 (libswiftCore artifact present, not in sysroot; stamp should have caught this)"
+        run_sysroot_stager
+    else
+        cannot sysroot-fe4-x86 STAGE_FE_SYSROOT "sysroot at $SYS is incomplete and inputs are unchanged"
     fi
 fi
 # Never copy arm64 dylibs into the x86 sysroot.

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -403,7 +403,11 @@ echo "==== FoundationEssentials / collections / cshims ($TARGET) ===="
 FE_OK=0
 COL_OK=0
 CSHIMS_OK=0
+OS_OK=0
+FE_IMPORTS_OK=0
 FE_OUT=$W/build/full${FULL_OUT_SUFFIX}/foundation
+OSMOD=$FE_OUT/os
+MC=$W/scratch/modcache_fe4${FULL_OUT_SUFFIX}
 
 try_collections() {
     local out=$FE_OUT/collections
@@ -460,6 +464,55 @@ try_cshims() {
     return 1
 }
 
+try_os_module() {
+    local out=$OSMOD
+    if [ -f "$out/os.o" ] && phase2_is_x86_macho "$out/os.o" && [ -f "$out/os.swiftmodule" ]; then
+        note os-module-x86 satisfied
+        OS_OK=1
+        return 0
+    fi
+    [ "$SYSROOT_OK" -eq 1 ] || {
+        cannot os-module-x86 NEEDS_X86_SYSROOT "os.swift @_exported-imports Darwin; needs $SYS"
+        return 1
+    }
+    [ "$LIBSWIFTCORE_X86" -eq 1 ] || {
+        cannot os-module-x86 BUILD_LIBSWIFTCORE_X86 "os-module compile needs x86_64 Swift.swiftmodule"
+        return 1
+    }
+    mkdir -p "$out"
+    set +e
+    W="$W" SYS="$SYS" OUT="$out" TARGET="$TARGET" MC="$MC" \
+        bash "$W/full/foundation/build_os_module.sh"
+    st=$?
+    set -e
+    if [ "$st" -eq 0 ] && [ -f "$out/os.o" ] && phase2_is_x86_macho "$out/os.o" \
+        && [ -f "$out/os.swiftmodule" ]; then
+        note os-module-x86 cold-built
+        OS_OK=1
+        return 0
+    fi
+    cannot os-module-x86 BUILD_OS_MODULE \
+        "build_os_module.sh exit $st OUT=$out (beside arm64 scratch/fe4_os, never overwrite). Calendar.swift import os is live because canImport(Darwin) is true."
+    return 1
+}
+
+try_fe_imports() {
+    local report
+    report=$(phase2_probe_fe_imports "$SYS" "$OSMOD" || true)
+    case "$report" in
+        MATCH*)
+            note fe-imports satisfied
+            FE_IMPORTS_OK=1
+            echo "  $report"
+            return 0
+            ;;
+        *)
+            cannot fe-imports FE_IMPORTS "$report"
+            return 1
+            ;;
+    esac
+}
+
 try_fe() {
     local out=$FE_OUT/essentials
     if [ -f "$out/FoundationEssentials.o" ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
@@ -473,9 +526,19 @@ try_fe() {
         cannot foundationessentials-x86 BUILD_LIBSWIFTCORE_X86 "swiftc -target $TARGET cannot compile 202 FE files without x86_64 Swift/_Concurrency modules"
         return 1
     }
+    [ "$OS_OK" -eq 1 ] || {
+        cannot foundationessentials-x86 NEEDS_X86_OS_MODULE \
+            "canImport(Darwin) is true so Calendar.swift:14 import os is live; os-module-x86 did not produce $OSMOD/os.swiftmodule"
+        return 1
+    }
+    [ "$FE_IMPORTS_OK" -eq 1 ] || {
+        cannot foundationessentials-x86 NEEDS_FE_IMPORTS \
+            "fe-imports probe refused; not invoking 202-file build_fe.sh"
+        return 1
+    }
     mkdir -p "$out"
     set +e
-    W="$W" SF="$SF" SYS="$SYS" TARGET="$TARGET" \
+    W="$W" SF="$SF" SYS="$SYS" TARGET="$TARGET" OSMOD="$OSMOD" \
         COLLECTIONS="$FE_OUT/collections" \
         bash "$W/full/foundation/build_fe.sh" \
             -emit-module -emit-module-path "$out/FoundationEssentials.swiftmodule" \
@@ -493,6 +556,8 @@ try_fe() {
 
 try_cshims || true
 try_collections || true
+try_os_module || true
+try_fe_imports || true
 try_fe || true
 
 # ---------------------------------------------------------------------------

--- a/scripts/x86/stage_fe_sysroot.sh
+++ b/scripts/x86/stage_fe_sysroot.sh
@@ -99,27 +99,10 @@ if [ -d "$MACHORUN/sdk/usr/lib" ]; then
     fi
 fi
 
-echo "== Swift.swiftmodule: only an x86_64-apple-macos slice, never the arm64 one under this name"
 artifacts=$W/swiftcore-macho/artifacts
 x86_core=$artifacts/swift-macosx/x86_64/libswiftCore.dylib
 x86_mod=$artifacts/swift-macosx/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
-if [ -f "$x86_core" ] && phase2_is_x86_macho "$x86_core"; then
-    mkdir -p "$SYS/usr/lib/swift"
-    cp -f "$x86_core" "$SYS/usr/lib/swift/libswiftCore.dylib"
-    echo "  + libswiftCore.dylib (x86_64)"
-else
-    echo "  no x86_64 libswiftCore.dylib in swiftcore-macho/artifacts (measured wall)"
-fi
-if [ -f "$x86_mod" ]; then
-    mkdir -p "$SYS/usr/lib/swift/Swift.swiftmodule"
-    for f in "$artifacts/swift-macosx/Swift.swiftmodule"/x86_64-apple-macos.*; do
-        [ -f "$f" ] || continue
-        cp -f "$f" "$SYS/usr/lib/swift/Swift.swiftmodule/$(basename "$f")"
-    done
-    echo "  + Swift.swiftmodule/x86_64-apple-macos.*"
-else
-    echo "  no x86_64-apple-macos.swiftmodule (arm64 slice is not a substitute)"
-fi
+x86_bf_mod=$artifacts/swift-macosx/_Builtin_float.swiftmodule/x86_64-apple-macos.swiftmodule
 
 echo "== ObjectiveC Clang module"
 mkdir -p "$SYS/usr/include/objc"
@@ -152,6 +135,26 @@ if [ -d "$gaps" ]; then
     done < <(find "$gaps" -type f -print0)
 fi
 
+if ! grep -q 'vm_copy' "$SYS/usr/include/mach/vm_map.h" 2>/dev/null; then
+    cat >> "$SYS/usr/include/mach/vm_map.h" <<'EOF'
+/* APPENDED by scripts/x86/stage_fe_sysroot.sh -- MEASUREMENT ONLY. */
+extern kern_return_t vm_copy(vm_map_t target_task, vm_address_t source_address,
+                             vm_size_t size, vm_address_t dest_address);
+EOF
+fi
+
+if [ -f "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" ]; then
+    cp "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" \
+        "$SYS/usr/include/_DarwinFoundation2.apinotes"
+fi
+
+# ORDER: base module.modulemap (ObjectiveC) then the Darwin family. The
+# generator appends extern module lines; running it first would lose Darwin.
+echo "== Darwin family Clang modulemaps (underlying Objective-C module Darwin)"
+phase2_install_darwin_modulemaps \
+    "$SYS" "$ARM_SYS" "$MACHORUN/scripts/gen_darwin_modulemap.py" \
+    || echo "  (Darwin.modulemap still absent; FE will fail with 'underlying Objective-C module Darwin not found')"
+
 echo "== textual Darwin overlays from the arm64 sysroot, if any (no dylibs, no arm64 .swiftmodule slices)"
 OVERLAYS_COPIED=0
 if [ -d "$ARM_SYS/usr/lib/swift" ]; then
@@ -171,18 +174,34 @@ if [ -d "$ARM_SYS/usr/lib/swift" ]; then
         OVERLAYS_COPIED=$((OVERLAYS_COPIED + 1))
     done < <(find "$ARM_SYS/usr/lib/swift" -type f -print0)
 fi
-if [ -f "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" ]; then
-    cp "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" \
-        "$SYS/usr/include/_DarwinFoundation2.apinotes"
-    OVERLAYS_COPIED=$((OVERLAYS_COPIED + 1))
-fi
 
-if ! grep -q 'vm_copy' "$SYS/usr/include/mach/vm_map.h" 2>/dev/null; then
-    cat >> "$SYS/usr/include/mach/vm_map.h" <<'EOF'
-/* APPENDED by scripts/x86/stage_fe_sysroot.sh -- MEASUREMENT ONLY. */
-extern kern_return_t vm_copy(vm_map_t target_task, vm_address_t source_address,
-                             vm_size_t size, vm_address_t dest_address);
-EOF
+echo "== x86 Swift runtime into $SYS/usr/lib/swift (toolchain layout; not left only in artifacts/)"
+mkdir -p "$SYS/usr/lib/swift"
+if [ -f "$x86_core" ] && phase2_is_x86_macho "$x86_core"; then
+    cp -f "$x86_core" "$SYS/usr/lib/swift/libswiftCore.dylib"
+    echo "  + usr/lib/swift/libswiftCore.dylib (x86_64)"
+else
+    echo "  no x86_64 libswiftCore.dylib in swiftcore-macho/artifacts (measured wall)"
+fi
+if [ -f "$x86_mod" ]; then
+    mkdir -p "$SYS/usr/lib/swift/Swift.swiftmodule"
+    for f in "$artifacts/swift-macosx/Swift.swiftmodule"/x86_64-apple-macos.*; do
+        [ -f "$f" ] || continue
+        cp -f "$f" "$SYS/usr/lib/swift/Swift.swiftmodule/$(basename "$f")"
+    done
+    echo "  + usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.*"
+else
+    echo "  no x86_64-apple-macos Swift.swiftmodule (arm64 slice is not a substitute)"
+fi
+if [ -f "$x86_bf_mod" ]; then
+    mkdir -p "$SYS/usr/lib/swift/_Builtin_float.swiftmodule"
+    for f in "$artifacts/swift-macosx/_Builtin_float.swiftmodule"/x86_64-apple-macos.*; do
+        [ -f "$f" ] || continue
+        cp -f "$f" "$SYS/usr/lib/swift/_Builtin_float.swiftmodule/$(basename "$f")"
+    done
+    echo "  + usr/lib/swift/_Builtin_float.swiftmodule/x86_64-apple-macos.*"
+else
+    echo "  no x86_64-apple-macos _Builtin_float.swiftmodule"
 fi
 
 empty_tbd=$(find "$SYS" -name '*.tbd' -size 0 -print -quit)
@@ -191,8 +210,17 @@ empty_tbd=$(find "$SYS" -name '*.tbd' -size 0 -print -quit)
     exit 2
 }
 
+overlay_if=$(phase2_arm_overlay_interface "$ARM_SYS" || true)
+phase2_write_sysroot_stamp "$SYS/$PHASE2_SYSROOT_STAMP" \
+    "$x86_core" "$x86_mod" "$x86_bf_mod" \
+    "$MACHORUN/scripts/gen_darwin_modulemap.py" \
+    "${overlay_if:-}" \
+    "$ARM_SYS/usr/include/Darwin.modulemap"
+echo "  wrote $SYS/$PHASE2_SYSROOT_STAMP (input-keyed; restage when these shas change)"
+
 echo "== $SYS"
 echo "  usr/include : $(find "$SYS/usr/include" -type f | wc -l | tr -d ' ') headers"
+echo "  modulemaps  : $(find "$SYS/usr/include" -maxdepth 1 -name '*.modulemap' | wc -l | tr -d ' ')"
 echo "  textual overlays copied from arm64 sysroot: $OVERLAYS_COPIED"
 if [ ! -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] \
     && [ ! -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
@@ -200,3 +228,11 @@ if [ ! -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] \
     exit 3
 fi
 echo "  Darwin overlays: present (textual, from $ARM_SYS)"
+if [ -f "$SYS/usr/include/Darwin.modulemap" ]; then
+    echo "  Darwin.modulemap: present"
+else
+    echo "  Darwin.modulemap: ABSENT (underlying Objective-C module Darwin will not be found)"
+fi
+if [ -f "$SYS/usr/lib/swift/libswiftCore.dylib" ]; then
+    echo "  libswiftCore: $(phase2_macho_cpu "$SYS/usr/lib/swift/libswiftCore.dylib") at usr/lib/swift/libswiftCore.dylib"
+fi

--- a/scripts/x86/stage_fe_sysroot.sh
+++ b/scripts/x86/stage_fe_sysroot.sh
@@ -164,6 +164,11 @@ if [ -d "$ARM_SYS/usr/lib/swift" ]; then
             *.dylib|*.tbd|*.a) continue ;;
             */arm64-apple-macos.*|arm64-apple-macos.*) continue ;;
             */arm64e-apple-macos.*|arm64e-apple-macos.*) continue ;;
+            os.swiftmodule|os.swiftmodule/*)
+                # Apple's os overlay @_exported-imports Clang os.*, which this
+                # sysroot does not declare. FE uses full/foundation/os-module.
+                continue
+                ;;
         esac
         case "$(file -b "$item")" in
             Mach-O*) continue ;;

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -232,6 +232,89 @@ case "$nogit" in
     *) die_test "non-repo ERROR expected, got: $nogit" ;;
 esac
 
+echo "== sysroot: input-keyed restage, Darwin modulemaps, Swift into usr/lib/swift"
+expect_grep 'gen_darwin_modulemap.py' "$STAGE" \
+    "stager runs gen_darwin_modulemap.py against the x86 sysroot"
+expect_grep 'usr/lib/swift/libswiftCore.dylib' "$STAGE" \
+    "stager copies libswiftCore into usr/lib/swift"
+expect_grep '_Builtin_float.swiftmodule' "$STAGE" \
+    "stager copies _Builtin_float into usr/lib/swift"
+expect_grep 'phase2_write_sysroot_stamp' "$STAGE" \
+    "stager writes an input stamp"
+expect_grep 're-stage sysroot-fe4-x86 (input changed:' "$PHASE2" \
+    "phase2 restages when input shas change and prints which"
+expect_grep 'DARWIN_CLANG_MODULEMAP' "$PHASE2" \
+    "missing Darwin.modulemap is its own CANNOT, not folded into overlays"
+expect_grep 'SWIFT_TOOLCHAIN' "$PHASE2" \
+    "phase2 exports SWIFT_TOOLCHAIN for overlay scripts"
+expect_grep 'SWIFT_TOOLCHAIN' "$ROOT/swiftcore-macho/scripts/guest_arch.inc" \
+    "guest_arch honors SWIFT_TOOLCHAIN"
+expect_not_grep 'no swiftc at /opt/swift624/usr/bin or /usr/bin' \
+    "$ROOT/swiftcore-macho/scripts/guest_arch.inc" \
+    "guest_arch no longer refuses solely on hardcoded toolchain paths"
+
+STAMPWORK=$(mktemp -d /tmp/phase2-stamp.XXXXXX)
+echo a > "$STAMPWORK/core-a"
+echo b > "$STAMPWORK/core-b"
+echo m > "$STAMPWORK/mod"
+echo f > "$STAMPWORK/bf"
+echo g > "$STAMPWORK/gen"
+echo o > "$STAMPWORK/overlay"
+echo d > "$STAMPWORK/dmap"
+phase2_write_sysroot_stamp "$STAMPWORK/stamp" \
+    "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap"
+match=$(phase2_sysroot_stamp_diff "$STAMPWORK/stamp" \
+    "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" && echo MATCH || echo FAIL)
+if [ "$match" = MATCH ]; then
+    ok "stamp matches when inputs are unchanged"
+else
+    die_test "unchanged inputs should match stamp, got $match"
+fi
+diff=$(phase2_sysroot_stamp_diff "$STAMPWORK/stamp" \
+    "$STAMPWORK/core-b" "$STAMPWORK/mod" "$STAMPWORK/bf" \
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" || true)
+case "$diff" in
+    *"libswiftCore "*) ok "stamp names libswiftCore when the artifact sha changes ($diff)" ;;
+    *) die_test "expected libswiftCore old->new, got: $diff" ;;
+esac
+missing_stamp=$(phase2_sysroot_stamp_diff "$STAMPWORK/absent" \
+    "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" || true)
+case "$missing_stamp" in
+    stamp=ABSENT) ok "missing stamp is stamp=ABSENT (restage, do not reuse)" ;;
+    *) die_test "missing stamp expected stamp=ABSENT, got: $missing_stamp" ;;
+esac
+rm -rf "$STAMPWORK"
+
+MMWORK=$(mktemp -d /tmp/phase2-modulemap.XXXXXX)
+mkdir -p "$MMWORK/arm/usr/include" "$MMWORK/sys/usr/include"
+cat > "$MMWORK/sys/usr/include/module.modulemap" <<'EOF'
+module ObjectiveC [system] { header "objc/objc.h" export * }
+EOF
+cat > "$MMWORK/arm/usr/include/Darwin.modulemap" <<'EOF'
+module Darwin [system] { header "stdio.h" export * }
+EOF
+cat > "$MMWORK/arm/usr/include/DarwinFoundation1.modulemap" <<'EOF'
+module _DarwinFoundation1 [system] { header "errno.h" export * }
+EOF
+printf 'module ObjectiveC [system] { header "objc/objc.h" export * }\nextern module Darwin "Darwin.modulemap"\nextern module _DarwinFoundation1 "DarwinFoundation1.modulemap"\n' \
+    > "$MMWORK/arm/usr/include/module.modulemap"
+# Generator is not Xcode; copy path must still produce Darwin.modulemap.
+if phase2_install_darwin_modulemaps "$MMWORK/sys" "$MMWORK/arm" "$MMWORK/no-such-gen.py"; then
+    if [ -f "$MMWORK/sys/usr/include/Darwin.modulemap" ] \
+        && [ -f "$MMWORK/sys/usr/include/DarwinFoundation1.modulemap" ] \
+        && grep -q 'extern module Darwin' "$MMWORK/sys/usr/include/module.modulemap"; then
+        ok "Darwin family maps copied from arm64 sysroot when generator cannot run"
+    else
+        die_test "copy path did not install Darwin.modulemap + extern module lines"
+    fi
+else
+    die_test "install_darwin_modulemaps failed on a fixture that has pruned maps"
+fi
+rm -rf "$MMWORK"
+
 echo
 echo "test_phase2: pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -315,6 +315,76 @@ else
 fi
 rm -rf "$MMWORK"
 
+echo "== os-module-x86 before build_fe + fe-imports census"
+expect_grep 'full/foundation/build_os_module.sh' "$PHASE2" \
+    "phase2 builds the local os module"
+expect_grep 'OSMOD="$OSMOD"' "$PHASE2" \
+    "phase2 passes OSMOD into build_fe.sh"
+expect_grep 'cannot fe-imports FE_IMPORTS' "$PHASE2" \
+    "fe-imports refusal is CANNOT_FE_IMPORTS"
+expect_grep 'try_os_module || true' "$PHASE2" \
+    "os-module runs in the FE chain"
+expect_grep 'os.swiftmodule|os.swiftmodule/\*' "$STAGE" \
+    "stager skips Apple os overlay (FE uses os-module)"
+OSMOD_SH=$ROOT/full/foundation/build_os_module.sh
+expect_grep 'TARGET:-arm64-apple-macos15.0' "$OSMOD_SH" \
+    "os-module script is TARGET-retargetable"
+expect_grep 'MC:-$W/scratch/modcache_fe4' "$OSMOD_SH" \
+    "os-module cache is overridable (x86 uses a suffixed cache)"
+# Order: build_os_module.sh must appear before build_fe.sh invocation.
+awk '
+    /full\/foundation\/build_os_module.sh/ { os=NR }
+    /full\/foundation\/build_fe.sh/ { fe=NR }
+    END {
+        if (!os || !fe || !(os<fe)) { print "ORDER os="os" fe="fe; exit 1 }
+        print "OK"
+    }
+' "$PHASE2" | grep -q OK && ok "os-module step is before build_fe.sh" \
+    || die_test "os-module is not before build_fe.sh"
+
+FEWORK=$(mktemp -d /tmp/phase2-fe-imports.XXXXXX)
+mkdir -p "$FEWORK/sys/usr/include" \
+    "$FEWORK/sys/usr/lib/swift/Darwin.swiftmodule" \
+    "$FEWORK/sys/usr/lib/swift/Swift.swiftmodule" \
+    "$FEWORK/sys/usr/lib/swift/_Builtin_float.swiftmodule" \
+    "$FEWORK/os"
+touch "$FEWORK/sys/usr/include/Darwin.modulemap"
+touch "$FEWORK/sys/usr/lib/swift/Darwin.swiftmodule/x86_64-apple-macos.swiftinterface"
+touch "$FEWORK/sys/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftmodule"
+touch "$FEWORK/sys/usr/lib/swift/_Builtin_float.swiftmodule/x86_64-apple-macos.swiftmodule"
+touch "$FEWORK/os/os.swiftmodule"
+missing=$(phase2_probe_fe_imports "$FEWORK/sys" "$FEWORK/os" || true)
+case "$missing" in
+    MISSING*"present=Darwin,os,Swift,_Builtin_float"*"absent=_StringProcessing,_Concurrency"*"optional_absent=Synchronization"*)
+        ok "fe-imports names _StringProcessing,_Concurrency absent in one line ($missing)"
+        ;;
+    *) die_test "fe-imports MISSING census expected, got: $missing" ;;
+esac
+mkdir -p "$FEWORK/sys/usr/lib/swift/_StringProcessing.swiftmodule" \
+    "$FEWORK/sys/usr/lib/swift/_Concurrency.swiftmodule" \
+    "$FEWORK/sys/usr/lib/swift/Synchronization.swiftmodule"
+touch "$FEWORK/sys/usr/lib/swift/_StringProcessing.swiftmodule/x86_64-apple-macos.swiftinterface"
+touch "$FEWORK/sys/usr/lib/swift/_Concurrency.swiftmodule/x86_64-apple-macos.swiftinterface"
+touch "$FEWORK/sys/usr/lib/swift/Synchronization.swiftmodule/x86_64-apple-macos.swiftinterface"
+match=$(phase2_probe_fe_imports "$FEWORK/sys" "$FEWORK/os" || true)
+case "$match" in
+    MATCH*"present=Darwin,os,Swift,_Builtin_float,_StringProcessing,_Concurrency,Synchronization"*)
+        ok "fe-imports MATCH when required modules and Synchronization are present"
+        ;;
+    *) die_test "fe-imports MATCH expected, got: $match" ;;
+esac
+# Arm64 slice under an x86 sysroot is not presence.
+rm -f "$FEWORK/sys/usr/lib/swift/_Concurrency.swiftmodule/x86_64-apple-macos.swiftinterface"
+touch "$FEWORK/sys/usr/lib/swift/_Concurrency.swiftmodule/arm64-apple-macos.swiftinterface"
+armonly=$(phase2_probe_fe_imports "$FEWORK/sys" "$FEWORK/os" || true)
+case "$armonly" in
+    MISSING*"absent=_Concurrency"*)
+        ok "fe-imports refuses an arm64 _Concurrency slice as x86 presence"
+        ;;
+    *) die_test "arm64-only _Concurrency should be absent, got: $armonly" ;;
+esac
+rm -rf "$FEWORK"
+
 echo
 echo "test_phase2: pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/swiftcore-macho/artifacts/manifest.schema.json
+++ b/swiftcore-macho/artifacts/manifest.schema.json
@@ -16,6 +16,18 @@
         "commit": { "type": "string", "minLength": 40, "maxLength": 40 }
       }
     },
+    "siblings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["repository", "tag", "commit"],
+        "properties": {
+          "repository": { "type": "string" },
+          "tag": { "type": "string" },
+          "commit": { "type": "string", "minLength": 40, "maxLength": 40 }
+        }
+      }
+    },
     "toolchain": { "type": "string" },
     "host": { "type": "string" },
     "generatedAtUtc": { "type": "string" },

--- a/swiftcore-macho/artifacts/x86_64.manifest.json
+++ b/swiftcore-macho/artifacts/x86_64.manifest.json
@@ -54,6 +54,8 @@
   "flags": {
     "SWIFTCORE_DARWIN_ARCH": "x86_64",
     "SWIFTCORE_MACHO_LEGACY_IMAGE_REG": "1",
+    "SWIFT_PATH_TO_LIBDISPATCH_SOURCE": "pinned sibling 2df91f94651f2d924d7506c9d14685929386d779",
+    "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE": "pinned sibling 91177e6225c63e885872b83d48e254b1270fa15a",
     "SWIFT_BUILD_SDK_OVERLAY": "OFF",
     "SWIFT_BUILD_STDLIB": "ON",
     "SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY": "ON",
@@ -70,6 +72,18 @@
     "commit": "ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b",
     "repository": "https://github.com/swiftlang/swift.git",
     "tag": "swift-6.2.4-RELEASE"
+  },
+  "siblings": {
+    "swift-corelibs-libdispatch": {
+      "commit": "2df91f94651f2d924d7506c9d14685929386d779",
+      "repository": "https://github.com/swiftlang/swift-corelibs-libdispatch.git",
+      "tag": "swift-6.2.4-RELEASE"
+    },
+    "swift-experimental-string-processing": {
+      "commit": "91177e6225c63e885872b83d48e254b1270fa15a",
+      "repository": "https://github.com/swiftlang/swift-experimental-string-processing.git",
+      "tag": "swift-6.2.4-RELEASE"
+    }
   },
   "toolchain": "Swift version 6.2.4 (swift-6.2.4-RELEASE)"
 }

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -69,18 +69,30 @@ Overlays, **as applicable**:
 | module | CMake | applicable on this Linux sysroot? |
 |---|---|---|
 | Swift / libswiftCore | `SWIFT_BUILD_STDLIB` | **yes** — the recorded target |
-| `_Concurrency` | `SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON` | yes; may need libdispatch (BUILD_LOG §16 / patch-8 wall) |
+| `_Concurrency` | `SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON` | **yes** with `SWIFTCORE_BUILD_DISPATCH=1` (defaults on when overlays=1); sibling `swift-corelibs-libdispatch` @ `2df91f94651f2d924d7506c9d14685929386d779` |
 | `_Builtin_float` | in-tree with the stdlib | yes |
-| `Synchronization` | `SWIFTCORE_OVERLAYS=1` → `SWIFT_ENABLE_SYNCHRONIZATION=ON` | in-tree; try |
-| `_StringProcessing` | `SWIFTCORE_OVERLAYS=1` → experimental ON | needs extra source; wall if cmake refuses |
+| `Synchronization` | `SWIFTCORE_OVERLAYS=1` → `SWIFT_ENABLE_SYNCHRONIZATION=ON` | **yes**, in-tree |
+| `_StringProcessing` | `SWIFTCORE_OVERLAYS=1` → experimental ON | **yes**, sibling `swift-experimental-string-processing` @ `91177e6225c63e885872b83d48e254b1270fa15a`. Empty path → `CANNOT_FETCH_STRING_PROCESSING_SOURCE` *before* CMake |
 | `swiftDarwin` / `swiftObjectiveC` | `SWIFT_BUILD_SDK_OVERLAY` | **no** — needs Xcode Darwin module maps. Stays OFF. Marker: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 
 ## 3. Operator command (16 vCPU x86 EC2)
 
 ```bash
 NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
   bash swiftcore-macho/scripts/build_stdlib.sh
 ```
+
+`SWIFTCORE_OVERLAYS=1` fetches `swift-experimental-string-processing` and
+defaults `SWIFTCORE_BUILD_DISPATCH=1` (libdispatch) at the
+`swift-6.2.4-RELEASE` commits in `scripts/guest_arch.inc`. Missing either
+checkout prints `CANNOT_FETCH_STRING_PROCESSING_SOURCE` or
+`CANNOT_FETCH_LIBDISPATCH_SOURCE` and exits 2 **before** CMake — the
+previous operator failure was `No SOURCES given to target:
+swift_StringProcessing-macosx-x86_64` forty lines into the log.
+
+`SWIFT_TOOLCHAIN` is the operator prefix (`/opt/swift`). Do not symlink it
+to `/opt/swift624`; `guest_arch.inc` also accepts `command -v swiftc`.
 
 That is bootstrap → x86 libSystem+objc4+.tbd → `stage_sdk.sh` →
 `apply_patches.py` (legacy image-reg) → `configure.sh` →
@@ -103,7 +115,7 @@ libdispatch wall, not a resource miss. Overlays / dispatch on a 16 vCPU host:
 
 ```bash
 NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
-  SWIFTCORE_BUILD_DISPATCH=1 \
+  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
   bash swiftcore-macho/scripts/build_stdlib.sh
 ```
 
@@ -114,6 +126,8 @@ NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
 | check | how | result |
 |---|---|---|
 | configure DRY | `scripts/test_configure_arch.sh` | **PASS** — 2 dumps; arm64 argv intact; x86 is the same flags with arch swapped |
+| overlay preflight | `scripts/test_overlay_siblings.sh` | refuse-before-cmake; both sibling `-D` paths when overlays=1 |
+| SWIFT_TOOLCHAIN | `scripts/test_toolchain.sh` | honors `/opt/swift`; `/opt/swift624` is not the only path |
 | MH_MAGIC_64 X86_64 DYLIB | `llvm-otool-18 -hv` | `MH_MAGIC_64 X86_64 ALL DYLIB` |
 | no arm64 slice | same header must not contain `ARM64` | **OK** |
 | LC_ID_DYLIB | `llvm-otool-18 -D` | `/usr/lib/swift/libswiftCore.dylib` |
@@ -143,8 +157,8 @@ Overlays this run (denominator: 6 named guests):
 |---|---|---|
 | Swift / libswiftCore | **yes** — staged | — |
 | `_Builtin_float` swiftmodule | **yes** — staged | — |
-| `_Concurrency` | **no** — `stdlib/public/Concurrency/dispatch` missing (BUILD_LOG §16 / patch-8). Needs a built libdispatch, `SWIFTCORE_BUILD_DISPATCH=1` | `CANNOT_BUILD_CONCURRENCY_X86` |
-| `_StringProcessing` / `Synchronization` | flags OFF this run (`SWIFTCORE_OVERLAYS` default 0) | operator: `SWIFTCORE_OVERLAYS=1` |
+| `_Concurrency` | **no** until operator reruns with fetched libdispatch | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing; else BUILD_LOG §16 |
+| `_StringProcessing` / `Synchronization` | fetch + explicit `-D` paths; CMake no longer sees `()` | `CANNOT_FETCH_STRING_PROCESSING_SOURCE` |
 | `swiftDarwin` | **no** — `'semaphore.h' file not found` via `LibcOverlayShims.h` | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 | `swiftObjectiveC` | **no** — `SWIFT_BUILD_SDK_OVERLAY=OFF` (needs Xcode module maps) | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 

--- a/swiftcore-macho/scripts/bootstrap_box.sh
+++ b/swiftcore-macho/scripts/bootstrap_box.sh
@@ -73,11 +73,20 @@ clone_tag "$W/swift" https://github.com/swiftlang/swift.git "$SWIFT_PIN_COMMIT"
 echo "=== corelibs-foundation (CoreFoundation headers for the sysroot) ==="
 clone_tag "$W/scf" https://github.com/swiftlang/swift-corelibs-foundation.git
 
-echo "=== swift-corelibs-libdispatch (the Linux-ported tree, NOT apple-oss-distributions) ==="
+echo "=== swift-corelibs-libdispatch (pin $LIBDISPATCH_PIN_COMMIT tag $SWIFT_PIN_TAG) ==="
 # apple-oss-distributions/libdispatch needs DISPATCH_USE_KEVENT_WORKQUEUE + HAVE_MACH.
 # corelibs has the completed Linux port with event_epoll.c in the SAME tree,
 # selected by configuration -- so this is a config choice, not a fork.
-clone_tag "$W/libdispatch" https://github.com/swiftlang/swift-corelibs-libdispatch.git
+# Always pin-fetch: SWIFTCORE_OVERLAYS=1 / SWIFTCORE_BUILD_DISPATCH=1 pass this
+# path into CMake. A missing tree must fail in configure.sh *before* cmake,
+# not 40 lines into a CMake diagnostic.
+clone_tag "$W/libdispatch" "$LIBDISPATCH_REPO" "$LIBDISPATCH_PIN_COMMIT"
+
+if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
+  echo "=== swift-experimental-string-processing (pin $STRING_PROCESSING_PIN_COMMIT tag $SWIFT_PIN_TAG) ==="
+  clone_tag "$W/swift-experimental-string-processing" \
+    "$STRING_PROCESSING_REPO" "$STRING_PROCESSING_PIN_COMMIT"
+fi
 
 mkdir -p "$W/shims"
 echo "bootstrap complete host=$(uname -m) darwin_arch=$SWIFTCORE_DARWIN_ARCH tc=$TC"

--- a/swiftcore-macho/scripts/build_compat.sh
+++ b/swiftcore-macho/scripts/build_compat.sh
@@ -27,7 +27,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 W=${W:-$HOME/work}
 SDK=${SDK:-$W/sdk/MacOSX.sdk}
-# TC already set by guest_arch.inc ( /opt/swift624/usr or /usr ).
+# TC already set by guest_arch.inc (SWIFT_TOOLCHAIN, PATH, /opt/swift624/usr, or /usr).
 SRC=${SRC:-$W/compat}
 # machorun's built userland -- the thing we must not collide with.
 MRLIB=${MRLIB:-$W/machorun/darwin/usr/lib}

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -5,11 +5,18 @@
 # Arm64 on Graviton is still the default on an aarch64 host. This script on an
 # x86_64 host produces the x86_64 slice beside the committed arm64 artifacts.
 #
-# Operator (16 vCPU x86_64 Ubuntu 24.04, clang-18, Swift 6.2.4):
+# Operator (16 vCPU x86_64 Ubuntu 24.04, clang-18, Swift 6.2.4).
+# SWIFT_TOOLCHAIN honors /opt/swift (do not symlink it to /opt/swift624):
 #
 #   NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+#     SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
 #     bash swiftcore-macho/scripts/build_stdlib.sh
 #
+# SWIFTCORE_OVERLAYS=1 fetches swift-experimental-string-processing and
+# (via BUILD_DISPATCH default 1) swift-corelibs-libdispatch at the
+# swift-6.2.4-RELEASE commits in guest_arch.inc. CMake is refused with
+# CANNOT_FETCH_*_SOURCE if either checkout is missing.
+
 # This 4-vCPU / 15 GiB cloud-agent VM uses NINJA_JOBS=2. It will configure and
 # compile as far as RAM/time allow; it will not fake a dylib. Execution of the
 # linked guest is refused here — that is the operator host's job.
@@ -25,7 +32,15 @@ B=${B:-$W/build}
 MACHORUN=${MACHORUN:-$OPENUIKIT_ROOT/machorun}
 NINJA_JOBS=${NINJA_JOBS:-2}
 STOP_AFTER=${STOP_AFTER:-}   # configure | ninja-first | link | all
+# Overlays imply dispatch: phase-2 needs _Concurrency as well as
+# _StringProcessing / Synchronization. Operator may still set
+# SWIFTCORE_BUILD_DISPATCH=1 explicitly.
+if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
+  SWIFTCORE_BUILD_DISPATCH=${SWIFTCORE_BUILD_DISPATCH:-1}
+fi
 export W B TC SWIFTCORE_DARWIN_ARCH SWIFT_HOST_VARIANT_ARCH
+export SWIFTCORE_OVERLAYS SWIFTCORE_BUILD_DISPATCH
+export SWIFT_TOOLCHAIN SWIFT_PATH_TO_STRING_PROCESSING_SOURCE SWIFT_PATH_TO_LIBDISPATCH_SOURCE
 
 mkdir -p "$W"
 step() { printf '\n==== %s ====\n' "$*"; }
@@ -181,6 +196,7 @@ else
   echo "objects compiled: $obj_n"
   echo "This VM did not produce the dylib. Operator command:"
   echo "  NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \\"
+  echo "    SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \\"
   echo "    bash swiftcore-macho/scripts/build_stdlib.sh"
   exit 2
 fi

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -41,11 +41,18 @@ done
 # _Concurrency (already on), Synchronization, experimental StringProcessing.
 # Darwin/ObjectiveC SDK overlays stay OFF: SWIFT_BUILD_SDK_OVERLAY needs
 # Xcode module maps this Linux sysroot does not have. See docs/X86_64.md.
+#
+# Phase-2 guests load _Concurrency + _StringProcessing + Synchronization.
+# Overlays therefore also fetch/pass libdispatch (BUILD_LOG §16): CMake with
+# STRING_PROCESSING=ON and an empty SWIFT_PATH_TO_STRING_PROCESSING_SOURCE
+# dies at stdlib/public/StringProcessing/CMakeLists.txt:41 ("No SOURCES
+# given to target") forty lines into the log. Refuse *before* cmake.
 OVERLAY_STRING=OFF
 OVERLAY_SYNC=OFF
 if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
   OVERLAY_STRING=ON
   OVERLAY_SYNC=ON
+  SWIFTCORE_BUILD_DISPATCH=${SWIFTCORE_BUILD_DISPATCH:-1}
 fi
 
 SYNTAX_FLAG=()
@@ -53,9 +60,59 @@ if [ -d "$W/swift-syntax" ]; then
   SYNTAX_FLAG=(-DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="$W/swift-syntax")
 fi
 
+STRING_PROCESSING_SRC=${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE:-$W/swift-experimental-string-processing}
+LIBDISPATCH_SRC=${SWIFT_PATH_TO_LIBDISPATCH_SOURCE:-$W/libdispatch}
+
+STRING_FLAG=()
 DISPATCH_FLAG=()
-if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ] && [ -d "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE:-$W/libdispatch}" ]; then
-  DISPATCH_FLAG=(-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="${SWIFT_PATH_TO_LIBDISPATCH_SOURCE:-$W/libdispatch}")
+
+refuse_checkout() {
+  local marker=$1 checkout=$2 pin=$3 expected=$4
+  echo "$marker checkout=$checkout pin=$pin tag=$SWIFT_PIN_TAG expected=$expected" >&2
+  echo "  bootstrap: SWIFTCORE_OVERLAYS=1 bash $SCRIPT_DIR/bootstrap_box.sh" >&2
+  echo "  do not invoke CMake with an empty sibling path" >&2
+  exit 2
+}
+
+# --print-flags is a dry dump (test_configure_arch.sh). The refuse is for the
+# real configure, before cmake, so the operator sees the missing checkout
+# instead of CMakeLists.txt:41.
+if [ "$PRINT_FLAGS" != 1 ]; then
+  if [ "$OVERLAY_STRING" = ON ]; then
+    if [ ! -d "$STRING_PROCESSING_SRC/Sources/_StringProcessing" ]; then
+      refuse_checkout CANNOT_FETCH_STRING_PROCESSING_SOURCE \
+        swift-experimental-string-processing "$STRING_PROCESSING_PIN_COMMIT" \
+        "$STRING_PROCESSING_SRC"
+    fi
+    if [ -d "$STRING_PROCESSING_SRC/.git" ]; then
+      got=$(git -C "$STRING_PROCESSING_SRC" rev-parse HEAD)
+      if [ "$got" != "$STRING_PROCESSING_PIN_COMMIT" ]; then
+        echo "CANNOT_FETCH_STRING_PROCESSING_SOURCE checkout=swift-experimental-string-processing reason=commit-mismatch have=$got want=$STRING_PROCESSING_PIN_COMMIT" >&2
+        exit 2
+      fi
+    fi
+  fi
+  if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ]; then
+    if [ ! -d "$LIBDISPATCH_SRC" ] || [ ! -f "$LIBDISPATCH_SRC/CMakeLists.txt" ]; then
+      refuse_checkout CANNOT_FETCH_LIBDISPATCH_SOURCE \
+        swift-corelibs-libdispatch "$LIBDISPATCH_PIN_COMMIT" \
+        "$LIBDISPATCH_SRC"
+    fi
+    if [ -d "$LIBDISPATCH_SRC/.git" ]; then
+      got=$(git -C "$LIBDISPATCH_SRC" rev-parse HEAD)
+      if [ "$got" != "$LIBDISPATCH_PIN_COMMIT" ]; then
+        echo "CANNOT_FETCH_LIBDISPATCH_SOURCE checkout=swift-corelibs-libdispatch reason=commit-mismatch have=$got want=$LIBDISPATCH_PIN_COMMIT" >&2
+        exit 2
+      fi
+    fi
+  fi
+fi
+
+if [ "$OVERLAY_STRING" = ON ]; then
+  STRING_FLAG=(-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE="$STRING_PROCESSING_SRC")
+fi
+if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ]; then
+  DISPATCH_FLAG=(-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="$LIBDISPATCH_SRC")
 fi
 
 CMAKE_ARGS=(
@@ -106,6 +163,7 @@ CMAKE_ARGS=(
   -DSWIFT_ENABLE_BACKTRACING=OFF
   -DSWIFT_STDLIB_ENABLE_OBJC_INTEROP=ON
   -DSWIFT_INCLUDE_APINOTES=ON
+  "${STRING_FLAG[@]}"
   "${DISPATCH_FLAG[@]}"
   "${CMAKE_EXTRA[@]}"
 )
@@ -120,6 +178,10 @@ if [ "$PRINT_FLAGS" = 1 ]; then
   printf 'SDK=%s\n' "$SDK"
   printf 'SRC=%s\n' "$SRC"
   printf 'B=%s\n' "$B"
+  printf 'SWIFTCORE_OVERLAYS=%s\n' "${SWIFTCORE_OVERLAYS:-0}"
+  printf 'SWIFTCORE_BUILD_DISPATCH=%s\n' "${SWIFTCORE_BUILD_DISPATCH:-0}"
+  printf 'STRING_PROCESSING_SRC=%s\n' "$STRING_PROCESSING_SRC"
+  printf 'LIBDISPATCH_SRC=%s\n' "$LIBDISPATCH_SRC"
   printf 'cmake'
   for a in "${CMAKE_ARGS[@]}"; do
     printf ' %q' "$a"

--- a/swiftcore-macho/scripts/guest_arch.inc
+++ b/swiftcore-macho/scripts/guest_arch.inc
@@ -60,20 +60,55 @@ case "$SWIFTCORE_DARWIN_ARCH" in
         ;;
 esac
 
-# Stock swift.org 6.2.4: /opt/swift624 on the Graviton box, /usr on the
-# swift:6.2-noble image this VM boots from.
-if [ -z "${TC:-}" ]; then
-    if [ -x /opt/swift624/usr/bin/swiftc ]; then
-        TC=/opt/swift624/usr
-    elif [ -x /usr/bin/swiftc ]; then
-        TC=/usr
-    else
-        echo "guest_arch: no swiftc at /opt/swift624/usr/bin or /usr/bin" >&2
+# Toolchain prefix (directory that contains bin/swiftc). Honor SWIFT_TOOLCHAIN
+# first — the operator x86 host keeps Swift 6.2.4 at /opt/swift, not the
+# Graviton path /opt/swift624. Then TC, then well-known prefixes, then
+# `command -v swiftc`.
+_sc_tc_from() {
+    local root=$1
+    if [ -x "$root/bin/swiftc" ]; then
+        printf '%s\n' "$root"
+        return 0
+    fi
+    if [ -x "$root/usr/bin/swiftc" ]; then
+        printf '%s\n' "$root/usr"
+        return 0
+    fi
+    return 1
+}
+if [ -n "${SWIFT_TOOLCHAIN:-}" ]; then
+    TC=$(_sc_tc_from "$SWIFT_TOOLCHAIN") || {
+        echo "guest_arch: SWIFT_TOOLCHAIN=$SWIFT_TOOLCHAIN has no bin/swiftc" >&2
+        exit 1
+    }
+elif [ -z "${TC:-}" ]; then
+    TC=""
+    for _sc_cand in /opt/swift624/usr /opt/swift624 /opt/swift/usr /opt/swift /usr; do
+        if TC=$(_sc_tc_from "$_sc_cand"); then
+            break
+        fi
+        TC=""
+    done
+    if [ -z "$TC" ]; then
+        _sc_swiftc=$(command -v swiftc 2>/dev/null || true)
+        if [ -n "$_sc_swiftc" ]; then
+            TC=$(cd "$(dirname "$_sc_swiftc")/.." && pwd)
+        fi
+    fi
+    if [ -z "$TC" ] || [ ! -x "$TC/bin/swiftc" ]; then
+        echo "guest_arch: no swiftc (set SWIFT_TOOLCHAIN or TC, or put swiftc on PATH)" >&2
         exit 1
     fi
 fi
+unset -f _sc_tc_from
+unset _sc_cand _sc_swiftc
 
 # Pinned by BUILD_LOG.md and full/observation/UPSTREAM.md. Tag is a label;
-# the commit is the pin.
+# the commit is the pin. Sibling tags are the same label on each repo;
+# ls-remote of swift-6.2.4-RELEASE on 2026-09-03.
 SWIFT_PIN_TAG=swift-6.2.4-RELEASE
 SWIFT_PIN_COMMIT=ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b
+STRING_PROCESSING_PIN_COMMIT=91177e6225c63e885872b83d48e254b1270fa15a
+LIBDISPATCH_PIN_COMMIT=2df91f94651f2d924d7506c9d14685929386d779
+STRING_PROCESSING_REPO=https://github.com/swiftlang/swift-experimental-string-processing.git
+LIBDISPATCH_REPO=https://github.com/swiftlang/swift-corelibs-libdispatch.git

--- a/swiftcore-macho/scripts/guest_arch.inc
+++ b/swiftcore-macho/scripts/guest_arch.inc
@@ -60,17 +60,43 @@ case "$SWIFTCORE_DARWIN_ARCH" in
         ;;
 esac
 
-# Stock swift.org 6.2.4: /opt/swift624 on the Graviton box, /usr on the
-# swift:6.2-noble image this VM boots from.
+# Linux Swift toolchain prefix (directory that contains bin/swiftc).
+# SWIFT_TOOLCHAIN and PATH win over the recorded Graviton / docker paths: a
+# host whose swiftc is neither /opt/swift624/usr/bin nor /usr/bin still has to
+# configure overlays. TC already set by the caller is left alone.
 if [ -z "${TC:-}" ]; then
-    if [ -x /opt/swift624/usr/bin/swiftc ]; then
+    _sc_pick_tc() {
+        local cand=$1
+        if [ -x "$cand/usr/bin/swiftc" ]; then
+            printf '%s\n' "$cand/usr"
+            return 0
+        fi
+        if [ -x "$cand/bin/swiftc" ]; then
+            printf '%s\n' "$cand"
+            return 0
+        fi
+        return 1
+    }
+    if [ -n "${SWIFT_TOOLCHAIN:-}" ]; then
+        TC=$(_sc_pick_tc "$SWIFT_TOOLCHAIN") || {
+            echo "guest_arch: SWIFT_TOOLCHAIN=$SWIFT_TOOLCHAIN has no bin/swiftc (tried \$SWIFT_TOOLCHAIN/usr/bin and \$SWIFT_TOOLCHAIN/bin)" >&2
+            exit 1
+        }
+    elif command -v swiftc >/dev/null 2>&1; then
+        TC=$(cd "$(dirname "$(command -v swiftc)")/.." && pwd)
+        if [ ! -x "$TC/bin/swiftc" ]; then
+            echo "guest_arch: command -v swiftc is $(command -v swiftc) but $TC/bin/swiftc is not executable" >&2
+            exit 1
+        fi
+    elif [ -x /opt/swift624/usr/bin/swiftc ]; then
         TC=/opt/swift624/usr
     elif [ -x /usr/bin/swiftc ]; then
         TC=/usr
     else
-        echo "guest_arch: no swiftc at /opt/swift624/usr/bin or /usr/bin" >&2
+        echo "guest_arch: no swiftc (SWIFT_TOOLCHAIN unset, not on PATH, not at /opt/swift624/usr/bin or /usr/bin)" >&2
         exit 1
     fi
+    unset -f _sc_pick_tc
 fi
 
 # Pinned by BUILD_LOG.md and full/observation/UPSTREAM.md. Tag is a label;

--- a/swiftcore-macho/scripts/stage_artifacts.sh
+++ b/swiftcore-macho/scripts/stage_artifacts.sh
@@ -97,11 +97,13 @@ done < <(find "$SRC_DIR/macosx" -maxdepth 1 -type d -name '*.swiftmodule' -print
 }
 
 python3 - "$MANIFEST" "$SWIFTCORE_DARWIN_ARCH" "$SWIFTCORE_MODULE_TRIPLE" \
-  "$SWIFT_PIN_COMMIT" "$SWIFT_PIN_TAG" "$DEST_ROOT" "$DEST_LIB" <<'PY'
+  "$SWIFT_PIN_COMMIT" "$SWIFT_PIN_TAG" "$DEST_ROOT" "$DEST_LIB" \
+  "$STRING_PROCESSING_PIN_COMMIT" "$LIBDISPATCH_PIN_COMMIT" <<'PY'
 import hashlib, json, os, sys, time
 from pathlib import Path
 
-manifest, arch, module_triple, commit, tag, dest_root, dest_lib = sys.argv[1:]
+(manifest, arch, module_triple, commit, tag, dest_root, dest_lib,
+ sp_commit, dispatch_commit) = sys.argv[1:]
 
 def sha256(p: Path):
     h = hashlib.sha256()
@@ -129,6 +131,18 @@ payload = {
         "tag": tag,
         "commit": commit,
     },
+    "siblings": {
+        "swift-experimental-string-processing": {
+            "repository": "https://github.com/swiftlang/swift-experimental-string-processing.git",
+            "tag": tag,
+            "commit": sp_commit,
+        },
+        "swift-corelibs-libdispatch": {
+            "repository": "https://github.com/swiftlang/swift-corelibs-libdispatch.git",
+            "tag": tag,
+            "commit": dispatch_commit,
+        },
+    },
     "patches": "scripts/apply_patches.py 1-5+7; patch 5 via SWIFTCORE_MACHO_LEGACY_IMAGE_REG=1; patch 6 (isa widen) off",
     "flags": {
         "SWIFTCORE_DARWIN_ARCH": arch,
@@ -139,6 +153,8 @@ payload = {
         "SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY": "ON",
         "SWIFT_BUILD_SDK_OVERLAY": "OFF",
         "SWIFTCORE_MACHO_LEGACY_IMAGE_REG": "1",
+        "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE": "pinned sibling",
+        "SWIFT_PATH_TO_LIBDISPATCH_SOURCE": "pinned sibling",
     },
     "toolchain": "Swift version 6.2.4 (swift-6.2.4-RELEASE)",
     "host": os.uname().machine + "-unknown-linux-gnu",

--- a/swiftcore-macho/scripts/test_configure_arch.sh
+++ b/swiftcore-macho/scripts/test_configure_arch.sh
@@ -62,6 +62,36 @@ printf '%s\n' "$x86" | grep -F -- "-DSWIFT_SDK_OSX_ARCHITECTURES=arm64" >/dev/nu
   && { echo "  FAIL x86 dump carries arm64 SDK arch"; fail=1; } \
   || echo "  OK  x86 dump has no arm64 SDK arch"
 
+# SWIFT_TOOLCHAIN / PATH, not only /opt/swift624 and /usr/bin.
+tcroot=$(mktemp -d)
+mkdir -p "$tcroot/usr/bin"
+printf '#!/bin/sh\nexit 0\n' > "$tcroot/usr/bin/swiftc"
+chmod +x "$tcroot/usr/bin/swiftc"
+toolchain_dump=$(
+  SWIFTCORE_DARWIN_ARCH=x86_64 SWIFT_HOST_VARIANT_ARCH=x86_64 \
+    SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
+    SWIFT_TOOLCHAIN="$tcroot" \
+    W=/tmp/swiftcore-print SRC=/tmp/swiftcore-print/swift B=/tmp/swiftcore-print/build \
+    bash "$cfg" --print-flags
+)
+need "$toolchain_dump" "TC=$tcroot/usr" "SWIFT_TOOLCHAIN selects TC"
+rm -rf "$tcroot"
+
+pathroot=$(mktemp -d)
+mkdir -p "$pathroot/bin"
+printf '#!/bin/sh\nexit 0\n' > "$pathroot/bin/swiftc"
+chmod +x "$pathroot/bin/swiftc"
+path_dump=$(
+  PATH="$pathroot/bin:/bin:/usr/bin" \
+    SWIFTCORE_DARWIN_ARCH=x86_64 SWIFT_HOST_VARIANT_ARCH=x86_64 \
+    SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
+    SWIFT_TOOLCHAIN= TC= \
+    W=/tmp/swiftcore-print SRC=/tmp/swiftcore-print/swift B=/tmp/swiftcore-print/build \
+    bash "$cfg" --print-flags
+)
+need "$path_dump" "TC=$pathroot" "command -v swiftc selects TC"
+rm -rf "$pathroot"
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "PASS -- 2 dumps, arm64 path intact, x86_64 is the same argv with arch swapped"

--- a/swiftcore-macho/scripts/test_overlay_siblings.sh
+++ b/swiftcore-macho/scripts/test_overlay_siblings.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# SWIFTCORE_OVERLAYS=1 must not reach CMake with an empty string-processing
+# path (CMakeLists.txt:41 "No SOURCES given"). Same for libdispatch.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cfg=$SCRIPT_DIR/configure.sh
+fail=0
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+need_marker() {
+  local out=$1 marker=$2
+  printf '%s\n' "$out" | grep -F -- "$marker" >/dev/null && echo "  OK  $marker" \
+    || { echo "  FAIL missing $marker"; echo "$out" | head -20; fail=1; }
+}
+
+echo "=== refuse overlays=1 with no checkouts (must not invoke cmake) ==="
+set +e
+out=$(
+  SWIFTCORE_OVERLAYS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    W="$tmp/empty" B="$tmp/empty/build" \
+    bash "$cfg" 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] && echo "  OK  exit 2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
+need_marker "$out" "CANNOT_FETCH_STRING_PROCESSING_SOURCE"
+need_marker "$out" "swift-experimental-string-processing"
+need_marker "$out" "91177e6225c63e885872b83d48e254b1270fa15a"
+printf '%s\n' "$out" | grep -F -- "No SOURCES given to target" >/dev/null \
+  && { echo "  FAIL cmake diagnostic leaked"; fail=1; } \
+  || echo "  OK  no CMakeLists.txt:41 diagnostic"
+[ -f "$tmp/empty/configure.log" ] && grep -q cmake "$tmp/empty/configure.log" 2>/dev/null \
+  && { echo "  FAIL configure.log looks like cmake ran"; fail=1; } \
+  || echo "  OK  cmake not invoked"
+
+echo
+echo "=== refuse BUILD_DISPATCH=1 with no libdispatch ==="
+set +e
+out=$(
+  SWIFTCORE_OVERLAYS=0 SWIFTCORE_BUILD_DISPATCH=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    W="$tmp/nodisp" B="$tmp/nodisp/build" \
+    bash "$cfg" 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] && echo "  OK  exit 2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
+need_marker "$out" "CANNOT_FETCH_LIBDISPATCH_SOURCE"
+need_marker "$out" "swift-corelibs-libdispatch"
+need_marker "$out" "2df91f94651f2d924d7506c9d14685929386d779"
+
+echo
+echo "=== --print-flags with overlays=1 passes both sibling -D paths ==="
+fake=$tmp/print
+mkdir -p "$fake/swift-experimental-string-processing/Sources/_StringProcessing"
+mkdir -p "$fake/libdispatch"
+touch "$fake/libdispatch/CMakeLists.txt"
+dump=$(
+  SWIFTCORE_OVERLAYS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    SWIFT_HOST_VARIANT_ARCH=x86_64 SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
+    W="$fake" bash "$cfg" --print-flags
+)
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$fake/swift-experimental-string-processing" >/dev/null \
+  && echo "  OK  STRING_PROCESSING_SOURCE path" \
+  || { echo "  FAIL missing STRING_PROCESSING -D"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$fake/libdispatch" >/dev/null \
+  && echo "  OK  LIBDISPATCH_SOURCE path" \
+  || { echo "  FAIL missing LIBDISPATCH -D"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=ON" >/dev/null \
+  && echo "  OK  STRING_PROCESSING=ON" \
+  || { echo "  FAIL STRING_PROCESSING not ON"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_SYNCHRONIZATION=ON" >/dev/null \
+  && echo "  OK  SYNCHRONIZATION=ON" \
+  || { echo "  FAIL SYNCHRONIZATION not ON"; fail=1; }
+
+echo
+echo "=== default (overlays off) dump has no empty string-processing -D ==="
+def=$(
+  SWIFTCORE_DARWIN_ARCH=x86_64 SWIFT_HOST_VARIANT_ARCH=x86_64 \
+    SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
+    W=/tmp/swiftcore-print bash "$cfg" --print-flags
+)
+printf '%s\n' "$def" | grep -F -- "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE" >/dev/null \
+  && { echo "  FAIL core dump still passes STRING_PROCESSING path"; fail=1; } \
+  || echo "  OK  core dump has no STRING_PROCESSING path"
+printf '%s\n' "$def" | grep -F -- "-DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=OFF" >/dev/null \
+  && echo "  OK  STRING_PROCESSING=OFF without overlays" \
+  || { echo "  FAIL default STRING_PROCESSING not OFF"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- refuse-before-cmake; sibling paths explicit when overlays=1"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_staged_slice.sh
+++ b/swiftcore-macho/scripts/test_staged_slice.sh
@@ -62,6 +62,17 @@ for rel, meta in man["files"].items():
         print(f"  FAIL {rel} sha/size mismatch"); bad += 1
 if man["source"]["commit"] != "ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b":
     print("  FAIL source commit is not the 6.2.4 pin"); bad += 1
+sib = man.get("siblings") or {}
+want = {
+    "swift-experimental-string-processing": "91177e6225c63e885872b83d48e254b1270fa15a",
+    "swift-corelibs-libdispatch": "2df91f94651f2d924d7506c9d14685929386d779",
+}
+for name, commit in want.items():
+    got = (sib.get(name) or {}).get("commit")
+    if got != commit:
+        print(f"  FAIL sibling {name} commit {got} != {commit}"); bad += 1
+    else:
+        print(f"  OK  sibling {name} @{commit}")
 print(f"  {'OK' if bad==0 else 'FAIL'}  {n} files in x86_64.manifest.json, mismatches={bad}")
 sys.exit(1 if bad else 0)
 PY

--- a/swiftcore-macho/scripts/test_toolchain.sh
+++ b/swiftcore-macho/scripts/test_toolchain.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SWIFT_TOOLCHAIN / command -v swiftc must win over the hardcoded
+# /opt/swift624 path. The operator host keeps 6.2.4 at /opt/swift.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+inc=$SCRIPT_DIR/guest_arch.inc
+fail=0
+
+echo "=== SWIFT_TOOLCHAIN missing dir refuses ==="
+set +e
+out=$(
+  unset TC SWIFTCORE_GUEST_ARCH_INC
+  SWIFT_TOOLCHAIN=/no/such/swiftcore-toolchain
+  # shellcheck disable=SC1091
+  . "$inc" 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] && echo "  OK  exit $rc" || { echo "  FAIL expected nonzero"; fail=1; }
+printf '%s\n' "$out" | grep -F -- "SWIFT_TOOLCHAIN=/no/such/swiftcore-toolchain" >/dev/null \
+  && echo "  OK  names the missing toolchain" \
+  || { echo "  FAIL did not name SWIFT_TOOLCHAIN"; echo "$out"; fail=1; }
+
+echo
+echo "=== SWIFT_TOOLCHAIN with usr/bin/swiftc ==="
+fake=$(mktemp -d)
+trap 'rm -rf "$fake"' EXIT
+mkdir -p "$fake/opt/swift/usr/bin"
+ln -s "$(command -v swiftc)" "$fake/opt/swift/usr/bin/swiftc"
+got=$(
+  unset TC SWIFTCORE_GUEST_ARCH_INC
+  SWIFT_TOOLCHAIN="$fake/opt/swift"
+  # shellcheck disable=SC1091
+  . "$inc"
+  printf '%s\n' "$TC"
+)
+[ "$got" = "$fake/opt/swift/usr" ] && echo "  OK  TC=$got" \
+  || { echo "  FAIL TC=$got want $fake/opt/swift/usr"; fail=1; }
+
+echo
+echo "=== default on this VM finds a swiftc ==="
+got=$(
+  unset TC SWIFT_TOOLCHAIN SWIFTCORE_GUEST_ARCH_INC
+  # shellcheck disable=SC1091
+  . "$inc"
+  printf '%s\n' "$TC"
+)
+[ -x "$got/bin/swiftc" ] && echo "  OK  default TC=$got" \
+  || { echo "  FAIL default TC=$got has no swiftc"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- SWIFT_TOOLCHAIN honored; /opt/swift624 is not the only path"
+  exit 0
+fi
+echo "FAIL"
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Real x86 host run of `phase2.sh` after PR #12 (`libswiftCore-x86=1`, collections/mrroot cold-built) hit three stager defects, none in the platform:

1. **Stale reuse.** `sysroot-fe4-x86 satisfied` was reused from the run *before* x86 libswiftCore existed, so OpenCombine refused with `no x86_64 libswiftCore in scratch/sysroot_fe4-x86_64` while `swiftcore-macho/artifacts/swift-macosx/x86_64/libswiftCore.dylib` sat in-tree. Idempotency keyed on the output directory existing.
2. **No underlying Clang module.** `build_fe.sh` died at `Darwin.swiftinterface: underlying Objective-C module 'Darwin' not found` / `no such module '_DarwinFoundation1._errno'` (the 6.2.1-vs-6.2.4 SDK message is the fallback). Arm64 `full/foundation/stage_fe_sysroot.sh` writes `usr/include/module.modulemap` then runs `machorun/scripts/gen_darwin_modulemap.py`. The x86 stager copied interfaces and skipped that generation.
3. **Swift runtime not in the sysroot.** `libswiftCore`, `Swift.swiftmodule`, and `_Builtin_float` must live at `sysroot_fe4-x86_64/usr/lib/swift` (the arm64 sysroot carries the toolchain layout). Later steps and OpenCombine look there.

Also: `guest_arch: no swiftc at /opt/swift624/usr/bin or /usr/bin` — overlay `guest_arch.inc` ignored `SWIFT_TOOLCHAIN` and `PATH`.

**Addendum (same host, after those sysroot fixes):** `satisfied=16 CANNOT=4`, `opencombine-x86 satisfied`, then `foundationessentials-x86` failed one step further:

```
Calendar.swift:14:17: error: no such module 'os'
```

On arm64 the FE chain builds `full/foundation/os-module` first. The x86 runner did not. A 202-file compile is the wrong way to discover the next missing overlay (`_StringProcessing`, `_Concurrency`, Synchronization).

**Addendum 2 (same host, os-module hand-run):**

```
SYS=$W/scratch/sysroot_fe4-x86_64 OUT=$W/scratch/fe4_os-x86_64 TARGET=x86_64-apple-macos15.0 \
  bash full/foundation/build_os_module.sh
```

failed with `_DarwinFoundation2` defined in both

- `/opt/openuikit/x86-verify/openuikit/scratch/modcache_fe4/…/_DarwinFoundation2-K86O93QRVYC9.pcm`
- `/w/scratch/modcache_fe4/…/_DarwinFoundation2-K86O93QRVYC9.pcm`

Cause: phase2 `host-w-layout` does `ln -sfn $W /w`. Different steps reached the **same** module cache through `$W/…` vs `/w/…`, so clang treated one `.pcm` as two conflicting definitions.

## What changed

- **Input-keyed restage.** `.phase2-stage-inputs` records artifact sha, `gen_darwin_modulemap.py` sha, Darwin overlay/modulemap shas, and a recipe id. A mismatch prints `re-stage sysroot-fe4-x86 (input changed: libswiftCore ABSENT->…)` and restages. Missing stamp is `stamp=ABSENT`, not a silent reuse.
- **Darwin family maps.** After the ObjectiveC `module.modulemap`, run `gen_darwin_modulemap.py` against the x86 sysroot. On Linux (no Xcode/`xcrun`) copy the pruned maps from the arm64 sysroot and print the generator error instead of folding it into “overlays absent”. Missing `Darwin.modulemap` is `CANNOT_DARWIN_CLANG_MODULEMAP`.
- **Swift into `usr/lib/swift`.** Stage x86 `libswiftCore.dylib`, `Swift.swiftmodule/x86_64-apple-macos.*`, `_Builtin_float.swiftmodule/x86_64-apple-macos.*` from in-tree artifacts. Do not copy Apple's `os.swiftmodule` (FE uses the local os-module).
- **Toolchain.** `swiftcore-macho/scripts/guest_arch.inc` honors `SWIFT_TOOLCHAIN` (usr/bin or bin) then `command -v swiftc`; `/opt/swift624` and `/usr` stay last-resort. `phase2.sh` exports `SWIFT_TOOLCHAIN` from the swiftc it actually found.
- **`os-module-x86`.** `full/foundation/build_os_module.sh` with `TARGET=x86_64-apple-macos15.0`, `OUT=build/full-x86_64/foundation/os` (beside arm64 `scratch/fe4_os`), `MC=scratch/modcache_fe4-x86_64`. `build_fe.sh` gets `OSMOD`.
- **`ENV_PREPARE fe-imports`.** Before the 202-file compile, one line lists required Darwin/os/Swift/`_Builtin_float`/`_StringProcessing`/`_Concurrency` and optional Synchronization (`canImport`-guarded). Missing required modules → `CANNOT_FE_IMPORTS` with `present=`/`absent=`. An arm64 slice is not x86 presence.
- **One canonical module cache per target.** `W=$(pwd -P)` so the runner never uses the `/w` symlink spelling. Dedicated `$W/scratch/modcache_fe4-x86_64` is `realpath -P`'d (`phase2_canonical_dir`) and passed as `MC` to every x86 `swiftc` (os-module, collections, FE, OpenCombine). Those scripts also `realpath` `MC` so a hand-run with `W=/w` still has one spelling. `ENV_PREPARE module-cache satisfied path=…` prints the cache so a collision is diagnosable; the os/collections/FE/OpenCombine lines include `mc=`. Fonts still use `/w`; compiler argv does not.

No `machorun/` edits. Pin SHA unchanged. Arm64 trees still beside, never overwritten.

## Tests

`bash scripts/x86/test_phase2.sh` — **106/106** (stamp match / `libswiftCore` old→new / `stamp=ABSENT`; Darwin maps copied when the generator cannot run; fe-imports names `_StringProcessing,_Concurrency` absent in one line; arm64 `_Concurrency` slice refused as x86; `/w`-style symlink and physical cache collapse to one `realpath` path; `MC=` passed to all four x86 `swiftc` steps).

`bash swiftcore-macho/scripts/test_configure_arch.sh` — SWIFT_TOOLCHAIN and `command -v swiftc` both select `TC`.

Live stager on this VM (no Darwin overlays in `scratch/sysroot_fe4`, so exit 3 as designed): x86 `libswiftCore` landed at `usr/lib/swift` (`MH_MAGIC_64 X86_64`, sha `8de09dba…` matching `x86_64.manifest.json`), plus 5 Swift.swiftmodule slices and 5 `_Builtin_float` slices; generator error printed (`xcrun: not found`) rather than folded into overlays.

Collision fixture: two spellings of `_DarwinFoundation2-K86O93QRVYC9.pcm` are the same inode; `phase2_canonical_dir` returns only the physical path.

[phase2 tests including canonical module-cache](https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_modcache_canonical_tests.txt)
[ /w vs $W pcm inode collision fixture](https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase2_modcache_collision_fixture.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

