### PR TITLE
Classify SwiftUI extension members from compact demangle

### DIFF
--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -980,9 +980,10 @@ llvm-objdump-18 --macho --bind "$OUT/focus_widget_guest" \
     > "$AUDIT/focus_widget_guest.bind"
 
 # Universal, non-vacuous two-level provider gate. Every symbol owned by
-# SwiftUI, OpenUIKit, or OpenCoreGraphics is classified, including associated
-# type descriptors, conformances, and extensions whose mangling does not begin
-# with its declaring module. Unknown framework-bearing manglings fail closed.
+# SwiftUI, OpenUIKit, OpenCoreGraphics, or FoundationEssentials is classified,
+# including associated type descriptors, conformances, and extensions whose
+# mangling does not begin with its declaring module. Unknown framework-bearing
+# manglings fail closed.
 # Every import is matched to every bind-table row and the exact defining
 # sibling; every definition is checked for reverse ownership.
 perl "$ATTEST" providers --nm llvm-nm-18 --objdump llvm-objdump-18 \
@@ -990,6 +991,7 @@ perl "$ATTEST" providers --nm llvm-nm-18 --objdump llvm-objdump-18 \
     --openuikit "$PACKAGE/libOpenUIKit.dylib" \
     --opencoregraphics "$PACKAGE/libOpenCoreGraphics.dylib" \
     --swiftui "$PACKAGE/libSwiftUI.dylib" \
+    --foundationessentials "$PACKAGE/libFoundationEssentials.dylib" \
     --combine "$PACKAGE/libCombine.dylib" \
     --opencombine "$PACKAGE/libOpenCombine.dylib" \
     --executable "$OUT/focus_widget_guest" \

--- a/full/swiftui/focus_widget_guest_attest.pl
+++ b/full/swiftui/focus_widget_guest_attest.pl
@@ -506,8 +506,10 @@ sub conformance_classifier_selftest {
         OpenCombine => 'libOpenCombine',
     );
 
