### PR TITLE
Fetch pinned _StringProcessing / libdispatch siblings before CMake

### DIFF
--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -61,8 +61,13 @@ cshims).
 
 The configure hardcoding is gone: `swiftcore-macho/scripts/guest_arch.inc`
 keeps the arm64 argv as `SWIFTCORE_DARWIN_ARCH=arm64` and selects x86_64 on
-this host. One-command recipe: `docs/X86_64.md` §3 /
-`bash swiftcore-macho/scripts/build_stdlib.sh`.
+this host. One-command recipe: `docs/X86_64.md` §3:
+
+```bash
+NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
+  bash swiftcore-macho/scripts/build_stdlib.sh
+```
 
 ## In-VM (this Cursor x86_64 VM) vs operator host
 

--- a/swiftcore-macho/artifacts/manifest.schema.json
+++ b/swiftcore-macho/artifacts/manifest.schema.json
@@ -16,6 +16,18 @@
         "commit": { "type": "string", "minLength": 40, "maxLength": 40 }
       }
     },
+    "siblings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["repository", "tag", "commit"],
+        "properties": {
+          "repository": { "type": "string" },
+          "tag": { "type": "string" },
+          "commit": { "type": "string", "minLength": 40, "maxLength": 40 }
+        }
+      }
+    },
     "toolchain": { "type": "string" },
     "host": { "type": "string" },
     "generatedAtUtc": { "type": "string" },

--- a/swiftcore-macho/artifacts/x86_64.manifest.json
+++ b/swiftcore-macho/artifacts/x86_64.manifest.json
@@ -54,6 +54,8 @@
   "flags": {
     "SWIFTCORE_DARWIN_ARCH": "x86_64",
     "SWIFTCORE_MACHO_LEGACY_IMAGE_REG": "1",
+    "SWIFT_PATH_TO_LIBDISPATCH_SOURCE": "pinned sibling 2df91f94651f2d924d7506c9d14685929386d779",
+    "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE": "pinned sibling 91177e6225c63e885872b83d48e254b1270fa15a",
     "SWIFT_BUILD_SDK_OVERLAY": "OFF",
     "SWIFT_BUILD_STDLIB": "ON",
     "SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY": "ON",
@@ -70,6 +72,18 @@
     "commit": "ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b",
     "repository": "https://github.com/swiftlang/swift.git",
     "tag": "swift-6.2.4-RELEASE"
+  },
+  "siblings": {
+    "swift-corelibs-libdispatch": {
+      "commit": "2df91f94651f2d924d7506c9d14685929386d779",
+      "repository": "https://github.com/swiftlang/swift-corelibs-libdispatch.git",
+      "tag": "swift-6.2.4-RELEASE"
+    },
+    "swift-experimental-string-processing": {
+      "commit": "91177e6225c63e885872b83d48e254b1270fa15a",
+      "repository": "https://github.com/swiftlang/swift-experimental-string-processing.git",
+      "tag": "swift-6.2.4-RELEASE"
+    }
   },
   "toolchain": "Swift version 6.2.4 (swift-6.2.4-RELEASE)"
 }

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -69,18 +69,30 @@ Overlays, **as applicable**:
 | module | CMake | applicable on this Linux sysroot? |
 |---|---|---|
 | Swift / libswiftCore | `SWIFT_BUILD_STDLIB` | **yes** — the recorded target |
-| `_Concurrency` | `SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON` | yes; may need libdispatch (BUILD_LOG §16 / patch-8 wall) |
+| `_Concurrency` | `SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON` | **yes** with `SWIFTCORE_BUILD_DISPATCH=1` (defaults on when overlays=1); sibling `swift-corelibs-libdispatch` @ `2df91f94651f2d924d7506c9d14685929386d779` |
 | `_Builtin_float` | in-tree with the stdlib | yes |
-| `Synchronization` | `SWIFTCORE_OVERLAYS=1` → `SWIFT_ENABLE_SYNCHRONIZATION=ON` | in-tree; try |
-| `_StringProcessing` | `SWIFTCORE_OVERLAYS=1` → experimental ON | needs extra source; wall if cmake refuses |
+| `Synchronization` | `SWIFTCORE_OVERLAYS=1` → `SWIFT_ENABLE_SYNCHRONIZATION=ON` | **yes**, in-tree |
+| `_StringProcessing` | `SWIFTCORE_OVERLAYS=1` → experimental ON | **yes**, sibling `swift-experimental-string-processing` @ `91177e6225c63e885872b83d48e254b1270fa15a`. Empty path → `CANNOT_FETCH_STRING_PROCESSING_SOURCE` *before* CMake |
 | `swiftDarwin` / `swiftObjectiveC` | `SWIFT_BUILD_SDK_OVERLAY` | **no** — needs Xcode Darwin module maps. Stays OFF. Marker: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 
 ## 3. Operator command (16 vCPU x86 EC2)
 
 ```bash
 NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
   bash swiftcore-macho/scripts/build_stdlib.sh
 ```
+
+`SWIFTCORE_OVERLAYS=1` fetches `swift-experimental-string-processing` and
+defaults `SWIFTCORE_BUILD_DISPATCH=1` (libdispatch) at the
+`swift-6.2.4-RELEASE` commits in `scripts/guest_arch.inc`. Missing either
+checkout prints `CANNOT_FETCH_STRING_PROCESSING_SOURCE` or
+`CANNOT_FETCH_LIBDISPATCH_SOURCE` and exits 2 **before** CMake — the
+previous operator failure was `No SOURCES given to target:
+swift_StringProcessing-macosx-x86_64` forty lines into the log.
+
+`SWIFT_TOOLCHAIN` is the operator prefix (`/opt/swift`). Do not symlink it
+to `/opt/swift624`; `guest_arch.inc` also accepts `command -v swiftc`.
 
 That is bootstrap → x86 libSystem+objc4+.tbd → `stage_sdk.sh` →
 `apply_patches.py` (legacy image-reg) → `configure.sh` →
@@ -103,7 +115,7 @@ libdispatch wall, not a resource miss. Overlays / dispatch on a 16 vCPU host:
 
 ```bash
 NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
-  SWIFTCORE_BUILD_DISPATCH=1 \
+  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
   bash swiftcore-macho/scripts/build_stdlib.sh
 ```
 
@@ -114,6 +126,8 @@ NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
 | check | how | result |
 |---|---|---|
 | configure DRY | `scripts/test_configure_arch.sh` | **PASS** — 2 dumps; arm64 argv intact; x86 is the same flags with arch swapped |
+| overlay preflight | `scripts/test_overlay_siblings.sh` | refuse-before-cmake; both sibling `-D` paths when overlays=1 |
+| SWIFT_TOOLCHAIN | `scripts/test_toolchain.sh` | honors `/opt/swift`; `/opt/swift624` is not the only path |
 | MH_MAGIC_64 X86_64 DYLIB | `llvm-otool-18 -hv` | `MH_MAGIC_64 X86_64 ALL DYLIB` |
 | no arm64 slice | same header must not contain `ARM64` | **OK** |
 | LC_ID_DYLIB | `llvm-otool-18 -D` | `/usr/lib/swift/libswiftCore.dylib` |
@@ -143,8 +157,8 @@ Overlays this run (denominator: 6 named guests):
 |---|---|---|
 | Swift / libswiftCore | **yes** — staged | — |
 | `_Builtin_float` swiftmodule | **yes** — staged | — |
-| `_Concurrency` | **no** — `stdlib/public/Concurrency/dispatch` missing (BUILD_LOG §16 / patch-8). Needs a built libdispatch, `SWIFTCORE_BUILD_DISPATCH=1` | `CANNOT_BUILD_CONCURRENCY_X86` |
-| `_StringProcessing` / `Synchronization` | flags OFF this run (`SWIFTCORE_OVERLAYS` default 0) | operator: `SWIFTCORE_OVERLAYS=1` |
+| `_Concurrency` | **no** until operator reruns with fetched libdispatch | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing; else BUILD_LOG §16 |
+| `_StringProcessing` / `Synchronization` | fetch + explicit `-D` paths; CMake no longer sees `()` | `CANNOT_FETCH_STRING_PROCESSING_SOURCE` |
 | `swiftDarwin` | **no** — `'semaphore.h' file not found` via `LibcOverlayShims.h` | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 | `swiftObjectiveC` | **no** — `SWIFT_BUILD_SDK_OVERLAY=OFF` (needs Xcode module maps) | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 

--- a/swiftcore-macho/scripts/bootstrap_box.sh
+++ b/swiftcore-macho/scripts/bootstrap_box.sh
@@ -73,11 +73,20 @@ clone_tag "$W/swift" https://github.com/swiftlang/swift.git "$SWIFT_PIN_COMMIT"
 echo "=== corelibs-foundation (CoreFoundation headers for the sysroot) ==="
 clone_tag "$W/scf" https://github.com/swiftlang/swift-corelibs-foundation.git
 
-echo "=== swift-corelibs-libdispatch (the Linux-ported tree, NOT apple-oss-distributions) ==="
+echo "=== swift-corelibs-libdispatch (pin $LIBDISPATCH_PIN_COMMIT tag $SWIFT_PIN_TAG) ==="
 # apple-oss-distributions/libdispatch needs DISPATCH_USE_KEVENT_WORKQUEUE + HAVE_MACH.
 # corelibs has the completed Linux port with event_epoll.c in the SAME tree,
 # selected by configuration -- so this is a config choice, not a fork.