-    # Authority reverse-ownership failure on main 8e12b714: libSwiftUI
-    # defines this Mc for `extension CGFloat: _OpenVectorArithmetic`.
+    # Authority reverse-ownership failures on the same SwiftUI extension of
+    # OpenCoreGraphics.CGFloat: Mc/WP/Wp for `_OpenVectorArithmetic` (main
+    # 8e12b714) and the property descriptor `MV` for `magnitudeSquared`
+    # (main 473b3860). Extension members are SwiftUI's, not the type's.
     my @positive = (
         [
             '_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADMc',
@@ -521,6 +523,20 @@ sub conformance_classifier_selftest {
         ],
         [
             '_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADWp',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
+        [
+            '_$s16OpenCoreGraphics7CGFloatV7SwiftUIE16magnitudeSquaredSdvpMV',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
+        # TextAttributes.swift `extension AttributeScopes { var swiftUI }`.
+        # Compact demangle uses Double as a parseable value encoding; ARM64
+        # may emit the nested SwiftUIAttributes metatype. Owner is the
+        # `(extension in SwiftUI):` clause either way.
+        [
+            '_$s20FoundationEssentials15AttributeScopesO7SwiftUIE7swiftUISdvpMV',
             'SwiftUI',
             'libSwiftUI',
         ],
@@ -572,46 +588,45 @@ sub framework_tokens {
         qw(SwiftUI OpenUIKit OpenCoreGraphics Combine OpenCombine);
 }
 
-# Protocol-conformance descriptors (`Mc`) and witness tables (`WP` / `Wp`)
-# mangle the conforming TYPE's module first. The module that emitted the
-# symbol is the one that declared the conformance; classify by the PROTOCOL
-# module from swift-demangle, not by slicing the mangled name. Reverse
-# ownership then treats a matching defining dylib as the symbol's owner.
-sub conformance_protocol_module {
+sub demangle_compact {
     my ($demangle, $symbol) = @_;
-    return (undef, undef) unless $symbol =~ /(?:Mc|WP|Wp)\z/;
     my $expanded = capture_command($demangle, '--compact', $symbol);
     $expanded =~ s/[\r\n]+\z//;
     fail("demangler returned multiple lines for $symbol") if $expanded =~ /[\r\n]/;
+    return $expanded;
+}
+
+# Owning module from compact demangle, in this order:
+#   1. `(extension in M):` anywhere → M (SwiftUI's CGFloat.magnitudeSquared MV
+#      and AttributeScopes.swiftUI; compact form is often
+#      `property descriptor for (extension in SwiftUI):…`, not a leading match)
+#   2. `… : M.Protocol in M2` conformance/witness (Mc/WP/Wp) → protocol module M
+#   3. otherwise undef (caller falls back to the leading nominal-type module)
+sub owning_module_from_demangle {
+    my ($expanded) = @_;
+    return undef unless defined $expanded && length $expanded;
     my $modules = join('|', map { quotemeta($_->[0]) } @FRAMEWORK_MODULES);
-    if ($expanded =~
-        /^(?:protocol conformance descriptor|protocol witness table(?: pattern)?) for .+ : ($modules)\./)
-    {
-        return ($1, $expanded);
-    }
-    return (undef, $expanded);
+    return $1 if $expanded =~ /\(extension in ($modules)\):/;
+    return $1 if $expanded =~
+        /^(?:protocol conformance descriptor|protocol witness table(?: pattern)?) for .+ : ($modules)\./;
+    return undef;
 }
 
 sub classify_framework_symbol {
     my ($demangle, $symbol) = @_;
-    my ($conformance_module, $conformance_expanded) =
-        conformance_protocol_module($demangle, $symbol);
-    return ($conformance_module, $conformance_expanded)
-        if defined $conformance_module;
-
     my $prefix = prefixed_swift_module($symbol);
-    return ($prefix, undef) if defined $prefix;
-
     my @mentioned = framework_tokens($symbol);
-    return (undef, undef) unless @mentioned;
-    my $expanded = capture_command($demangle, '--compact', $symbol);
-    $expanded =~ s/[\r\n]+\z//;
-    fail("demangler returned multiple lines for $symbol") if $expanded =~ /[\r\n]/;
+    return (undef, undef) unless defined $prefix || @mentioned;
+
+    my $expanded = demangle_compact($demangle, $symbol);
+    my $from_demangle = owning_module_from_demangle($expanded);
+    return ($from_demangle, $expanded) if defined $from_demangle;
+    return ($prefix, $expanded) if defined $prefix;
+
     my @owners;
     for my $module (qw(SwiftUI OpenUIKit OpenCoreGraphics Combine OpenCombine)) {
         push @owners, $module
-            if $expanded =~ /\(extension in \Q$module\E\):/
-            || $expanded =~ /^associated type descriptor for \Q$module\E\./
+            if $expanded =~ /^associated type descriptor for \Q$module\E\./
             || $expanded =~ /\bin \Q$module\E\z/;
     }
     fail("ambiguous framework owner [@owners] for $symbol ($expanded)") if @owners > 1;
@@ -688,17 +703,6 @@ sub provider_command {
         my @undefined = symbol_records($demangle, capture_command($nm, '-u', $paths{$image}));
         for my $record (@defined) {
             my ($symbol, $module) = @$record;
-            # A method declared in one framework as an extension of a type
-            # owned by another begins with the extended type's module.  Only
-            # definitions outside that default owner need the more expensive
-            # demangle; require an explicit `(extension in Module):` result.
-            if ($definition_owner{$module} ne $image) {
-                my $expanded = capture_command($demangle, '--compact', $symbol);
-                $expanded =~ s/[\r\n]+\z//;
-                if ($expanded =~ /^\(extension in (SwiftUI|OpenUIKit|OpenCoreGraphics|Combine|OpenCombine)\):/) {
-                    $module = $1;
-                }
-            }
             $definitions{$image}{$symbol} = 1;
             $symbol_module{$symbol} = $module;
             $counts{$image}{defined}{$module}++;

--- a/full/swiftui/focus_widget_guest_attest.pl
+++ b/full/swiftui/focus_widget_guest_attest.pl
@@ -399,6 +399,7 @@ my @FRAMEWORK_MODULES = (
     [ 'SwiftUI', 7 ],
     [ 'OpenUIKit', 9 ],
     [ 'OpenCoreGraphics', 16 ],
+    [ 'FoundationEssentials', 20 ],
     [ 'Combine', 7 ],
     [ 'OpenCombine', 11 ],
 );
@@ -502,6 +503,7 @@ sub conformance_classifier_selftest {
         SwiftUI => 'libSwiftUI',
         OpenUIKit => 'libOpenUIKit',
         OpenCoreGraphics => 'libOpenCoreGraphics',
+        FoundationEssentials => 'libFoundationEssentials',
         Combine => 'libCombine',
         OpenCombine => 'libOpenCombine',
     );
@@ -540,6 +542,16 @@ sub conformance_classifier_selftest {
             'SwiftUI',
             'libSwiftUI',
         ],
+        [
+            '_$s20FoundationEssentials15AttributeScopesO7SwiftUIE7swiftUISdvg',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
+        [
+            '_$s20FoundationEssentials22AttributeDynamicLookupO7SwiftUIEyxqd__cluig',
+            'SwiftUI',
+            'libSwiftUI',
+        ],
     );
     for my $fixture (@positive) {
         my ($symbol, $expected_module, $defining_image) = @$fixture;
@@ -551,10 +563,16 @@ sub conformance_classifier_selftest {
             unless $definition_owner{$actual} eq $defining_image;
     }
 
-    # Nominal type descriptor for the same foreign CGFloat: still owned by
-    # OpenCoreGraphics. libSwiftUI defining it must keep failing.
+    # Nominal type descriptors for the foreign CGFloat / AttributeScopes types:
+    # still owned by OpenCoreGraphics / FoundationEssentials. libSwiftUI
+    # defining them must keep failing.
     my @negative = (
         [ '_$s16OpenCoreGraphics7CGFloatVMn', 'OpenCoreGraphics', 'libSwiftUI' ],
+        [
+            '_$s20FoundationEssentials15AttributeScopesOMn',
+            'FoundationEssentials',
+            'libSwiftUI',
+        ],
     );
     for my $fixture (@negative) {
         my ($symbol, $expected_module, $wrong_image) = @$fixture;
@@ -575,6 +593,7 @@ sub prefixed_swift_module {
     return 'SwiftUI' if $symbol =~ /^_?\$s7SwiftUI/;
     return 'OpenUIKit' if $symbol =~ /^_?\$s9OpenUIKit/;
     return 'OpenCoreGraphics' if $symbol =~ /^_?\$s16OpenCoreGraphics/;
+    return 'FoundationEssentials' if $symbol =~ /^_?\$s20FoundationEssentials/;
     return 'Combine' if $symbol =~ /^_?\$s7Combine/;
     return 'OpenCombine' if $symbol =~ /^_?\$s11OpenCombine/;
     my $objc_module = objc_swift_module($symbol);
@@ -585,7 +604,7 @@ sub prefixed_swift_module {
 sub framework_tokens {
     my ($symbol) = @_;
     return grep { index($symbol, length($_) . $_) >= 0 }
-        qw(SwiftUI OpenUIKit OpenCoreGraphics Combine OpenCombine);
+        qw(SwiftUI OpenUIKit OpenCoreGraphics FoundationEssentials Combine OpenCombine);
 }
 
 sub demangle_compact {
@@ -597,9 +616,9 @@ sub demangle_compact {
 }
 
 # Owning module from compact demangle, in this order:
-#   1. `(extension in M):` anywhere → M (SwiftUI's CGFloat.magnitudeSquared MV
-#      and AttributeScopes.swiftUI; compact form is often
-#      `property descriptor for (extension in SwiftUI):…`, not a leading match)
+#   1. `(extension in M):` anywhere → M (SwiftUI's CGFloat.magnitudeSquared MV,
+#      AttributeScopes.swiftUI, AttributeDynamicLookup subscript; compact form
+#      is often `property descriptor for (extension in SwiftUI):…`, not leading)
 #   2. `… : M.Protocol in M2` conformance/witness (Mc/WP/Wp) → protocol module M
 #   3. otherwise undef (caller falls back to the leading nominal-type module)
 sub owning_module_from_demangle {
@@ -624,7 +643,7 @@ sub classify_framework_symbol {
     return ($prefix, $expanded) if defined $prefix;
 
     my @owners;
-    for my $module (qw(SwiftUI OpenUIKit OpenCoreGraphics Combine OpenCombine)) {
+    for my $module (qw(SwiftUI OpenUIKit OpenCoreGraphics FoundationEssentials Combine OpenCombine)) {
         push @owners, $module
             if $expanded =~ /^associated type descriptor for \Q$module\E\./
             || $expanded =~ /\bin \Q$module\E\z/;
@@ -650,7 +669,7 @@ sub symbol_records {
 sub provider_command {
     my (@args) = @_;
     my ($nm, $objdump, $demangle, $openuikit, $opencoregraphics, $swiftui,
-        $combine, $opencombine, $executable);
+        $foundationessentials, $combine, $opencombine, $executable);
     GetOptionsFromArray(
         \@args,
         'nm=s'         => \$nm,
@@ -659,14 +678,16 @@ sub provider_command {
         'openuikit=s'  => \$openuikit,
         'opencoregraphics=s' => \$opencoregraphics,
         'swiftui=s'    => \$swiftui,
+        'foundationessentials=s' => \$foundationessentials,
         'combine=s'    => \$combine,
         'opencombine=s' => \$opencombine,
         'executable=s' => \$executable,
     ) or fail('invalid provider options');
     fail('providers takes no positional arguments') if @args;
-    fail('providers requires --nm, --objdump, --demangle, --openuikit, --opencoregraphics, --swiftui, --combine, --opencombine, and --executable')
+    fail('providers requires --nm, --objdump, --demangle, --openuikit, --opencoregraphics, --swiftui, --foundationessentials, --combine, --opencombine, and --executable')
         unless defined($nm) && defined($objdump) && defined($demangle) && defined($openuikit)
             && defined($opencoregraphics) && defined($swiftui)
+            && defined($foundationessentials)
             && defined($combine) && defined($opencombine)
             && defined($executable);
 
@@ -674,6 +695,7 @@ sub provider_command {
         libOpenUIKit => $openuikit,
         libOpenCoreGraphics => $opencoregraphics,
         libSwiftUI => $swiftui,
+        libFoundationEssentials => $foundationessentials,
         libCombine => $combine,
         libOpenCombine => $opencombine,
         executable => $executable,
@@ -686,6 +708,7 @@ sub provider_command {
         SwiftUI => 'libSwiftUI',
         OpenUIKit => 'libOpenUIKit',
         OpenCoreGraphics => 'libOpenCoreGraphics',
+        FoundationEssentials => 'libFoundationEssentials',
         Combine => 'libCombine',
         OpenCombine => 'libCombine',
     );
@@ -693,6 +716,7 @@ sub provider_command {
         SwiftUI => 'libSwiftUI',
         OpenUIKit => 'libOpenUIKit',
         OpenCoreGraphics => 'libOpenCoreGraphics',
+        FoundationEssentials => 'libFoundationEssentials',
         Combine => 'libCombine',
         OpenCombine => 'libOpenCombine',
     );
@@ -766,6 +790,8 @@ sub provider_command {
         [ 'libOpenCombine', 'defined', 'OpenCombine' ],
         [ 'libSwiftUI', 'undefined', 'OpenUIKit' ],
         [ 'libSwiftUI', 'undefined', 'OpenCoreGraphics' ],
+        [ 'libFoundationEssentials', 'defined', 'FoundationEssentials' ],
+        [ 'libSwiftUI', 'undefined', 'FoundationEssentials' ],
         [ 'libSwiftUI', 'undefined', 'OpenCombine' ],
         [ 'executable', 'undefined', 'SwiftUI' ],
         [ 'executable', 'undefined', 'OpenUIKit' ],
@@ -778,7 +804,7 @@ sub provider_command {
     print "format\tfocus-widget-framework-providers-v2\n";
     for my $image (sort keys %paths) {
         for my $kind (qw(defined undefined)) {
-            for my $module (qw(SwiftUI OpenUIKit OpenCoreGraphics Combine OpenCombine)) {
+            for my $module (qw(SwiftUI OpenUIKit OpenCoreGraphics FoundationEssentials Combine OpenCombine)) {
                 printf "count\t%s\t%s\t%s\t%d\n", $image, $kind, $module,
                     ($counts{$image}{$kind}{$module} || 0);
             }

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -249,6 +249,7 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         self.assertIn("framework-providers.tsv", text)
         self.assertIn('perl "$ATTEST" providers', text)
         self.assertIn('--opencoregraphics "$PACKAGE/libOpenCoreGraphics.dylib"', text)
+        self.assertIn('--foundationessentials "$PACKAGE/libFoundationEssentials.dylib"', text)
         self.assertIn("--demangle swift-demangle", text)
         self.assertIn("Universal, non-vacuous two-level provider gate", text)
         self.assertIn("_$sxSg7SwiftUI9_OpenViewA2bCRzlMc", text)
@@ -500,7 +501,14 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
 
     def test_provider_gate_is_universal_and_rejects_reverse_ownership(self) -> None:
         helper = ATTEST.read_text()
-        for module in ("SwiftUI", "OpenUIKit", "OpenCoreGraphics", "Combine", "OpenCombine"):
+        for module in (
+            "SwiftUI",
+            "OpenUIKit",
+            "OpenCoreGraphics",
+            "FoundationEssentials",
+            "Combine",
+            "OpenCombine",
+        ):
             self.assertIn(module, helper)
         self.assertIn("no two-level bind", helper)
         self.assertIn("expected exactly", helper)
@@ -549,7 +557,16 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
             "_$s20FoundationEssentials15AttributeScopesO7SwiftUIE7swiftUISdvpMV",
             helper,
         )
+        self.assertIn(
+            "_$s20FoundationEssentials15AttributeScopesO7SwiftUIE7swiftUISdvg",
+            helper,
+        )
+        self.assertIn(
+            "_$s20FoundationEssentials22AttributeDynamicLookupO7SwiftUIEyxqd__cluig",
+            helper,
+        )
         self.assertIn("_$s16OpenCoreGraphics7CGFloatVMn", helper)
+        self.assertIn("_$s20FoundationEssentials15AttributeScopesOMn", helper)
         self.assertIn("conformance-classifier-selftest", helper)
         self.assertIn("owning_module_from_demangle", helper)
         result = subprocess.run(
@@ -560,7 +577,7 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
         )
         self.assertEqual(
             result.stdout,
-            "CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=5 negatives=1\n",
+            "CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=7 negatives=2\n",
         )
         self.assertEqual(result.stderr, "")
 

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -513,7 +513,9 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
         self.assertIn("extension in", helper)
         self.assertIn("protocol conformance descriptor", helper)
         self.assertIn("protocol witness table", helper)
-        self.assertIn("conformance_protocol_module", helper)
+        self.assertIn("owning_module_from_demangle", helper)
+        self.assertNotIn("conformance_protocol_module", helper)
+        self.assertNotIn("/^\\(extension in", helper)
         self.assertIn("^_OBJC_(?:CLASS|METACLASS)_\\$__TtC", helper)
         self.assertIn("^_OBJC_IVAR_\\$__TtC", helper)
         self.assertIn("for (1 .. $nested_count + 2)", helper)
@@ -539,8 +541,17 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
             "_$s16OpenCoreGraphics7CGFloatV7SwiftUI01_A16VectorArithmeticADMc"
         )
         self.assertIn(exact, helper)
+        self.assertIn(
+            "_$s16OpenCoreGraphics7CGFloatV7SwiftUIE16magnitudeSquaredSdvpMV",
+            helper,
+        )
+        self.assertIn(
+            "_$s20FoundationEssentials15AttributeScopesO7SwiftUIE7swiftUISdvpMV",
+            helper,
+        )
         self.assertIn("_$s16OpenCoreGraphics7CGFloatVMn", helper)
         self.assertIn("conformance-classifier-selftest", helper)
+        self.assertIn("owning_module_from_demangle", helper)
         result = subprocess.run(
             ["perl", str(ATTEST), "conformance-classifier-selftest"],
             check=True,
@@ -549,7 +560,7 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
         )
         self.assertEqual(
             result.stdout,
-            "CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=3 negatives=1\n",
+            "CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=5 negatives=1\n",
         )
         self.assertEqual(result.stderr, "")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The ARM64 Focus widget gate on main `473b3860` (PR #13 merged) now accepts the `CGFloat: _OpenVectorArithmetic` Mc/WP/Wp, then dies on the next symbol:

```
focus_widget_guest_attest: reverse ownership violation: libSwiftUI defines OpenCoreGraphics symbol _$s16OpenCoreGraphics7CGFloatV7SwiftUIE16magnitudeSquaredSdvpMV
```

That `MV` is the property descriptor for `CGFloat.magnitudeSquared` declared in SwiftUI’s extension of `OpenCoreGraphics.CGFloat` (`uikit/Sources/SwiftUI/Compatibility.swift`). Compact demangle is:

```
property descriptor for (extension in SwiftUI):OpenCoreGraphics.CGFloat.magnitudeSquared : Swift.Double
```

The `7SwiftUIE` marker is the extension-in-module production. PR #13 classified only suffix-gated Mc/WP/Wp, then a second pass required `^\(extension in M):`. Compact demangle of a property descriptor is `property descriptor for (extension in SwiftUI):…`, so the caret never matched and prefix classification kept OpenCoreGraphics.

## Classifier

Every reverse-ownership symbol is classified from `swift-demangle --compact`, in this order:

1. `(extension in M):` **anywhere** → M (MV, accessors, methods, thunks, associated-type witnesses whose demangle contains that clause)
2. `… : M.Protocol in M2` conformance/witness (Mc/WP/Wp) → the protocol’s module M
3. otherwise the leading nominal-type module (`prefixed_swift_module`)

`_$s16OpenCoreGraphics7CGFloatVMn` and `_$s20FoundationEssentials15AttributeScopesOMn` defined by libSwiftUI still fail (rule 3). No pin hashes or refusal strings change.

FoundationEssentials is now in the audited module set (length-20 prefix, tokens, `definition_owner` / bind provider `libFoundationEssentials`) and `providers` takes `--foundationessentials`. SwiftUI’s AttributeScopes / AttributeDynamicLookup members still classify as SwiftUI via rule 1, so they will not be the next reverse-ownership refusal.

Selftest: **positives=7 negatives=2** (CGFloat Mc/WP/Wp/MV, AttributeScopes.swiftUI MV + getter, AttributeDynamicLookup subscript getter; CGFloat Mn and AttributeScopes Mn).

Canonical branch: `cursor/swiftui-demangle-ownership` (`01b754ea`).

## SwiftUI foreign-extension census (`uikit/Sources/SwiftUI/*.swift`)

`nm -gU` on the arm64 dylib is not available here. Every `extension <ForeignModule>.<Type>` and every retroactive conformance in that tree:

| Site | Form | Classifier rule |
| --- | --- | --- |
| `Compatibility.swift:199` | `extension CGFloat: _OpenVectorArithmetic` (OpenCoreGraphics) | Mc/WP/Wp → protocol SwiftUI; members (MV `magnitudeSquared`, `scale(by:)`, accessors) → `(extension in SwiftUI):` |
| `Compatibility.swift:189` | `extension Double: _OpenVectorArithmetic` (Swift stdlib) | same; type module is outside the packaged-sibling set |
| `Compatibility.swift:194` | `extension Float: _OpenVectorArithmetic` (Swift stdlib) | same |
| `View.swift:771` | `extension Never: _OpenView` (Swift stdlib) | Mc/WP/Wp → protocol SwiftUI |
| `View.swift:1086` | `extension Optional: _OpenView where Wrapped: _OpenView` | Mc/WP/Wp → protocol SwiftUI |
| `AppLifecycle.swift:61` | `extension Never: _OpenScene` | Mc/WP/Wp → protocol SwiftUI |
| `AppLifecycle.swift:191` | `extension Optional: _OpenScene where Wrapped: _OpenScene` | Mc/WP/Wp → protocol SwiftUI |
| `TextAttributes.swift:39` | `extension AttributeScopes` (`var swiftUI`, nested `SwiftUIAttributes`) (FoundationEssentials) | MV + getter → `(extension in SwiftUI):FoundationEssentials.AttributeScopes…` |
| `TextAttributes.swift:56` | `extension AttributeDynamicLookup` (dynamicMember subscript) (FoundationEssentials) | subscript getter → `(extension in SwiftUI):` |
| `TextAttributes.swift:65` | `extension AttributeScopes.SwiftUIAttributes` (attribute-key enums) | nested types/members/associated-type witnesses → `(extension in SwiftUI):` |
| `Compatibility.swift:15` | `extension DeveloperToolsSupport.Preview` | preview-gated (`canImport(DeveloperToolsSupport) && canImport(Foundation)`); absent from the Foundation-hidden widget guest |

SwiftUI-internal extensions (`_OpenColor: _OpenView`, `_OpenRectangle`, gestures, etc.) keep the SwiftUI type-module prefix and never trip reverse-ownership.

No `extension CGRect` / `CGSize` / `CGPoint` and no `extension UI*` in SwiftUI sources. OpenUIKit’s `CGRect.inset(by:)` (`UILayoutGuide.swift`) is a libOpenUIKit definition and already matches `(extension in OpenUIKit):`.

## Static results (this x86_64 VM)

- `perl -c full/swiftui/focus_widget_guest_attest.pl`: syntax OK
- `perl … conformance-classifier-selftest`: `CONFORMANCE_CLASSIFIER_SELFTEST_OK positives=7 negatives=2`
- `python3 -m unittest full.swiftui.test_focus_widget_guest`: **22/22 OK**

## ARM64 authority

This VM is x86_64. The gates already refuse execution with:

```
CURSOR_ENV_CANNOT_EXECUTE_ARM64 host=x86_64 machorun=arm64-linux-native split=compile-link-static-in-vm/execution-arm64-ec2/macos-oracle-local-only
```

The operator re-runs `full/swiftui/build_focus_widget_guest.sh` on the ARM64 EC2 authority. Compile/link/attest may proceed on this VM; execution cannot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