-clone_tag "$W/libdispatch" https://github.com/swiftlang/swift-corelibs-libdispatch.git
+# Always pin-fetch: SWIFTCORE_OVERLAYS=1 / SWIFTCORE_BUILD_DISPATCH=1 pass this
+# path into CMake. A missing tree must fail in configure.sh *before* cmake,
+# not 40 lines into a CMake diagnostic.
+clone_tag "$W/libdispatch" "$LIBDISPATCH_REPO" "$LIBDISPATCH_PIN_COMMIT"
+
+if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
+  echo "=== swift-experimental-string-processing (pin $STRING_PROCESSING_PIN_COMMIT tag $SWIFT_PIN_TAG) ==="
+  clone_tag "$W/swift-experimental-string-processing" \
+    "$STRING_PROCESSING_REPO" "$STRING_PROCESSING_PIN_COMMIT"
+fi
 
 mkdir -p "$W/shims"
 echo "bootstrap complete host=$(uname -m) darwin_arch=$SWIFTCORE_DARWIN_ARCH tc=$TC"

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -5,11 +5,18 @@
 # Arm64 on Graviton is still the default on an aarch64 host. This script on an
 # x86_64 host produces the x86_64 slice beside the committed arm64 artifacts.
 #
-# Operator (16 vCPU x86_64 Ubuntu 24.04, clang-18, Swift 6.2.4):
+# Operator (16 vCPU x86_64 Ubuntu 24.04, clang-18, Swift 6.2.4).
+# SWIFT_TOOLCHAIN honors /opt/swift (do not symlink it to /opt/swift624):
 #
 #   NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+#     SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
 #     bash swiftcore-macho/scripts/build_stdlib.sh
 #
+# SWIFTCORE_OVERLAYS=1 fetches swift-experimental-string-processing and
+# (via BUILD_DISPATCH default 1) swift-corelibs-libdispatch at the
+# swift-6.2.4-RELEASE commits in guest_arch.inc. CMake is refused with
+# CANNOT_FETCH_*_SOURCE if either checkout is missing.
+
 # This 4-vCPU / 15 GiB cloud-agent VM uses NINJA_JOBS=2. It will configure and
 # compile as far as RAM/time allow; it will not fake a dylib. Execution of the
 # linked guest is refused here — that is the operator host's job.
@@ -25,7 +32,15 @@ B=${B:-$W/build}
 MACHORUN=${MACHORUN:-$OPENUIKIT_ROOT/machorun}
 NINJA_JOBS=${NINJA_JOBS:-2}
 STOP_AFTER=${STOP_AFTER:-}   # configure | ninja-first | link | all
+# Overlays imply dispatch: phase-2 needs _Concurrency as well as
+# _StringProcessing / Synchronization. Operator may still set
+# SWIFTCORE_BUILD_DISPATCH=1 explicitly.
+if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
+  SWIFTCORE_BUILD_DISPATCH=${SWIFTCORE_BUILD_DISPATCH:-1}
+fi
 export W B TC SWIFTCORE_DARWIN_ARCH SWIFT_HOST_VARIANT_ARCH
+export SWIFTCORE_OVERLAYS SWIFTCORE_BUILD_DISPATCH
+export SWIFT_TOOLCHAIN SWIFT_PATH_TO_STRING_PROCESSING_SOURCE SWIFT_PATH_TO_LIBDISPATCH_SOURCE
 
 mkdir -p "$W"
 step() { printf '\n==== %s ====\n' "$*"; }
@@ -181,6 +196,7 @@ else
   echo "objects compiled: $obj_n"
   echo "This VM did not produce the dylib. Operator command:"
   echo "  NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \\"
+  echo "    SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \\"
   echo "    bash swiftcore-macho/scripts/build_stdlib.sh"
   exit 2
 fi

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -41,11 +41,18 @@ done
 # _Concurrency (already on), Synchronization, experimental StringProcessing.
 # Darwin/ObjectiveC SDK overlays stay OFF: SWIFT_BUILD_SDK_OVERLAY needs
 # Xcode module maps this Linux sysroot does not have. See docs/X86_64.md.
+#
+# Phase-2 guests load _Concurrency + _StringProcessing + Synchronization.
+# Overlays therefore also fetch/pass libdispatch (BUILD_LOG §16): CMake with
+# STRING_PROCESSING=ON and an empty SWIFT_PATH_TO_STRING_PROCESSING_SOURCE
+# dies at stdlib/public/StringProcessing/CMakeLists.txt:41 ("No SOURCES
+# given to target") forty lines into the log. Refuse *before* cmake.
 OVERLAY_STRING=OFF
 OVERLAY_SYNC=OFF
 if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
   OVERLAY_STRING=ON
   OVERLAY_SYNC=ON
+  SWIFTCORE_BUILD_DISPATCH=${SWIFTCORE_BUILD_DISPATCH:-1}
 fi
 
 SYNTAX_FLAG=()
@@ -53,9 +60,59 @@ if [ -d "$W/swift-syntax" ]; then
   SYNTAX_FLAG=(-DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="$W/swift-syntax")
 fi
 
+STRING_PROCESSING_SRC=${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE:-$W/swift-experimental-string-processing}
+LIBDISPATCH_SRC=${SWIFT_PATH_TO_LIBDISPATCH_SOURCE:-$W/libdispatch}
+
+STRING_FLAG=()
 DISPATCH_FLAG=()
-if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ] && [ -d "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE:-$W/libdispatch}" ]; then
-  DISPATCH_FLAG=(-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="${SWIFT_PATH_TO_LIBDISPATCH_SOURCE:-$W/libdispatch}")
+
+refuse_checkout() {
+  local marker=$1 checkout=$2 pin=$3 expected=$4
+  echo "$marker checkout=$checkout pin=$pin tag=$SWIFT_PIN_TAG expected=$expected" >&2
+  echo "  bootstrap: SWIFTCORE_OVERLAYS=1 bash $SCRIPT_DIR/bootstrap_box.sh" >&2
+  echo "  do not invoke CMake with an empty sibling path" >&2
+  exit 2
+}
+
+# --print-flags is a dry dump (test_configure_arch.sh). The refuse is for the
+# real configure, before cmake, so the operator sees the missing checkout
+# instead of CMakeLists.txt:41.
+if [ "$PRINT_FLAGS" != 1 ]; then
+  if [ "$OVERLAY_STRING" = ON ]; then
+    if [ ! -d "$STRING_PROCESSING_SRC/Sources/_StringProcessing" ]; then
+      refuse_checkout CANNOT_FETCH_STRING_PROCESSING_SOURCE \
+        swift-experimental-string-processing "$STRING_PROCESSING_PIN_COMMIT" \
+        "$STRING_PROCESSING_SRC"
+    fi
+    if [ -d "$STRING_PROCESSING_SRC/.git" ]; then
+      got=$(git -C "$STRING_PROCESSING_SRC" rev-parse HEAD)
+      if [ "$got" != "$STRING_PROCESSING_PIN_COMMIT" ]; then
+        echo "CANNOT_FETCH_STRING_PROCESSING_SOURCE checkout=swift-experimental-string-processing reason=commit-mismatch have=$got want=$STRING_PROCESSING_PIN_COMMIT" >&2
+        exit 2
+      fi
+    fi
+  fi
+  if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ]; then
+    if [ ! -d "$LIBDISPATCH_SRC" ] || [ ! -f "$LIBDISPATCH_SRC/CMakeLists.txt" ]; then
+      refuse_checkout CANNOT_FETCH_LIBDISPATCH_SOURCE \
+        swift-corelibs-libdispatch "$LIBDISPATCH_PIN_COMMIT" \
+        "$LIBDISPATCH_SRC"
+    fi
+    if [ -d "$LIBDISPATCH_SRC/.git" ]; then
+      got=$(git -C "$LIBDISPATCH_SRC" rev-parse HEAD)
+      if [ "$got" != "$LIBDISPATCH_PIN_COMMIT" ]; then
+        echo "CANNOT_FETCH_LIBDISPATCH_SOURCE checkout=swift-corelibs-libdispatch reason=commit-mismatch have=$got want=$LIBDISPATCH_PIN_COMMIT" >&2
+        exit 2
+      fi
+    fi
+  fi
+fi
+
+if [ "$OVERLAY_STRING" = ON ]; then
+  STRING_FLAG=(-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE="$STRING_PROCESSING_SRC")
+fi
+if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ]; then
+  DISPATCH_FLAG=(-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="$LIBDISPATCH_SRC")
 fi
 
 CMAKE_ARGS=(
@@ -106,6 +163,7 @@ CMAKE_ARGS=(
   -DSWIFT_ENABLE_BACKTRACING=OFF
   -DSWIFT_STDLIB_ENABLE_OBJC_INTEROP=ON
   -DSWIFT_INCLUDE_APINOTES=ON
+  "${STRING_FLAG[@]}"
   "${DISPATCH_FLAG[@]}"
   "${CMAKE_EXTRA[@]}"
 )
@@ -120,6 +178,10 @@ if [ "$PRINT_FLAGS" = 1 ]; then
   printf 'SDK=%s\n' "$SDK"
   printf 'SRC=%s\n' "$SRC"
   printf 'B=%s\n' "$B"
+  printf 'SWIFTCORE_OVERLAYS=%s\n' "${SWIFTCORE_OVERLAYS:-0}"
+  printf 'SWIFTCORE_BUILD_DISPATCH=%s\n' "${SWIFTCORE_BUILD_DISPATCH:-0}"
+  printf 'STRING_PROCESSING_SRC=%s\n' "$STRING_PROCESSING_SRC"
+  printf 'LIBDISPATCH_SRC=%s\n' "$LIBDISPATCH_SRC"
   printf 'cmake'
   for a in "${CMAKE_ARGS[@]}"; do
     printf ' %q' "$a"

--- a/swiftcore-macho/scripts/guest_arch.inc
+++ b/swiftcore-macho/scripts/guest_arch.inc
@@ -60,20 +60,55 @@ case "$SWIFTCORE_DARWIN_ARCH" in
         ;;
 esac
 
-# Stock swift.org 6.2.4: /opt/swift624 on the Graviton box, /usr on the
-# swift:6.2-noble image this VM boots from.
-if [ -z "${TC:-}" ]; then
-    if [ -x /opt/swift624/usr/bin/swiftc ]; then
-        TC=/opt/swift624/usr
-    elif [ -x /usr/bin/swiftc ]; then
-        TC=/usr
-    else
-        echo "guest_arch: no swiftc at /opt/swift624/usr/bin or /usr/bin" >&2
+# Toolchain prefix (directory that contains bin/swiftc). Honor SWIFT_TOOLCHAIN
+# first — the operator x86 host keeps Swift 6.2.4 at /opt/swift, not the
+# Graviton path /opt/swift624. Then TC, then well-known prefixes, then
+# `command -v swiftc`.
+_sc_tc_from() {
+    local root=$1
+    if [ -x "$root/bin/swiftc" ]; then
+        printf '%s\n' "$root"
+        return 0
+    fi
+    if [ -x "$root/usr/bin/swiftc" ]; then
+        printf '%s\n' "$root/usr"
+        return 0
+    fi
+    return 1
+}
+if [ -n "${SWIFT_TOOLCHAIN:-}" ]; then
+    TC=$(_sc_tc_from "$SWIFT_TOOLCHAIN") || {
+        echo "guest_arch: SWIFT_TOOLCHAIN=$SWIFT_TOOLCHAIN has no bin/swiftc" >&2
+        exit 1
+    }
+elif [ -z "${TC:-}" ]; then
+    TC=""
+    for _sc_cand in /opt/swift624/usr /opt/swift624 /opt/swift/usr /opt/swift /usr; do
+        if TC=$(_sc_tc_from "$_sc_cand"); then
+            break
+        fi
+        TC=""
+    done
+    if [ -z "$TC" ]; then
+        _sc_swiftc=$(command -v swiftc 2>/dev/null || true)
+        if [ -n "$_sc_swiftc" ]; then
+            TC=$(cd "$(dirname "$_sc_swiftc")/.." && pwd)
+        fi
+    fi
+    if [ -z "$TC" ] || [ ! -x "$TC/bin/swiftc" ]; then
+        echo "guest_arch: no swiftc (set SWIFT_TOOLCHAIN or TC, or put swiftc on PATH)" >&2
         exit 1
     fi
 fi
+unset -f _sc_tc_from
+unset _sc_cand _sc_swiftc
 
 # Pinned by BUILD_LOG.md and full/observation/UPSTREAM.md. Tag is a label;
-# the commit is the pin.
+# the commit is the pin. Sibling tags are the same label on each repo;
+# ls-remote of swift-6.2.4-RELEASE on 2026-09-03.
 SWIFT_PIN_TAG=swift-6.2.4-RELEASE
 SWIFT_PIN_COMMIT=ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b
+STRING_PROCESSING_PIN_COMMIT=91177e6225c63e885872b83d48e254b1270fa15a
+LIBDISPATCH_PIN_COMMIT=2df91f94651f2d924d7506c9d14685929386d779
+STRING_PROCESSING_REPO=https://github.com/swiftlang/swift-experimental-string-processing.git
+LIBDISPATCH_REPO=https://github.com/swiftlang/swift-corelibs-libdispatch.git

--- a/swiftcore-macho/scripts/stage_artifacts.sh
+++ b/swiftcore-macho/scripts/stage_artifacts.sh
@@ -97,11 +97,13 @@ done < <(find "$SRC_DIR/macosx" -maxdepth 1 -type d -name '*.swiftmodule' -print
 }
 
 python3 - "$MANIFEST" "$SWIFTCORE_DARWIN_ARCH" "$SWIFTCORE_MODULE_TRIPLE" \
-  "$SWIFT_PIN_COMMIT" "$SWIFT_PIN_TAG" "$DEST_ROOT" "$DEST_LIB" <<'PY'
+  "$SWIFT_PIN_COMMIT" "$SWIFT_PIN_TAG" "$DEST_ROOT" "$DEST_LIB" \
+  "$STRING_PROCESSING_PIN_COMMIT" "$LIBDISPATCH_PIN_COMMIT" <<'PY'
 import hashlib, json, os, sys, time
 from pathlib import Path
 
-manifest, arch, module_triple, commit, tag, dest_root, dest_lib = sys.argv[1:]
+(manifest, arch, module_triple, commit, tag, dest_root, dest_lib,
+ sp_commit, dispatch_commit) = sys.argv[1:]
 
 def sha256(p: Path):
     h = hashlib.sha256()
@@ -129,6 +131,18 @@ payload = {
         "tag": tag,
         "commit": commit,
     },
+    "siblings": {
+        "swift-experimental-string-processing": {
+            "repository": "https://github.com/swiftlang/swift-experimental-string-processing.git",
+            "tag": tag,
+            "commit": sp_commit,
+        },
+        "swift-corelibs-libdispatch": {
+            "repository": "https://github.com/swiftlang/swift-corelibs-libdispatch.git",
+            "tag": tag,
+            "commit": dispatch_commit,
+        },
+    },
     "patches": "scripts/apply_patches.py 1-5+7; patch 5 via SWIFTCORE_MACHO_LEGACY_IMAGE_REG=1; patch 6 (isa widen) off",
     "flags": {
         "SWIFTCORE_DARWIN_ARCH": arch,
@@ -139,6 +153,8 @@ payload = {
         "SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY": "ON",
         "SWIFT_BUILD_SDK_OVERLAY": "OFF",
         "SWIFTCORE_MACHO_LEGACY_IMAGE_REG": "1",
+        "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE": "pinned sibling",
+        "SWIFT_PATH_TO_LIBDISPATCH_SOURCE": "pinned sibling",
     },
     "toolchain": "Swift version 6.2.4 (swift-6.2.4-RELEASE)",
     "host": os.uname().machine + "-unknown-linux-gnu",

--- a/swiftcore-macho/scripts/test_overlay_siblings.sh
+++ b/swiftcore-macho/scripts/test_overlay_siblings.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# SWIFTCORE_OVERLAYS=1 must not reach CMake with an empty string-processing
+# path (CMakeLists.txt:41 "No SOURCES given"). Same for libdispatch.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cfg=$SCRIPT_DIR/configure.sh
+fail=0
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+need_marker() {
+  local out=$1 marker=$2
+  printf '%s\n' "$out" | grep -F -- "$marker" >/dev/null && echo "  OK  $marker" \
+    || { echo "  FAIL missing $marker"; echo "$out" | head -20; fail=1; }
+}
+
+echo "=== refuse overlays=1 with no checkouts (must not invoke cmake) ==="
+set +e
+out=$(
+  SWIFTCORE_OVERLAYS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    W="$tmp/empty" B="$tmp/empty/build" \
+    bash "$cfg" 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] && echo "  OK  exit 2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
+need_marker "$out" "CANNOT_FETCH_STRING_PROCESSING_SOURCE"
+need_marker "$out" "swift-experimental-string-processing"
+need_marker "$out" "91177e6225c63e885872b83d48e254b1270fa15a"
+printf '%s\n' "$out" | grep -F -- "No SOURCES given to target" >/dev/null \
+  && { echo "  FAIL cmake diagnostic leaked"; fail=1; } \
+  || echo "  OK  no CMakeLists.txt:41 diagnostic"
+[ -f "$tmp/empty/configure.log" ] && grep -q cmake "$tmp/empty/configure.log" 2>/dev/null \
+  && { echo "  FAIL configure.log looks like cmake ran"; fail=1; } \
+  || echo "  OK  cmake not invoked"
+
+echo
+echo "=== refuse BUILD_DISPATCH=1 with no libdispatch ==="
+set +e
+out=$(
+  SWIFTCORE_OVERLAYS=0 SWIFTCORE_BUILD_DISPATCH=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    W="$tmp/nodisp" B="$tmp/nodisp/build" \
+    bash "$cfg" 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] && echo "  OK  exit 2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
+need_marker "$out" "CANNOT_FETCH_LIBDISPATCH_SOURCE"
+need_marker "$out" "swift-corelibs-libdispatch"
+need_marker "$out" "2df91f94651f2d924d7506c9d14685929386d779"
+
+echo
+echo "=== --print-flags with overlays=1 passes both sibling -D paths ==="
+fake=$tmp/print
+mkdir -p "$fake/swift-experimental-string-processing/Sources/_StringProcessing"
+mkdir -p "$fake/libdispatch"
+touch "$fake/libdispatch/CMakeLists.txt"
+dump=$(
+  SWIFTCORE_OVERLAYS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    SWIFT_HOST_VARIANT_ARCH=x86_64 SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
+    W="$fake" bash "$cfg" --print-flags
+)
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$fake/swift-experimental-string-processing" >/dev/null \
+  && echo "  OK  STRING_PROCESSING_SOURCE path" \
+  || { echo "  FAIL missing STRING_PROCESSING -D"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$fake/libdispatch" >/dev/null \
+  && echo "  OK  LIBDISPATCH_SOURCE path" \
+  || { echo "  FAIL missing LIBDISPATCH -D"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=ON" >/dev/null \
+  && echo "  OK  STRING_PROCESSING=ON" \
+  || { echo "  FAIL STRING_PROCESSING not ON"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_SYNCHRONIZATION=ON" >/dev/null \
+  && echo "  OK  SYNCHRONIZATION=ON" \
+  || { echo "  FAIL SYNCHRONIZATION not ON"; fail=1; }
+
+echo
+echo "=== default (overlays off) dump has no empty string-processing -D ==="
+def=$(
+  SWIFTCORE_DARWIN_ARCH=x86_64 SWIFT_HOST_VARIANT_ARCH=x86_64 \
+    SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
+    W=/tmp/swiftcore-print bash "$cfg" --print-flags
+)
+printf '%s\n' "$def" | grep -F -- "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE" >/dev/null \
+  && { echo "  FAIL core dump still passes STRING_PROCESSING path"; fail=1; } \
+  || echo "  OK  core dump has no STRING_PROCESSING path"
+printf '%s\n' "$def" | grep -F -- "-DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=OFF" >/dev/null \
+  && echo "  OK  STRING_PROCESSING=OFF without overlays" \
+  || { echo "  FAIL default STRING_PROCESSING not OFF"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- refuse-before-cmake; sibling paths explicit when overlays=1"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_staged_slice.sh
+++ b/swiftcore-macho/scripts/test_staged_slice.sh
@@ -62,6 +62,17 @@ for rel, meta in man["files"].items():
         print(f"  FAIL {rel} sha/size mismatch"); bad += 1
 if man["source"]["commit"] != "ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b":
     print("  FAIL source commit is not the 6.2.4 pin"); bad += 1
+sib = man.get("siblings") or {}
+want = {
+    "swift-experimental-string-processing": "91177e6225c63e885872b83d48e254b1270fa15a",
+    "swift-corelibs-libdispatch": "2df91f94651f2d924d7506c9d14685929386d779",
+}
+for name, commit in want.items():
+    got = (sib.get(name) or {}).get("commit")
+    if got != commit:
+        print(f"  FAIL sibling {name} commit {got} != {commit}"); bad += 1
+    else:
+        print(f"  OK  sibling {name} @{commit}")
 print(f"  {'OK' if bad==0 else 'FAIL'}  {n} files in x86_64.manifest.json, mismatches={bad}")
 sys.exit(1 if bad else 0)
 PY

--- a/swiftcore-macho/scripts/test_toolchain.sh
+++ b/swiftcore-macho/scripts/test_toolchain.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SWIFT_TOOLCHAIN / command -v swiftc must win over the hardcoded
+# /opt/swift624 path. The operator host keeps 6.2.4 at /opt/swift.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+inc=$SCRIPT_DIR/guest_arch.inc
+fail=0
+
+echo "=== SWIFT_TOOLCHAIN missing dir refuses ==="
+set +e
+out=$(
+  unset TC SWIFTCORE_GUEST_ARCH_INC
+  SWIFT_TOOLCHAIN=/no/such/swiftcore-toolchain
+  # shellcheck disable=SC1091
+  . "$inc" 2>&1
+)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] && echo "  OK  exit $rc" || { echo "  FAIL expected nonzero"; fail=1; }
+printf '%s\n' "$out" | grep -F -- "SWIFT_TOOLCHAIN=/no/such/swiftcore-toolchain" >/dev/null \
+  && echo "  OK  names the missing toolchain" \
+  || { echo "  FAIL did not name SWIFT_TOOLCHAIN"; echo "$out"; fail=1; }
+
+echo
+echo "=== SWIFT_TOOLCHAIN with usr/bin/swiftc ==="
+fake=$(mktemp -d)
+trap 'rm -rf "$fake"' EXIT
+mkdir -p "$fake/opt/swift/usr/bin"
+ln -s "$(command -v swiftc)" "$fake/opt/swift/usr/bin/swiftc"
+got=$(
+  unset TC SWIFTCORE_GUEST_ARCH_INC
+  SWIFT_TOOLCHAIN="$fake/opt/swift"
+  # shellcheck disable=SC1091
+  . "$inc"
+  printf '%s\n' "$TC"
+)
+[ "$got" = "$fake/opt/swift/usr" ] && echo "  OK  TC=$got" \
+  || { echo "  FAIL TC=$got want $fake/opt/swift/usr"; fail=1; }
+
+echo
+echo "=== default on this VM finds a swiftc ==="
+got=$(
+  unset TC SWIFT_TOOLCHAIN SWIFTCORE_GUEST_ARCH_INC
+  # shellcheck disable=SC1091
+  . "$inc"
+  printf '%s\n' "$TC"
+)
+[ -x "$got/bin/swiftc" ] && echo "  OK  default TC=$got" \
+  || { echo "  FAIL default TC=$got has no swiftc"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- SWIFT_TOOLCHAIN honored; /opt/swift624 is not the only path"
+  exit 0
+fi
+echo "FAIL"
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The operator one-command from PR #12 failed at CMake on the 16 vCPU x86 host:

```
-- Synchronization Support: ON
-- Using Experimental String Processing library for _StringProcessing ().
No SOURCES given to target: swift_StringProcessing-macosx-x86_64
  (stdlib/public/StringProcessing/CMakeLists.txt:41)
build_stdlib rc=1
```

The `()` is an empty `SWIFT_PATH_TO_STRING_PROCESSING_SOURCE`. `SWIFTCORE_OVERLAYS=1` turned the flag ON but `build_stdlib.sh` did not fetch `swift-experimental-string-processing`. Same class of miss for `SWIFTCORE_BUILD_DISPATCH=1` / libdispatch (BUILD_LOG §16). The toolchain lookup also hardcoded `/opt/swift624`, so the operator had to symlink `/opt/swift`.

## What changed

Pins (tag `swift-6.2.4-RELEASE`, commit is the pin, `ls-remote` 2026-09-03):

| checkout | commit |
|---|---|
| `swiftlang/swift` | `ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b` (unchanged) |
| `swift-experimental-string-processing` | `91177e6225c63e885872b83d48e254b1270fa15a` |
| `swift-corelibs-libdispatch` | `2df91f94651f2d924d7506c9d14685929386d779` |

Recorded in `artifacts/x86_64.manifest.json` `siblings` (12/12 file hashes unchanged; arm64 `libswiftCore` still `dd01686e…12708cb`).

- `bootstrap_box.sh` pin-fetches libdispatch always, and string-processing when `SWIFTCORE_OVERLAYS=1`.
- `configure.sh` passes `-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE` and `-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE` explicitly. If either tree is missing or at the wrong commit it prints `CANNOT_FETCH_STRING_PROCESSING_SOURCE` / `CANNOT_FETCH_LIBDISPATCH_SOURCE` and **exits 2 before cmake** — no CMakeLists.txt:41.
- `guest_arch.inc` honors `SWIFT_TOOLCHAIN` then `TC` then `/opt/swift` then `command -v swiftc`. No symlink required.
- `SWIFTCORE_OVERLAYS=1` defaults `SWIFTCORE_BUILD_DISPATCH=1` because phase 2 needs `_Concurrency` as well as `_StringProcessing` / `Synchronization`.

## Verification (this VM)

| check | result |
|---|---|
| `test_configure_arch.sh` | PASS — 2 dumps, arm64 path intact |
| `test_overlay_siblings.sh` | PASS — refuse-before-cmake; both `-D` paths when overlays=1; core dump has no empty string-processing path |
| `test_toolchain.sh` | PASS — `SWIFT_TOOLCHAIN=/opt/swift/usr` layout; missing toolchain named |
| `test_staged_slice.sh` | PASS — 12/12 files; sibling pins; arm64 sha unchanged |
| CMake `SWIFTCORE_OVERLAYS=1` | **exit 0** in 3.6s. Log: `_StringProcessing (/home/ubuntu/work/swift-experimental-string-processing)` — not `()`. No `No SOURCES given to target`. |

Did **not** ninja the overlay dylibs here (4 vCPU / 15 GiB). That is the operator rerun.

[CANNOT_FETCH_STRING_PROCESSING_SOURCE before CMake](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_refuse_before_cmake.png)
[CMake log with filled string-processing path](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_cmake_string_processing_path.png)

## Operator command (rerun on the 16 vCPU box)

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

No `/opt/swift` → `/opt/swift624` symlink. Execution of the linked guest is still `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST` in the cloud VM; the operator host runs it.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35369cc-b509-457d-83ef-c090127c9afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

