### PR TITLE
Fix false-green ninja, Darwin overlay headers, overlay targets, and x86 loader probe

### DIFF
--- a/swiftcore-macho/README.md
+++ b/swiftcore-macho/README.md
@@ -64,8 +64,10 @@ Same recipe, `SWIFTCORE_DARWIN_ARCH=x86_64`, on an x86_64 Linux host.
 10 123 624 bytes, install name `/usr/lib/swift/libswiftCore.dylib`, sha256
 `8de09dbae55b672287985812c64fe859029197aaf70458aa3097bbbdce4c39fb`. The arm64
 dylib is untouched (`dd01686e…12708cb`). Compile+link of a hello-world against
-`x86_64-apple-macos15.0` succeeds in-VM; execution is refused here
-(`CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST`). `_Concurrency` is still the
+`x86_64-apple-macos15.0` succeeds in-VM. Execution is a **positive probe** for
+a machorun loader that can run an x86_64 Mach-O on this host (operator path
+`/opt/openuikit/x86-verify/openuikit/machorun`); `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST`
+is printed only when that probe finds nothing. `_Concurrency` is still the
 §16 libdispatch wall. Recipe: `docs/X86_64.md` / `scripts/build_stdlib.sh`.
 
 Known-open, both on the loader side rather than ours:

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -167,7 +167,7 @@ is not.
 | `_Builtin_float` swiftmodule | **yes** — staged | `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
 | `_Concurrency` | **no** until operator reruns with fetched libdispatch | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing; else BUILD_LOG §16 |
 | `_StringProcessing` / `Synchronization` | fetch + explicit `-D` paths; CMake no longer sees `()` | `CANNOT_FETCH_STRING_PROCESSING_SOURCE`; `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
-| `swiftDarwin` | sysroot now has Apple `semaphore.h` + `sys/ioctl.h` closure from Libc-1752.120.2 / xnu-12377.121.6 (same pins as machorun/sdk/SOURCES.tsv). Darwin.o compile still needs the 16 vCPU operator rerun. | ninja failure now **exits non-zero** (no false green). Absent target: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
+| `swiftDarwin` | sysroot now has Apple `semaphore.h` + `sys/ioctl.h` closure from Libc-1752.120.2 / xnu-12377.121.6 (same pins as machorun/sdk/SOURCES.tsv). **LibcOverlayShims.h compiles** (`clang -fsyntax-only` rc=0; Darwin.o no longer reports `semaphore.h` file not found). Next Darwin.o wall: `underlying Objective-C module 'Darwin' not found` (`@_exported import Darwin` — Xcode Darwin.modulemap, `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS`). | ninja failure now **exits non-zero** (no false green). Absent target: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 | `swiftObjectiveC` | **no** — not a CMake target on Linux | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` (do not invoke `ninja` on the missing name) |
 
 Ninja rc tests: `scripts/test_ninja_rc.sh`, `scripts/test_overlay_targets.sh`,

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -73,7 +73,8 @@ Overlays, **as applicable**:
 | `_Builtin_float` | in-tree with the stdlib | yes |
 | `Synchronization` | `SWIFTCORE_OVERLAYS=1` → `SWIFT_ENABLE_SYNCHRONIZATION=ON` | **yes**, in-tree |
 | `_StringProcessing` | `SWIFTCORE_OVERLAYS=1` → experimental ON | **yes**, sibling `swift-experimental-string-processing` @ `91177e6225c63e885872b83d48e254b1270fa15a`. Empty path → `CANNOT_FETCH_STRING_PROCESSING_SOURCE` *before* CMake |
-| `swiftDarwin` / `swiftObjectiveC` | `SWIFT_BUILD_SDK_OVERLAY` | **no** — needs Xcode Darwin module maps. Stays OFF. Marker: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
+| `swiftDarwin` | `SWIFT_BUILD_SDK_OVERLAY` (derived; see below) | **try** — Platform overlay *is* in the Linux ninja graph. `stage_sdk.sh` now stages Apple's POSIX `<semaphore.h>` + `<sys/ioctl.h>` closure from the machorun OSS pins. Compile still needs the operator rerun. |
+| `swiftObjectiveC` | not a CMake target on Linux | **no** — Apple picks it up from the Xcode SDK. `build_stdlib.sh` derives names from `ninja -t targets` and prints `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` rather than invoking `swiftObjectiveC-macosx-*`. |
 
 ## 3. Operator command (16 vCPU x86 EC2)
 
@@ -96,8 +97,11 @@ to `/opt/swift624`; `guest_arch.inc` also accepts `command -v swiftc`.
 
 That is bootstrap → x86 libSystem+objc4+.tbd → `stage_sdk.sh` →
 `apply_patches.py` (legacy image-reg) → `configure.sh` →
-`ninja swiftCore-macosx-x86_64` → `link_macho_dylib.sh` (wall 7: ninja
-emits ELF `.so`) → `verify.sh` → `stage_artifacts.sh` → compile+link hello.
+`ninja swiftCore-macosx-x86_64` → overlay ninja names from `ninja -t targets`
+(a failing overlay ninja **exits non-zero**; the core gold wall is the only
+allowed ninja failure) → `link_macho_dylib.sh` (wall 7: ninja emits ELF `.so`)
+→ `verify.sh` → `stage_artifacts.sh` → compile+link hello → **run hello
+under machorun if a loader probe succeeds**.
 
 Expected sizes (measured; x86_64 from this VM, arm64 from the Graviton sibling):
 
@@ -134,7 +138,7 @@ NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
 | size / sha256 | `sha256sum` | **10 123 624** bytes, `8de09dbae55b672287985812c64fe859029197aaf70458aa3097bbbdce4c39fb` |
 | exports | `llvm-nm --defined-only --extern-only` | **30 595** (spot-check 13/13 `swift_*` / `_TtCs12_SwiftObject`) |
 | `swiftc -target x86_64-apple-macos15.0` compile+link | `scripts/verify_hello.sh` | Mach-O `MH_MAGIC_64 X86_64 EXECUTE`; links `libswiftCore` |
-| execute the guest | **refused** | `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST` |
+| execute the guest | positive probe for a machorun ELF that can run an x86_64 Mach-O (`/opt/openuikit/x86-verify/openuikit/machorun` on the operator box; `machorun/build/machorun` here) | **run** when the loader is present (print output + `hello_swiftcore machorun exit=`); `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST` only after the probe finds nothing |
 | arm64 artifacts untouched | sha256 before/after staging | `dd01686e06c81a21755bb864b43dad446c011e6c60c6b387b3b332c0a12708cb` |
 | not a rename | cmp arm64 vs x86 dylib | differ |
 | staged-slice regression | `scripts/test_staged_slice.sh` | grades both slices + manifest |
@@ -151,16 +155,23 @@ Configure (this VM, 4.5 s):
 Ninja `swiftCore-macosx-x86_64` `-j2`: 173/174 objects, then expected wall 7
 (`-fuse-ld=gold` ELF `libswiftCore.so`). Mach-O link via `link_macho_dylib.sh`.
 
-Overlays this run (denominator: 6 named guests):
+Overlays this run (denominator: 6 named guests). Ninja names are taken from
+`ninja -t targets`, not a hardcoded list. `-DSWIFT_BUILD_SDK_OVERLAY=OFF` is
+overwritten by Swift 6.2.4 from `SWIFT_BUILD_DYNAMIC_SDK_OVERLAY` (TRUE on
+Linux), so `swiftDarwin-macosx-x86_64` **is** in the graph; `swiftObjectiveC-*`
+is not.
 
 | overlay | this VM | marker if missing |
 |---|---|---|
 | Swift / libswiftCore | **yes** — staged | — |
-| `_Builtin_float` swiftmodule | **yes** — staged | — |
+| `_Builtin_float` swiftmodule | **yes** — staged | `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
 | `_Concurrency` | **no** until operator reruns with fetched libdispatch | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing; else BUILD_LOG §16 |
-| `_StringProcessing` / `Synchronization` | fetch + explicit `-D` paths; CMake no longer sees `()` | `CANNOT_FETCH_STRING_PROCESSING_SOURCE` |
-| `swiftDarwin` | **no** — `'semaphore.h' file not found` via `LibcOverlayShims.h` | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
-| `swiftObjectiveC` | **no** — `SWIFT_BUILD_SDK_OVERLAY=OFF` (needs Xcode module maps) | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
+| `_StringProcessing` / `Synchronization` | fetch + explicit `-D` paths; CMake no longer sees `()` | `CANNOT_FETCH_STRING_PROCESSING_SOURCE`; `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
+| `swiftDarwin` | sysroot now has Apple `semaphore.h` + `sys/ioctl.h` closure from Libc-1752.120.2 / xnu-12377.121.6 (same pins as machorun/sdk/SOURCES.tsv). Darwin.o compile still needs the 16 vCPU operator rerun. | ninja failure now **exits non-zero** (no false green). Absent target: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
+| `swiftObjectiveC` | **no** — not a CMake target on Linux | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` (do not invoke `ninja` on the missing name) |
+
+Ninja rc tests: `scripts/test_ninja_rc.sh`, `scripts/test_overlay_targets.sh`,
+`scripts/test_overlay_posix.sh`, `scripts/test_probe_machorun.sh`.
 
 ## 5. Layout
 

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -19,13 +19,18 @@
 
 # This 4-vCPU / 15 GiB cloud-agent VM uses NINJA_JOBS=2. It will configure and
 # compile as far as RAM/time allow; it will not fake a dylib. Execution of the
-# linked guest is refused here — that is the operator host's job.
+# linked guest is a positive machorun-loader probe in verify_hello.sh, not a
+# VM assumption.
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SWIFTCORE_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 OPENUIKIT_ROOT=$(cd "$SWIFTCORE_ROOT/.." && pwd)
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/guest_arch.inc"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/ninja_checked.inc"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/overlay_targets.inc"
 
 W=${W:-$HOME/work}
 B=${B:-$W/build}
@@ -44,6 +49,37 @@ export SWIFT_TOOLCHAIN SWIFT_PATH_TO_STRING_PROCESSING_SOURCE SWIFT_PATH_TO_LIBD
 
 mkdir -p "$W"
 step() { printf '\n==== %s ====\n' "$*"; }
+
+# Every ninja invocation reports its status. The core target may hit the
+# expected ELF gold wall (BUILD_LOG wall 7); overlay targets may not.
+run_stdlib_ninja() {
+  step "ninja $SWIFTCORE_NINJA_CORE -j$NINJA_JOBS"
+  ninja_checked --allow-gold-wall "$W/build.log" -C "$B" -j "$NINJA_JOBS" \
+    "$SWIFTCORE_NINJA_CORE"
+  obj_n=$(find "$B" -name '*.o' 2>/dev/null | wc -l)
+  echo "objects=$obj_n"
+  if [ "$STOP_AFTER" = ninja-first ]; then
+    echo "STOP_AFTER=ninja-first — first ninja finished. objects=$obj_n"
+    exit 0
+  fi
+  if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
+    overlay_select_targets "$B" "$SWIFTCORE_DARWIN_ARCH"
+    local t
+    for t in "${OVERLAY_NINJA_TARGETS[@]}"; do
+      step "ninja overlay $t"
+      ninja_checked "$W/build.log" -C "$B" -j "$NINJA_JOBS" "$t"
+    done
+  fi
+}
+
+# Test hook: skip bootstrap/cmake so test_ninja_rc.sh can prove a failing
+# ninja target makes this script exit non-zero.
+if [ "${SWIFTCORE_NINJA_HARNESS:-0}" = 1 ]; then
+  mkdir -p "$B"
+  run_stdlib_ninja
+  echo "build_stdlib done darwin_arch=$SWIFTCORE_DARWIN_ARCH harness=1"
+  exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # 0. Recorded arm64 artifacts must still be the arm64 slice after we finish.
@@ -130,38 +166,11 @@ if [ "$STOP_AFTER" = configure ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Build. The ninja link edge is ELF (.so); that is expected (BUILD_LOG wall 7).
+# 6. Build. The ninja link edge is ELF (.so); that is expected (BUILD_LOG wall 7)
+#    and is the only ninja failure that is allowed to continue. Overlay ninja
+#    failures (unknown target, missing header, compile error) exit non-zero.
 # ---------------------------------------------------------------------------
-step "ninja $SWIFTCORE_NINJA_CORE -j$NINJA_JOBS"
-set +e
-ninja -C "$B" -j "$NINJA_JOBS" "$SWIFTCORE_NINJA_CORE" 2>&1 | tee "$W/build.log"
-ninja_st=${PIPESTATUS[0]}
-set -e
-obj_n=$(find "$B" -name '*.o' | wc -l)
-echo "ninja exit=$ninja_st objects=$obj_n"
-if [ "$STOP_AFTER" = ninja-first ]; then
-  echo "STOP_AFTER=ninja-first — first ninja finished. objects=$obj_n"
-  exit 0
-fi
-
-# Overlay targets, best-effort after core objects exist. Each is a separate
-# ninja invocation so a wall names itself.
-if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
-  for t in \
-      "$SWIFTCORE_NINJA_CONCURRENCY" \
-      "swiftSynchronization-macosx-${SWIFTCORE_DARWIN_ARCH}" \
-      "swift_StringProcessing-macosx-${SWIFTCORE_DARWIN_ARCH}" \
-      "swift_Builtin_float-macosx-${SWIFTCORE_DARWIN_ARCH}" \
-      "swiftDarwin-macosx-${SWIFTCORE_DARWIN_ARCH}" \
-      "swiftObjectiveC-macosx-${SWIFTCORE_DARWIN_ARCH}"
-  do
-    step "ninja overlay $t"
-    set +e
-    ninja -C "$B" -j "$NINJA_JOBS" "$t" 2>&1 | tee -a "$W/build.log"
-    echo "overlay $t exit=${PIPESTATUS[0]}"
-    set -e
-  done
-fi
+run_stdlib_ninja
 
 # ---------------------------------------------------------------------------
 # 7. Mach-O link from ninja's object list
@@ -190,7 +199,7 @@ if [ -f "$CORE_OUT" ]; then
   step "verify $CORE_OUT"
   bash "$SCRIPT_DIR/verify.sh"
   bash "$SCRIPT_DIR/stage_artifacts.sh"
-  bash "$SCRIPT_DIR/verify_hello.sh" || true
+  bash "$SCRIPT_DIR/verify_hello.sh"
 else
   echo "NO libswiftCore.dylib at $CORE_OUT"
   echo "objects compiled: $obj_n"

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -39,8 +39,12 @@ done
 # (configure.sh's checked-in defaults). SWIFTCORE_OVERLAYS=1 turns on the
 # guest-needed in-tree overlays that do not require an Xcode Darwin SDK:
 # _Concurrency (already on), Synchronization, experimental StringProcessing.
-# Darwin/ObjectiveC SDK overlays stay OFF: SWIFT_BUILD_SDK_OVERLAY needs
-# Xcode module maps this Linux sysroot does not have. See docs/X86_64.md.
+# -DSWIFT_BUILD_SDK_OVERLAY=OFF is passed below but Swift 6.2.4 overwrites
+# it from SWIFT_BUILD_DYNAMIC_SDK_OVERLAY (default TRUE on a non-Apple host),
+# so Platform/swiftDarwin *is* in the ninja graph. ObjectiveC is not a
+# CMake target on Linux. build_stdlib.sh derives overlay names from
+# `ninja -t targets` and prints CANNOT_STAGE_XCODE_DARWIN_OVERLAYS rather
+# than invoking a missing name. See docs/X86_64.md.
 #
 # Phase-2 guests load _Concurrency + _StringProcessing + Synchronization.
 # Overlays therefore also fetch/pass libdispatch (BUILD_LOG §16): CMake with

--- a/swiftcore-macho/scripts/ninja_checked.inc
+++ b/swiftcore-macho/scripts/ninja_checked.inc
@@ -1,0 +1,58 @@
+# ninja_checked.inc -- sourced. Run ninja and propagate its exit status.
+#
+# The Darwin stdlib ninja graph links ELF .so with -fuse-ld=gold (BUILD_LOG
+# wall 7). That invocation is allowed to fail *only* when the log is that
+# gold wall. Every other ninja invocation — overlays included — must fail
+# the caller. PIPESTATUS[0] is ninja, not tee.
+
+if [ -n "${SWIFTCORE_NINJA_CHECKED_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+SWIFTCORE_NINJA_CHECKED_INC=1
+
+# ninja_checked [--allow-gold-wall] <logfile> [ninja-args...]
+# Honors NINJA (default: ninja). Returns ninja's status; 0 on the expected
+# gold wall when --allow-gold-wall is set.
+ninja_checked() {
+    local allow_gold=0
+    if [ "${1:-}" = --allow-gold-wall ]; then
+        allow_gold=1
+        shift
+    fi
+    local log=${1:?ninja_checked: logfile}
+    shift
+    local ninja_bin=${NINJA:-ninja}
+    if [ ! -x "$ninja_bin" ] && ! command -v "$ninja_bin" >/dev/null 2>&1; then
+        echo "ninja_checked: no ninja binary (NINJA=$ninja_bin)" >&2
+        return 127
+    fi
+    mkdir -p "$(dirname "$log")"
+    local chunk
+    chunk=$(mktemp)
+    set +e
+    "$ninja_bin" "$@" 2>&1 | tee -a "$log" | tee "$chunk"
+    local st=${PIPESTATUS[0]}
+    set -e
+    echo "ninja $* exit=$st"
+    if [ "$st" -eq 0 ]; then
+        rm -f "$chunk"
+        return 0
+    fi
+    if [ "$allow_gold" = 1 ] && _sc_gold_wall_only "$chunk"; then
+        echo "ninja: expected ELF gold wall (BUILD_LOG wall 7: -fuse-ld=gold); continuing"
+        rm -f "$chunk"
+        return 0
+    fi
+    echo "ninja: FAILED rc=$st" >&2
+    rm -f "$chunk"
+    return "$st"
+}
+
+_sc_gold_wall_only() {
+    local chunk=$1
+    grep -q "invalid linker name in argument '-fuse-ld=gold'" "$chunk" || return 1
+    # A real compile/unknown-target failure alongside gold is not the wall.
+    grep -q 'ninja: error:' "$chunk" && return 1
+    grep -Eq "error: '.+' file not found" "$chunk" && return 1
+    return 0
+}

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -1,0 +1,93 @@
+# overlay_targets.inc -- sourced. Derive overlay ninja names from the
+# configured graph (`ninja -t targets`), never from a hardcoded list that
+# can name a target CMake did not create.
+#
+# Phase-2 required overlays (FE arm64 load list): _Concurrency,
+# _StringProcessing, Synchronization, _Builtin_float. Darwin is in this
+# Linux graph (Platform/) even with -DSWIFT_BUILD_SDK_OVERLAY=OFF, because
+# Swift 6.2.4 overwrites that option from SWIFT_BUILD_DYNAMIC_SDK_OVERLAY
+# (default TRUE on a non-Apple host). ObjectiveC is not a CMake target here;
+# Apple picks it up from the Xcode SDK.
+
+if [ -n "${SWIFTCORE_OVERLAY_TARGETS_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+SWIFTCORE_OVERLAY_TARGETS_INC=1
+
+overlay_candidate_targets() {
+    local arch=${1:?overlay_candidate_targets: arch}
+    printf '%s\n' \
+        "swift_Concurrency-macosx-${arch}" \
+        "swiftSynchronization-macosx-${arch}" \
+        "swift_StringProcessing-macosx-${arch}" \
+        "swift_Builtin_float-macosx-${arch}" \
+        "swiftDarwin-macosx-${arch}" \
+        "swiftObjectiveC-macosx-${arch}"
+}
+
+overlay_required_target() {
+    case "$1" in
+        swift_Concurrency-macosx-*|swiftSynchronization-macosx-*|swift_StringProcessing-macosx-*|swift_Builtin_float-macosx-*)
+            return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+overlay_xcode_only_target() {
+    case "$1" in
+        swiftObjectiveC-macosx-*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Fill OVERLAY_NINJA_TARGETS. Print CANNOT_* for missing names. Exit 2 if a
+# required overlay is absent. Never emit a name that is not in `ninja -t targets`.
+#
+# overlay_select_targets <build_dir> <arch>
+overlay_select_targets() {
+    local build_dir=${1:?overlay_select_targets: build dir}
+    local arch=${2:?overlay_select_targets: arch}
+    local dump n have
+    OVERLAY_NINJA_TARGETS=()
+
+    if [ -n "${NINJA_TARGETS_DUMP:-}" ]; then
+        dump=$(cat "$NINJA_TARGETS_DUMP")
+    else
+        local ninja_bin=${NINJA:-ninja}
+        dump=$("$ninja_bin" -C "$build_dir" -t targets)
+    fi
+    echo "overlay_select: ninja -t targets from ${NINJA_TARGETS_DUMP:-$build_dir}"
+
+    local missing_required=0
+    while IFS= read -r n; do
+        [ -n "$n" ] || continue
+        have=0
+        printf '%s\n' "$dump" | grep -E "^${n}:" >/dev/null && have=1
+        if [ "$have" = 1 ]; then
+            echo "overlay_select: have $n"
+            OVERLAY_NINJA_TARGETS+=("$n")
+            continue
+        fi
+        if overlay_xcode_only_target "$n"; then
+            echo "CANNOT_STAGE_XCODE_DARWIN_OVERLAYS target=$n reason=not in ninja -t targets; Swift 6.2.4 does not create an ObjectiveC overlay CMake target on Linux (Apple picks it up from the Xcode SDK)"
+            continue
+        fi
+        if overlay_required_target "$n"; then
+            echo "CANNOT_OVERLAY_TARGET_ABSENT target=$n reason=not in ninja -t targets; required overlay was not created by this CMake configuration" >&2
+            missing_required=1
+            continue
+        fi
+        # Darwin (and any other optional Platform overlay): named refusal, skip.
+        echo "CANNOT_STAGE_XCODE_DARWIN_OVERLAYS target=$n reason=not in ninja -t targets"
+    done < <(overlay_candidate_targets "$arch")
+
+    if [ "$missing_required" = 1 ]; then
+        return 2
+    fi
+    if [ ${#OVERLAY_NINJA_TARGETS[@]} -eq 0 ]; then
+        echo "overlay_select: no overlay ninja targets in this configuration" >&2
+        return 2
+    fi
+    echo "overlay_select: will ninja ${OVERLAY_NINJA_TARGETS[*]}"
+    return 0
+}

--- a/swiftcore-macho/scripts/probe_machorun.inc
+++ b/swiftcore-macho/scripts/probe_machorun.inc
@@ -1,0 +1,113 @@
+# probe_machorun.inc -- sourced. Positive probe for a machorun loader that
+# can run an x86_64 Mach-O on THIS host. Never assume the host is a cloud
+# agent VM; never print CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST without
+# having looked for a loader.
+
+if [ -n "${SWIFTCORE_PROBE_MACHORUN_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+SWIFTCORE_PROBE_MACHORUN_INC=1
+
+# Append unique non-empty paths to the nameref array.
+_sc_probe_add() {
+    local -n _arr=$1
+    local p=$2
+    [ -n "$p" ] || return 0
+    local e
+    for e in "${_arr[@]+"${_arr[@]}"}"; do
+        [ "$e" = "$p" ] && return 0
+    done
+    _arr+=("$p")
+}
+
+# Try one candidate path. On success print:  <loader>\t<root>
+# A directory is treated as a machorun tree (build/machorun inside).
+# A file is treated as the loader binary.
+_sc_try_machorun_loader() {
+    local cand=$1
+    local bin="" root=""
+    [ -n "$cand" ] || return 1
+    if [ -d "$cand" ]; then
+        if [ -x "$cand/build/machorun" ] && [ -f "$cand/build/machorun" ]; then
+            bin=$cand/build/machorun
+            root=$cand
+        elif [ -x "$cand/machorun" ] && [ -f "$cand/machorun" ]; then
+            bin=$cand/machorun
+            root=$cand
+        else
+            return 1
+        fi
+    elif [ -x "$cand" ] && [ -f "$cand" ]; then
+        bin=$cand
+        local d
+        d=$(cd "$(dirname "$cand")" && pwd)
+        if [ "$(basename "$d")" = build ]; then
+            root=$(cd "$d/.." && pwd)
+        else
+            root=$d
+        fi
+    else
+        return 1
+    fi
+
+    local host desc
+    host=$(uname -m)
+    desc=$(file -b "$bin" 2>/dev/null || true)
+    case "$host" in
+        x86_64)
+            printf '%s' "$desc" | grep -q 'ELF 64-bit' || return 1
+            printf '%s' "$desc" | grep -Eq 'x86-64|x86_64' || return 1
+            ;;
+        aarch64|arm64)
+            printf '%s' "$desc" | grep -q 'ELF 64-bit' || return 1
+            printf '%s' "$desc" | grep -Eq 'aarch64|ARM aarch64' || return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    # An aarch64 ELF loader cannot run an x86_64 Mach-O guest.
+    if [ "${SWIFTCORE_DARWIN_ARCH:-x86_64}" = x86_64 ] && [ "$host" != x86_64 ]; then
+        return 1
+    fi
+
+    local usage
+    usage=$("$bin" 2>&1 || true)
+    printf '%s' "$usage" | grep -qi 'mach-o' || return 1
+
+    printf '%s\t%s\n' "$bin" "$root"
+    return 0
+}
+
+# Print probed candidate paths (one per line) — for the CANNOT reason.
+probe_machorun_candidates() {
+    local cands=()
+    _sc_probe_add cands "${MACHORUN_LOADER:-}"
+    _sc_probe_add cands /opt/openuikit/x86-verify/openuikit/machorun
+    _sc_probe_add cands /opt/openuikit/x86-verify/openuikit/machorun/build/machorun
+    _sc_probe_add cands "${MACHORUN:-}/build/machorun"
+    _sc_probe_add cands "${MACHORUN:-}"
+    if [ -n "${OPENUIKIT_ROOT:-}" ]; then
+        _sc_probe_add cands "$OPENUIKIT_ROOT/machorun/build/machorun"
+        _sc_probe_add cands "$OPENUIKIT_ROOT/machorun"
+    fi
+    _sc_probe_add cands "${W:-$HOME/work}/machorun/build/machorun"
+    _sc_probe_add cands "${W:-$HOME/work}/machorun"
+    local c
+    for c in "${cands[@]+"${cands[@]}"}"; do
+        printf '%s\n' "$c"
+    done
+}
+
+# First matching loader. Prints "<loader>\t<root>". Returns 1 if none.
+probe_x86_macho_loader() {
+    local cand got
+    while IFS= read -r cand; do
+        [ -n "$cand" ] || continue
+        got=$(_sc_try_machorun_loader "$cand") || continue
+        printf '%s\n' "$got"
+        return 0
+    done < <(probe_machorun_candidates)
+    return 1
+}

--- a/swiftcore-macho/scripts/stage_overlay_posix.sh
+++ b/swiftcore-macho/scripts/stage_overlay_posix.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Stage Apple's POSIX overlay headers into a Darwin sysroot.
+#
+# Usage: stage_overlay_posix.sh [SDK_ROOT]
+#
+# Copies verbatim apple-oss-distributions headers (sdk/overlay-posix/) that
+# LibcOverlayShims.h / the Platform overlay need and that machorun's SDK
+# does not carry: POSIX <semaphore.h> and the <sys/ioctl.h> closure.
+# Refuse-overwrite: never bury a real header with this copy.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SWIFTCORE_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SDK=${1:-${SDK:-$HOME/work/sdk/MacOSX.sdk}}
+SRC=$SWIFTCORE_ROOT/sdk/overlay-posix
+
+LIBC_TAG=Libc-1752.120.2
+LIBC_COMMIT=4e34d0559e3a1b081afeb8604d9e204a1f31321d
+XNU_TAG=xnu-12377.121.6
+XNU_COMMIT=ac9718fb1af618d5ce8678d0dc6e8a58f252216f
+
+stage_one() {
+  local rel=$1 src=$2 repo=$3 tag=$4 commit=$5 upath=$6
+  local dest=$SDK/$rel
+  mkdir -p "$(dirname "$dest")"
+  if [ -e "$dest" ]; then
+    echo "stage_overlay_posix: REFUSING to overwrite $dest" >&2
+    echo "  with apple-oss-distributions/$repo $upath ($tag)." >&2
+    echo "  If machorun's SDK now carries this header, delete the overlay-posix copy." >&2
+    exit 2
+  fi
+  cp "$src" "$dest"
+  echo "stage_overlay_posix: staged $rel"
+  echo "  from apple-oss-distributions/$repo tag=$tag commit=$commit path=$upath"
+}
+
+[ -d "$SRC" ] || { echo "stage_overlay_posix: missing $SRC" >&2; exit 2; }
+
+stage_one usr/include/semaphore.h "$SRC/semaphore.h" \
+  Libc "$LIBC_TAG" "$LIBC_COMMIT" include/semaphore.h
+stage_one usr/include/sys/ioctl.h "$SRC/sys/ioctl.h" \
+  xnu "$XNU_TAG" "$XNU_COMMIT" bsd/sys/ioctl.h
+stage_one usr/include/sys/ioccom.h "$SRC/sys/ioccom.h" \
+  xnu "$XNU_TAG" "$XNU_COMMIT" bsd/sys/ioccom.h
+stage_one usr/include/sys/ttycom.h "$SRC/sys/ttycom.h" \
+  xnu "$XNU_TAG" "$XNU_COMMIT" bsd/sys/ttycom.h
+stage_one usr/include/sys/filio.h "$SRC/sys/filio.h" \
+  xnu "$XNU_TAG" "$XNU_COMMIT" bsd/sys/filio.h
+stage_one usr/include/sys/sockio.h "$SRC/sys/sockio.h" \
+  xnu "$XNU_TAG" "$XNU_COMMIT" bsd/sys/sockio.h
+
+echo "stage_overlay_posix: done sysroot=$SDK"
+echo "  staged: semaphore.h (Libc $LIBC_TAG) + sys/{ioctl,ioccom,ttycom,filio,sockio}.h (xnu $XNU_TAG)"

--- a/swiftcore-macho/scripts/stage_sdk.sh
+++ b/swiftcore-macho/scripts/stage_sdk.sh
@@ -89,11 +89,18 @@ for h in "$W/libc/"*.h; do
   cp "$h" "$SDK/usr/include/$b"
 done
 
-# 3c. libc++. A real macOS SDK ships Apple's libc++ at usr/include/c++/v1; the
+# 3c. POSIX overlay headers LibcOverlayShims.h needs (semaphore.h, sys/ioctl.h
+#     and the ioctl closure). Copied from the same apple-oss-distributions
+#     pins as machorun/sdk/SOURCES.tsv — not stand-ins. Refuse-overwrite lives
+#     in stage_overlay_posix.sh.
+bash "$SCRIPT_DIR/stage_overlay_posix.sh" "$SDK"
+
+# 3d. libc++. A real macOS SDK ships Apple's libc++ at usr/include/c++/v1; the
 #     stdlib's C++ half needs <new>, <atomic>, <type_traits>, ... machorun's
 #     SDK_SURVEY §2.5 measured stock LLVM 18 libc++ as a drop-in for Apple's
 #     (objc4 scored the same 41/44 and produced a byte-identical binary), so we
 #     use Ubuntu's libc++-18 headers rather than fabricating 734 of our own.
+#     (Numbering: overlay POSIX headers are 3c; this is 3d.)
 mkdir -p "$SDK/usr/include/c++"
 cp -a /usr/lib/llvm-18/include/c++/v1 "$SDK/usr/include/c++/v1"
 

--- a/swiftcore-macho/scripts/test_configure_arch.sh
+++ b/swiftcore-macho/scripts/test_configure_arch.sh
@@ -8,7 +8,8 @@ fail=0
 
 dump() {
   local arch=$1 host=$2 triple=$3
-  SWIFTCORE_DARWIN_ARCH=$arch SWIFT_HOST_VARIANT_ARCH=$host SWIFT_HOST_TRIPLE=$triple \
+  SWIFTCORE_OVERLAYS=0 SWIFTCORE_BUILD_DISPATCH=0 \
+    SWIFTCORE_DARWIN_ARCH=$arch SWIFT_HOST_VARIANT_ARCH=$host SWIFT_HOST_TRIPLE=$triple \
     W=/tmp/swiftcore-print SRC=/tmp/swiftcore-print/swift B=/tmp/swiftcore-print/build \
     bash "$cfg" --print-flags
 }

--- a/swiftcore-macho/scripts/test_ninja_rc.sh
+++ b/swiftcore-macho/scripts/test_ninja_rc.sh
@@ -51,13 +51,13 @@ EOF
 chmod +x "$fake/ninja"
 
 run() {
-  local label=$1; shift
+  local label=$1 overlays=$2
   set +e
   out=$(
-    PATH="$fake:$PATH" NINJA="$fake/ninja" \
+    env PATH="$fake:$PATH" NINJA="$fake/ninja" \
       SWIFTCORE_NINJA_HARNESS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+      SWIFTCORE_OVERLAYS="$overlays" \
       W="$tmp/work" B="$tmp/work/build" \
-      "$@" \
       bash "$build" 2>&1
   )
   rc=$?
@@ -67,7 +67,7 @@ run() {
 }
 
 echo "=== failing core ninja (no gold wall) makes build_stdlib exit non-zero ==="
-run core SWIFTCORE_OVERLAYS=0
+run core 0
 if [ "$rc" -ne 0 ]; then
   echo "  OK  rc=$rc"
 else
@@ -125,7 +125,7 @@ exit 1
 EOF
 chmod +x "$fake/ninja"
 
-run overlay SWIFTCORE_OVERLAYS=1
+run overlay 1
 if [ "$rc" -ne 0 ]; then
   echo "  OK  rc=$rc"
 else
@@ -140,7 +140,7 @@ printf '%s\n' "$out" | grep -q 'ninja: FAILED rc=' \
 printf '%s\n' "$out" | grep -q 'build_stdlib done' \
   && { echo "  FAIL printed done after overlay failure"; fail=1; } \
   || echo "  OK  did not claim done"
-printf '%s\n' "$out" | grep -q 'swiftObjectiveC' \
+printf '%s\n' "$out" | grep -E 'ninja overlay swiftObjectiveC|will ninja.*swiftObjectiveC' \
   && { echo "  FAIL asked ninja for swiftObjectiveC"; fail=1; } \
   || echo "  OK  did not invoke missing ObjectiveC target"
 

--- a/swiftcore-macho/scripts/test_ninja_rc.sh
+++ b/swiftcore-macho/scripts/test_ninja_rc.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# A failing ninja target must make build_stdlib.sh exit non-zero.
+# SWIFTCORE_NINJA_HARNESS=1 skips bootstrap/cmake so this is a unit test.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+build=$SCRIPT_DIR/build_stdlib.sh
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fake=$tmp/bin
+mkdir -p "$fake" "$tmp/work/build"
+
+cat > "$fake/ninja" <<'EOF'
+#!/bin/bash
+# Minimal fake ninja. Honors -C / -t targets / -j, then the target name.
+args=("$@")
+targets_mode=0
+target=""
+i=0
+while [ $i -lt ${#args[@]} ]; do
+  a=${args[$i]}
+  case "$a" in
+    -C) i=$((i+2)); continue ;;
+    -j) i=$((i+2)); continue ;;
+    -t)
+      i=$((i+1))
+      if [ "${args[$i]:-}" = targets ]; then targets_mode=1; fi
+      i=$((i+1)); continue
+      ;;
+    *) target=$a; i=$((i+1)); continue ;;
+  esac
+done
+
+if [ "$targets_mode" = 1 ]; then
+  cat <<'T'
+swiftCore-macosx-x86_64: phony
+swift_Concurrency-macosx-x86_64: phony
+swiftSynchronization-macosx-x86_64: phony
+swift_StringProcessing-macosx-x86_64: phony
+swift_Builtin_float-macosx-x86_64: phony
+swiftDarwin-macosx-x86_64: phony
+T
+  exit 0
+fi
+
+echo "FAILED: $target"
+echo "ninja: error: fake ninja failing $target"
+exit 1
+EOF
+chmod +x "$fake/ninja"
+
+run() {
+  local label=$1; shift
+  set +e
+  out=$(
+    PATH="$fake:$PATH" NINJA="$fake/ninja" \
+      SWIFTCORE_NINJA_HARNESS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+      W="$tmp/work" B="$tmp/work/build" \
+      "$@" \
+      bash "$build" 2>&1
+  )
+  rc=$?
+  set -e
+  printf '%s\n' "$out"
+  echo "--- $label rc=$rc ---"
+}
+
+echo "=== failing core ninja (no gold wall) makes build_stdlib exit non-zero ==="
+run core SWIFTCORE_OVERLAYS=0
+if [ "$rc" -ne 0 ]; then
+  echo "  OK  rc=$rc"
+else
+  echo "  FAIL expected nonzero"; fail=1
+fi
+printf '%s\n' "$out" | grep -q 'ninja: FAILED rc=' \
+  && echo "  OK  ninja_checked reported failure" \
+  || { echo "  FAIL missing ninja: FAILED"; fail=1; }
+printf '%s\n' "$out" | grep -q 'build_stdlib done' \
+  && { echo "  FAIL printed build_stdlib done after ninja failure"; fail=1; } \
+  || echo "  OK  did not claim done"
+
+echo
+echo "=== failing overlay ninja makes build_stdlib exit non-zero ==="
+# Core is allowed to hit the gold wall; overlay must still fail the script.
+cat > "$fake/ninja" <<'EOF'
+#!/bin/bash
+args=("$@")
+targets_mode=0
+target=""
+i=0
+while [ $i -lt ${#args[@]} ]; do
+  a=${args[$i]}
+  case "$a" in
+    -C) i=$((i+2)); continue ;;
+    -j) i=$((i+2)); continue ;;
+    -t)
+      i=$((i+1))
+      if [ "${args[$i]:-}" = targets ]; then targets_mode=1; fi
+      i=$((i+1)); continue
+      ;;
+    *) target=$a; i=$((i+1)); continue ;;
+  esac
+done
+if [ "$targets_mode" = 1 ]; then
+  cat <<'T'
+swiftCore-macosx-x86_64: phony
+swift_Concurrency-macosx-x86_64: phony
+swiftSynchronization-macosx-x86_64: phony
+swift_StringProcessing-macosx-x86_64: phony
+swift_Builtin_float-macosx-x86_64: phony
+swiftDarwin-macosx-x86_64: phony
+T
+  exit 0
+fi
+if [[ "$target" == swiftCore-* ]]; then
+  echo "clang++: error: invalid linker name in argument '-fuse-ld=gold'"
+  echo "ninja: build stopped: subcommand failed."
+  exit 1
+fi
+echo "FAILED: stdlib/public/Platform/OSX/x86_64/Darwin.o"
+echo "error: 'semaphore.h' file not found"
+echo "ninja: build stopped: subcommand failed."
+exit 1
+EOF
+chmod +x "$fake/ninja"
+
+run overlay SWIFTCORE_OVERLAYS=1
+if [ "$rc" -ne 0 ]; then
+  echo "  OK  rc=$rc"
+else
+  echo "  FAIL expected nonzero after overlay ninja failure"; fail=1
+fi
+printf '%s\n' "$out" | grep -q 'expected ELF gold wall' \
+  && echo "  OK  core gold wall allowed" \
+  || { echo "  FAIL core gold wall not recognized"; fail=1; }
+printf '%s\n' "$out" | grep -q 'ninja: FAILED rc=' \
+  && echo "  OK  overlay ninja propagated" \
+  || { echo "  FAIL overlay failure swallowed"; fail=1; }
+printf '%s\n' "$out" | grep -q 'build_stdlib done' \
+  && { echo "  FAIL printed done after overlay failure"; fail=1; } \
+  || echo "  OK  did not claim done"
+printf '%s\n' "$out" | grep -q 'swiftObjectiveC' \
+  && { echo "  FAIL asked ninja for swiftObjectiveC"; fail=1; } \
+  || echo "  OK  did not invoke missing ObjectiveC target"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- failing ninja makes build_stdlib.sh exit non-zero"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_overlay_posix.sh
+++ b/swiftcore-macho/scripts/test_overlay_posix.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# POSIX overlay headers are Apple's, from the machorun SDK pins, refuse-overwrite.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "=== stage into empty sysroot prints provenance ==="
+mkdir -p "$tmp/sdk"
+set +e
+out=$(bash "$SCRIPT_DIR/stage_overlay_posix.sh" "$tmp/sdk" 2>&1)
+rc=$?
+set -e
+printf '%s\n' "$out"
+[ "$rc" -eq 0 ] && echo "  OK  rc=0" || { echo "  FAIL rc=$rc"; fail=1; }
+for h in usr/include/semaphore.h usr/include/sys/ioctl.h usr/include/sys/ioccom.h \
+         usr/include/sys/ttycom.h usr/include/sys/filio.h usr/include/sys/sockio.h; do
+  [ -f "$tmp/sdk/$h" ] && echo "  OK  $h" || { echo "  FAIL missing $h"; fail=1; }
+done
+printf '%s\n' "$out" | grep -q 'tag=Libc-1752.120.2' \
+  && echo "  OK  Libc tag" || { echo "  FAIL missing Libc tag"; fail=1; }
+printf '%s\n' "$out" | grep -q 'commit=4e34d0559e3a1b081afeb8604d9e204a1f31321d' \
+  && echo "  OK  Libc commit" || { echo "  FAIL missing Libc commit"; fail=1; }
+printf '%s\n' "$out" | grep -q 'tag=xnu-12377.121.6' \
+  && echo "  OK  xnu tag" || { echo "  FAIL missing xnu tag"; fail=1; }
+printf '%s\n' "$out" | grep -q 'commit=ac9718fb1af618d5ce8678d0dc6e8a58f252216f' \
+  && echo "  OK  xnu commit" || { echo "  FAIL missing xnu commit"; fail=1; }
+# Byte-identical to the vendored Apple file, not a stand-in.
+cmp -s "$ROOT/sdk/overlay-posix/semaphore.h" "$tmp/sdk/usr/include/semaphore.h" \
+  && echo "  OK  semaphore.h is the vendored Apple file" \
+  || { echo "  FAIL semaphore.h mismatch"; fail=1; }
+grep -q '_BSD_SEMAPHORE_H' "$tmp/sdk/usr/include/semaphore.h" \
+  && echo "  OK  Apple POSIX wrapper guard" || { echo "  FAIL not Apple wrapper"; fail=1; }
+
+echo
+echo "=== refuse overwrite ==="
+set +e
+out=$(bash "$SCRIPT_DIR/stage_overlay_posix.sh" "$tmp/sdk" 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 2 ] && echo "  OK  rc=2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
+printf '%s\n' "$out" | grep -q REFUSING \
+  && echo "  OK  REFUSING" || { echo "  FAIL no REFUSING"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- overlay POSIX headers staged from Apple OSS pins"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_overlay_siblings.sh
+++ b/swiftcore-macho/scripts/test_overlay_siblings.sh
@@ -77,6 +77,7 @@ printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_SYNCHRONIZATION=ON" >/dev/nul
 echo
 echo "=== default (overlays off) dump has no empty string-processing -D ==="
 def=$(
+  unset SWIFTCORE_OVERLAYS SWIFTCORE_BUILD_DISPATCH
   SWIFTCORE_DARWIN_ARCH=x86_64 SWIFT_HOST_VARIANT_ARCH=x86_64 \
     SWIFT_HOST_TRIPLE=x86_64-unknown-linux-gnu \
     W=/tmp/swiftcore-print bash "$cfg" --print-flags

--- a/swiftcore-macho/scripts/test_overlay_targets.sh
+++ b/swiftcore-macho/scripts/test_overlay_targets.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Overlay ninja names come from `ninja -t targets`. Missing required targets
+# refuse with CANNOT_OVERLAY_TARGET_ABSENT. ObjectiveC is not invoked.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/overlay_targets.inc"
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "=== dump with required overlays + Darwin, no ObjectiveC ==="
+cat > "$tmp/targets" <<'EOF'
+swift_Concurrency-macosx-x86_64: phony
+swiftSynchronization-macosx-x86_64: phony
+swift_StringProcessing-macosx-x86_64: phony
+swift_Builtin_float-macosx-x86_64: phony
+swiftDarwin-macosx-x86_64: phony
+swiftCore-macosx-x86_64: phony
+EOF
+set +e
+out=$(NINJA_TARGETS_DUMP="$tmp/targets" overlay_select_targets /no/build x86_64 2>&1)
+rc=$?
+set -e
+printf '%s\n' "$out"
+[ "$rc" -eq 0 ] && echo "  OK  rc=0" || { echo "  FAIL rc=$rc"; fail=1; }
+printf '%s\n' "$out" | grep -q 'will ninja.*swiftDarwin-macosx-x86_64' \
+  && echo "  OK  Darwin in ninja list" || { echo "  FAIL Darwin not selected"; fail=1; }
+printf '%s\n' "$out" | grep -q 'CANNOT_STAGE_XCODE_DARWIN_OVERLAYS target=swiftObjectiveC-macosx-x86_64' \
+  && echo "  OK  ObjectiveC named CANNOT" || { echo "  FAIL missing ObjectiveC CANNOT"; fail=1; }
+printf '%s\n' "$out" | grep -q 'will ninja.*swiftObjectiveC' \
+  && { echo "  FAIL ObjectiveC still in will-ninja list"; fail=1; } \
+  || echo "  OK  ObjectiveC not ninja'd"
+
+echo
+echo "=== missing required _StringProcessing is CANNOT_OVERLAY_TARGET_ABSENT ==="
+cat > "$tmp/targets" <<'EOF'
+swift_Concurrency-macosx-x86_64: phony
+swiftSynchronization-macosx-x86_64: phony
+swift_Builtin_float-macosx-x86_64: phony
+swiftDarwin-macosx-x86_64: phony
+EOF
+set +e
+out=$(NINJA_TARGETS_DUMP="$tmp/targets" overlay_select_targets /no/build x86_64 2>&1)
+rc=$?
+set -e
+printf '%s\n' "$out"
+[ "$rc" -eq 2 ] && echo "  OK  rc=2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
+printf '%s\n' "$out" | grep -q 'CANNOT_OVERLAY_TARGET_ABSENT target=swift_StringProcessing-macosx-x86_64' \
+  && echo "  OK  named the missing required target" \
+  || { echo "  FAIL missing CANNOT_OVERLAY_TARGET_ABSENT"; fail=1; }
+
+echo
+echo "=== live ninja -t targets from overlay-cmake-proof (if present) ==="
+proof=/tmp/overlay-cmake-proof
+if [ -f "$proof/build.ninja" ]; then
+  set +e
+  out=$(unset NINJA_TARGETS_DUMP; overlay_select_targets "$proof" x86_64 2>&1)
+  rc=$?
+  set -e
+  printf '%s\n' "$out"
+  [ "$rc" -eq 0 ] && echo "  OK  live graph rc=0" || { echo "  FAIL live rc=$rc"; fail=1; }
+  printf '%s\n' "$out" | grep -q 'swiftObjectiveC' && ! printf '%s\n' "$out" | grep -q 'will ninja.*swiftObjectiveC' \
+    && echo "  OK  live graph does not ninja ObjectiveC" \
+    || {
+      if printf '%s\n' "$out" | grep -q 'will ninja.*swiftObjectiveC'; then
+        echo "  FAIL live graph selected ObjectiveC"; fail=1
+      else
+        echo "  OK  live graph has no ObjectiveC to ninja"
+      fi
+    }
+else
+  echo "  skip (no $proof/build.ninja)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- overlay targets derived from ninja -t targets; ObjectiveC gated"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_probe_machorun.sh
+++ b/swiftcore-macho/scripts/test_probe_machorun.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# The execute-guest marker is decided by a positive loader probe, never by
+# assuming this process is a cloud-agent VM.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/probe_machorun.inc"
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "=== empty tree is not a loader ==="
+set +e
+got=$(
+  unset MACHORUN_LOADER MACHORUN OPENUIKIT_ROOT
+  MACHORUN=/no/such/machorun OPENUIKIT_ROOT=/no/such/openuikit W="$tmp" \
+    probe_x86_macho_loader
+)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] && echo "  OK  no loader rc=$rc" || { echo "  FAIL probed a loader: $got"; fail=1; }
+
+echo
+echo "=== real loader on this host (if present) ==="
+# Point only at well-known in-tree / work-dir loaders; still a positive probe.
+found=0
+for cand in \
+  "${SCRIPT_DIR}/../../machorun/build/machorun" \
+  "$HOME/work/machorun/build/machorun" \
+  /workspace/machorun/build/machorun
+do
+  [ -x "$cand" ] || continue
+  set +e
+  got=$(
+    SWIFTCORE_DARWIN_ARCH=x86_64 \
+      MACHORUN_LOADER="$cand" MACHORUN=/no/such OPENUIKIT_ROOT=/no/such W="$tmp" \
+      probe_x86_macho_loader
+  )
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "  OK  probed $got"
+    printf '%s' "$got" | grep -q "$cand" && echo "  OK  path is the candidate" \
+      || { echo "  FAIL got=$got want $cand"; fail=1; }
+    found=1
+    break
+  fi
+done
+if [ "$found" = 0 ]; then
+  echo "  skip (no in-tree machorun ELF on this host)"
+fi
+
+echo
+echo "=== script that is not a machorun loader is rejected ==="
+printf '#!/bin/bash\necho hello\n' > "$tmp/not-loader"
+chmod +x "$tmp/not-loader"
+set +e
+got=$(MACHORUN_LOADER="$tmp/not-loader" MACHORUN=/no OPENUIKIT_ROOT=/no W="$tmp" \
+  probe_x86_macho_loader)
+rc=$?
+set -e
+[ "$rc" -ne 0 ] && echo "  OK  non-ELF / non-machorun rejected" \
+  || { echo "  FAIL accepted $got"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- loader probe is positive, not a VM assumption"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/verify_hello.sh
+++ b/swiftcore-macho/scripts/verify_hello.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 # Compile+link a hello-world Swift program against the just-built Darwin slice.
-# Execution is refused: this cloud-agent VM is not the operator x86 host.
+# Execution is a positive probe: a machorun loader binary that can run an
+# x86_64 Mach-O on this host. The marker is never printed just because the
+# process happens to be a cloud-agent VM.
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SWIFTCORE_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+OPENUIKIT_ROOT=$(cd "$SWIFTCORE_ROOT/.." && pwd)
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/guest_arch.inc"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/probe_machorun.inc"
 
 W=${W:-$HOME/work}
 B=${B:-$W/build}
@@ -13,6 +19,7 @@ RES=$B/lib/swift
 LIBDIR=$B/lib/swift/${SWIFTCORE_STDLIB_DIR}
 HELLO=${HELLO:-$W/hello_swiftcore.swift}
 OUT=${OUT:-$W/hello_swiftcore}
+MACHORUN=${MACHORUN:-$OPENUIKIT_ROOT/machorun}
 
 if [ ! -f "$LIBDIR/libswiftCore.dylib" ]; then
   echo "verify_hello: no $LIBDIR/libswiftCore.dylib" >&2
@@ -67,5 +74,41 @@ if [ "$SWIFTCORE_DARWIN_ARCH" = x86_64 ]; then
 fi
 
 echo "compile+link OK  guest=$OUT  cpu=$SWIFTCORE_MACHO_CPU"
-echo "CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST host=$(uname -m) split=compile-link-in-vm/execution-operator-x86-ec2 reason=linked Mach-O $OUT is ${SWIFTCORE_MACHO_CPU}; running it needs the ported machorun loader on the operator x86 host, not this cloud-agent VM" >&2
+
+if [ "$SWIFTCORE_DARWIN_ARCH" != x86_64 ]; then
+  echo "verify_hello: guest is $SWIFTCORE_DARWIN_ARCH; x86_64 loader probe skipped"
+  exit 0
+fi
+
+probed=$(probe_x86_macho_loader || true)
+if [ -z "$probed" ]; then
+  cands=$(probe_machorun_candidates | tr '\n' ' ')
+  echo "CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST host=$(uname -m) guest=$OUT cpu=${SWIFTCORE_MACHO_CPU} reason=no machorun loader binary on this host can run an x86_64 Mach-O (probed: $cands)" >&2
+  exit 0
+fi
+
+loader=${probed%%$'\t'*}
+root=${probed#*$'\t'}
+echo "probe: machorun loader=$loader root=$root"
+echo "probe: $(file -b "$loader")"
+
+# Prefix map: /usr/lib/swift/libswiftCore.dylib -> $root/darwin/usr/lib/swift/...
+dst_dir=$root/darwin/usr/lib/swift
+mkdir -p "$dst_dir"
+if [ -e "$dst_dir/libswiftCore.dylib" ]; then
+  if ! cmp -s "$LIBDIR/libswiftCore.dylib" "$dst_dir/libswiftCore.dylib"; then
+    echo "verify_hello: $dst_dir/libswiftCore.dylib differs from this build; parking it"
+    mv "$dst_dir/libswiftCore.dylib" "$dst_dir/libswiftCore.dylib.park-$$"
+  fi
+fi
+ln -sfn "$LIBDIR/libswiftCore.dylib" "$dst_dir/libswiftCore.dylib"
+echo "probe: staged $dst_dir/libswiftCore.dylib -> $LIBDIR/libswiftCore.dylib"
+
+echo "=== hello under machorun ==="
+set +e
+hello_out=$(MACHORUN_ROOT="$root" "$loader" "$OUT" 2>&1)
+hello_rc=$?
+set -e
+printf '%s\n' "$hello_out"
+echo "hello_swiftcore machorun exit=$hello_rc"
 exit 0

--- a/swiftcore-macho/sdk/overlay-posix/PROVENANCE.txt
+++ b/swiftcore-macho/sdk/overlay-posix/PROVENANCE.txt
@@ -1,0 +1,29 @@
+overlay-posix — Darwin Platform overlay headers missing from machorun's SDK
+
+These are Apple's published headers, copied verbatim from the same
+apple-oss-distributions pins machorun/sdk/SOURCES.tsv already uses for the
+arm64 overlay sysroot. They are NOT clean-room stand-ins. stage_sdk.sh copies
+them into $W/sdk/MacOSX.sdk with refuse-overwrite (same rule as sdk/libc/).
+
+They are NOT copied into machorun/sdk/. POSIX <semaphore.h> staying out of
+machorun's SDK is the CONCURRENCY.md standing agreement (libdispatch
+USE_POSIX_SEM vs Darwin's 4-byte sem_t). The Swift overlay sysroot is a
+different tree.
+
+Libc  tag=Libc-1752.120.2  commit=4e34d0559e3a1b081afeb8604d9e204a1f31321d
+  include/semaphore.h  -> usr/include/semaphore.h
+  sha256=203aef4191a0bb7283892baa28f3b5e668a580c4ce6dcdc4e6cb64690a25b31f
+  Apple's POSIX wrapper: #include <sys/types.h>, <sys/fcntl.h>, <sys/semaphore.h>
+  (Darwin sem_t is typedef int in the already-staged xnu sys/semaphore.h).
+
+xnu   tag=xnu-12377.121.6  commit=ac9718fb1af618d5ce8678d0dc6e8a58f252216f
+  bsd/sys/ioctl.h   -> usr/include/sys/ioctl.h
+  bsd/sys/ioccom.h  -> usr/include/sys/ioccom.h
+  bsd/sys/ttycom.h  -> usr/include/sys/ttycom.h
+  bsd/sys/filio.h   -> usr/include/sys/filio.h
+  bsd/sys/sockio.h  -> usr/include/sys/sockio.h
+
+Consumer: stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
+  #include <semaphore.h>
+  #include <sys/ioctl.h>
+and the Platform overlay (swiftDarwin) that imports SwiftOverlayShims.

--- a/swiftcore-macho/sdk/overlay-posix/semaphore.h
+++ b/swiftcore-macho/sdk/overlay-posix/semaphore.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+#ifndef _BSD_SEMAPHORE_H
+#define _BSD_SEMAPHORE_H
+
+#include <sys/types.h>
+#include <sys/fcntl.h>
+
+#include <sys/semaphore.h>
+
+#endif /* _BSD_SEMAPHORE_H */

--- a/swiftcore-macho/sdk/overlay-posix/sys/filio.h
+++ b/swiftcore-macho/sdk/overlay-posix/sys/filio.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2000-2023 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/* Copyright (c) 1995 NeXT Computer, Inc. All Rights Reserved */
+/*-
+ * Copyright (c) 1982, 1986, 1990, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)filio.h	8.1 (Berkeley) 3/28/94
+ */
+
+#ifndef _SYS_FILIO_H_
+#define _SYS_FILIO_H_
+
+#include <sys/ioccom.h>
+
+/* Generic file-descriptor ioctl's. */
+#define FIOCLEX          _IO('f', 1)            /* set close on exec on fd */
+#define FIONCLEX         _IO('f', 2)            /* remove close on exec */
+#define FIONREAD        _IOR('f', 127, int)     /* get # bytes to read */
+#define FIONBIO         _IOW('f', 126, int)     /* set/clear non-blocking i/o */
+#define FIOASYNC        _IOW('f', 125, int)     /* set/clear async i/o */
+#define FIOSETOWN       _IOW('f', 124, int)     /* set owner */
+#define FIOGETOWN       _IOR('f', 123, int)     /* get owner */
+#define FIODTYPE        _IOR('f', 122, int)     /* get d_type */
+
+#ifdef KERNEL_PRIVATE
+#define FIODEVICELOCKED _IO('f', 121)   /* device locked/unlocked */
+#define FIOPINSWAP              _IO('f', 120)   /* pin swap file to fast device */
+#define FIODEVICEEPSTATE _IOR('f', 119, int)  /* get device ephemeral state */
+#define FIODEVICECXSTATE _IO('f', 118)  /* cx class expired */
+#endif
+
+#endif /* !_SYS_FILIO_H_ */

--- a/swiftcore-macho/sdk/overlay-posix/sys/ioccom.h
+++ b/swiftcore-macho/sdk/overlay-posix/sys/ioccom.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/* Copyright (c) 1995 NeXT Computer, Inc. All Rights Reserved */
+/*-
+ * Copyright (c) 1982, 1986, 1990, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ioccom.h	8.2 (Berkeley) 3/28/94
+ */
+
+#ifndef _SYS_IOCCOM_H_
+#define _SYS_IOCCOM_H_
+
+#include <sys/_types.h>
+
+/*
+ * Ioctl's have the command encoded in the lower word, and the size of
+ * any in or out parameters in the upper word.  The high 3 bits of the
+ * upper word are used to encode the in/out status of the parameter.
+ */
+#define IOCPARM_MASK    0x1fff          /* parameter length, at most 13 bits */
+#define IOCPARM_LEN(x)  (((x) >> 16) & IOCPARM_MASK)
+#define IOCBASECMD(x)   ((x) & ~(IOCPARM_MASK << 16))
+#define IOCGROUP(x)     (((x) >> 8) & 0xff)
+
+#define IOCPARM_MAX     (IOCPARM_MASK + 1)      /* max size of ioctl args */
+/* no parameters */
+#define IOC_VOID        (__uint32_t)0x20000000
+/* copy parameters out */
+#define IOC_OUT         (__uint32_t)0x40000000
+/* copy parameters in */
+#define IOC_IN          (__uint32_t)0x80000000
+/* copy parameters in and out */
+#define IOC_INOUT       (IOC_IN|IOC_OUT)
+/* mask for IN/OUT/VOID */
+#define IOC_DIRMASK     (__uint32_t)0xe0000000
+
+#define _IOC(inout, group, num, len) \
+	(inout | ((len & IOCPARM_MASK) << 16) | ((group) << 8) | (num))
+#define _IO(g, n)        _IOC(IOC_VOID,	(g), (n), 0)
+#define _IOR(g, n, t)     _IOC(IOC_OUT,	(g), (n), sizeof(t))
+#define _IOW(g, n, t)     _IOC(IOC_IN,	(g), (n), sizeof(t))
+/* this should be _IORW, but stdio got there first */
+#define _IOWR(g, n, t)    _IOC(IOC_INOUT,	(g), (n), sizeof(t))
+
+#endif /* !_SYS_IOCCOM_H_ */

--- a/swiftcore-macho/sdk/overlay-posix/sys/ioctl.h
+++ b/swiftcore-macho/sdk/overlay-posix/sys/ioctl.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/* Copyright (c) 1995 NeXT Computer, Inc. All Rights Reserved */
+/*-
+ * Copyright (c) 1982, 1986, 1990, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ioctl.h	8.6 (Berkeley) 3/28/94
+ */
+
+#ifndef _SYS_IOCTL_H_
+#define _SYS_IOCTL_H_
+
+#include <sys/ttycom.h>
+
+/*
+ * Pun for SunOS prior to 3.2.  SunOS 3.2 and later support TIOCGWINSZ
+ * and TIOCSWINSZ (yes, even 3.2-3.5, the fact that it wasn't documented
+ * nonwithstanding).
+ */
+struct ttysize {
+	unsigned short  ts_lines;
+	unsigned short  ts_cols;
+	unsigned short  ts_xxx;
+	unsigned short  ts_yyy;
+};
+#define TIOCGSIZE       TIOCGWINSZ
+#define TIOCSSIZE       TIOCSWINSZ
+
+#include <sys/ioccom.h>
+
+#include <sys/filio.h>
+#include <sys/sockio.h>
+
+#ifndef KERNEL
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+int     ioctl(int, unsigned long, ...);
+__END_DECLS
+#endif /* !KERNEL */
+#endif /* !_SYS_IOCTL_H_ */
+
+/*
+ * Keep outside _SYS_IOCTL_H_
+ * Compatability with old terminal driver
+ *
+ * Source level -> #define USE_OLD_TTY
+ * Kernel level -> always on
+ */
+#if defined(USE_OLD_TTY) || defined(BSD_KERNEL_PRIVATE)
+#include <sys/ioctl_compat.h>
+#endif /* defined(USE_OLD_TTY) || defined(BSD_KERNEL_PRIVATE) */

--- a/swiftcore-macho/sdk/overlay-posix/sys/sockio.h
+++ b/swiftcore-macho/sdk/overlay-posix/sys/sockio.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2000-2023 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/* Copyright (c) 1995 NeXT Computer, Inc. All Rights Reserved */
+/*-
+ * Copyright (c) 1982, 1986, 1990, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)sockio.h	8.1 (Berkeley) 3/28/94
+ */
+
+#ifndef _SYS_SOCKIO_H_
+#define _SYS_SOCKIO_H_
+
+#include <sys/appleapiopts.h>
+
+#ifndef KERNEL_PRIVATE
+#include <net/if.h>
+#endif
+#include <sys/ioccom.h>
+
+/* Socket ioctl's. */
+#define SIOCSHIWAT       _IOW('s',  0, int)             /* set high watermark */
+#define SIOCGHIWAT       _IOR('s',  1, int)             /* get high watermark */
+#define SIOCSLOWAT       _IOW('s',  2, int)             /* set low watermark */
+#define SIOCGLOWAT       _IOR('s',  3, int)             /* get low watermark */
+#define SIOCATMARK       _IOR('s',  7, int)             /* at oob mark? */
+#define SIOCSPGRP        _IOW('s',  8, int)             /* set process group */
+#define SIOCGPGRP        _IOR('s',  9, int)             /* get process group */
+
+#define SIOCSIFADDR     _IOW('i', 12, struct ifreq)     /* set ifnet address */
+#ifdef KERNEL_PRIVATE
+/* See sockio_private.h for extended ioctls */
+#endif /* KERNEL_PRIVATE */
+#define SIOCSIFDSTADDR   _IOW('i', 14, struct ifreq)    /* set p-p address */
+#define SIOCSIFFLAGS     _IOW('i', 16, struct ifreq)    /* set ifnet flags */
+#define SIOCGIFFLAGS    _IOWR('i', 17, struct ifreq)    /* get ifnet flags */
+#define SIOCSIFBRDADDR   _IOW('i', 19, struct ifreq)    /* set broadcast addr */
+#define SIOCSIFNETMASK   _IOW('i', 22, struct ifreq)    /* set net addr mask */
+#define SIOCGIFMETRIC   _IOWR('i', 23, struct ifreq)    /* get IF metric */
+#define SIOCSIFMETRIC   _IOW('i', 24, struct ifreq)     /* set IF metric */
+#define SIOCDIFADDR     _IOW('i', 25, struct ifreq)     /* delete IF addr */
+#define SIOCAIFADDR     _IOW('i', 26, struct ifaliasreq)/* add/chg IF alias */
+
+#define SIOCGIFADDR     _IOWR('i', 33, struct ifreq)    /* get ifnet address */
+#define SIOCGIFDSTADDR  _IOWR('i', 34, struct ifreq)    /* get p-p address */
+#define SIOCGIFBRDADDR  _IOWR('i', 35, struct ifreq)    /* get broadcast addr */
+#if !defined(KERNEL) || defined(KERNEL_PRIVATE)
+#define SIOCGIFCONF     _IOWR('i', 36, struct ifconf)   /* get ifnet list */
+#endif /* !KERNEL || KERNEL_PRIVATE */
+#ifdef KERNEL_PRIVATE
+/* See sockio_private.h for extended ioctls */
+#endif /* KERNEL_PRIVATE */
+#define SIOCGIFNETMASK  _IOWR('i', 37, struct ifreq)    /* get net addr mask */
+#define SIOCAUTOADDR    _IOWR('i', 38, struct ifreq)    /* autoconf address */
+#define SIOCAUTONETMASK _IOW('i', 39, struct ifreq)     /* autoconf netmask */
+#define SIOCARPIPLL             _IOWR('i', 40, struct ifreq)    /* arp for IPv4LL address */
+
+#define SIOCADDMULTI     _IOW('i', 49, struct ifreq)    /* add m'cast addr */
+#define SIOCDELMULTI     _IOW('i', 50, struct ifreq)    /* del m'cast addr */
+#define SIOCGIFMTU      _IOWR('i', 51, struct ifreq)    /* get IF mtu */
+#define SIOCSIFMTU       _IOW('i', 52, struct ifreq)    /* set IF mtu */
+#define SIOCGIFPHYS     _IOWR('i', 53, struct ifreq)    /* get IF wire */
+#define SIOCSIFPHYS      _IOW('i', 54, struct ifreq)    /* set IF wire */
+#define SIOCSIFMEDIA    _IOWR('i', 55, struct ifreq)    /* set net media */
+
+/*
+ * The command SIOCGIFMEDIA does not allow a process to access the extended
+ * media subtype and extended subtype values are returned as IFM_OTHER.
+ */
+#define SIOCGIFMEDIA    _IOWR('i', 56, struct ifmediareq) /* get compatible net media  */
+#ifdef KERNEL_PRIVATE
+/* See sockio_private.h for extended ioctls */
+#endif /* KERNEL_PRIVATE */
+
+#define SIOCSIFGENERIC   _IOW('i', 57, struct ifreq)    /* generic IF set op */
+#define SIOCGIFGENERIC  _IOWR('i', 58, struct ifreq)    /* generic IF get op */
+#define SIOCRSLVMULTI   _IOWR('i', 59, struct rslvmulti_req)
+
+#define SIOCSIFLLADDR   _IOW('i', 60, struct ifreq)     /* set link level addr */
+#define SIOCGIFSTATUS   _IOWR('i', 61, struct ifstat)   /* get IF status */
+#define SIOCSIFPHYADDR   _IOW('i', 62, struct ifaliasreq) /* set gif addres */
+#define SIOCGIFPSRCADDR _IOWR('i', 63, struct ifreq)    /* get gif psrc addr */
+#define SIOCGIFPDSTADDR _IOWR('i', 64, struct ifreq)    /* get gif pdst addr */
+#define SIOCDIFPHYADDR   _IOW('i', 65, struct ifreq)    /* delete gif addrs */
+
+#define SIOCGIFDEVMTU   _IOWR('i', 68, struct ifreq)    /* get if ifdevmtu */
+#define SIOCSIFALTMTU    _IOW('i', 69, struct ifreq)    /* set if alternate mtu */
+#define SIOCGIFALTMTU   _IOWR('i', 72, struct ifreq)    /* get if alternate mtu */
+#define SIOCSIFBOND      _IOW('i', 70, struct ifreq)    /* set bond if config */
+#define SIOCGIFBOND     _IOWR('i', 71, struct ifreq)    /* get bond if config */
+
+/*
+ * The command SIOCGIFXMEDIA is meant to be used by processes only to be able
+ * to access the extended media subtypes with the extended IFM_TMASK.
+ *
+ * An ifnet must not implement SIOCGIFXMEDIA as it gets the extended
+ * media subtypes by simply compiling with <net/if_media.h>
+ */
+#define SIOCGIFXMEDIA   _IOWR('i', 72, struct ifmediareq) /* get net extended media */
+#ifdef KERNEL_PRIVATE
+/* See sockio_private.h for extended ioctls */
+#endif /* KERNEL_PRIVATE */
+
+#define SIOCSIFCAP       _IOW('i', 90, struct ifreq)    /* set IF features */
+#define SIOCGIFCAP      _IOWR('i', 91, struct ifreq)    /* get IF features */
+
+#define SIOCSIFMANAGEMENT       _IOWR('i', 92, struct ifreq)   /* set management interface */
+
+#define SIOCIFCREATE    _IOWR('i', 120, struct ifreq)   /* create clone if */
+#define SIOCIFDESTROY    _IOW('i', 121, struct ifreq)   /* destroy clone if */
+#define SIOCIFCREATE2   _IOWR('i', 122, struct ifreq)   /* create clone if with data */
+
+#define SIOCSDRVSPEC    _IOW('i', 123, struct ifdrv)    /* set driver-specific
+	                                                 *         parameters */
+#define SIOCGDRVSPEC    _IOWR('i', 123, struct ifdrv)   /* get driver-specific
+	                                                 *         parameters */
+#ifdef KERNEL_PRIVATE
+/* See sockio_private.h for extended ioctls */
+#endif /* KERNEL_PRIVATE */
+#define SIOCSIFVLAN      _IOW('i', 126, struct ifreq)   /* set VLAN config */
+#define SIOCGIFVLAN     _IOWR('i', 127, struct ifreq)   /* get VLAN config */
+#define SIOCSETVLAN     SIOCSIFVLAN
+#define SIOCGETVLAN     SIOCGIFVLAN
+
+#if !defined(KERNEL) || defined(KERNEL_PRIVATE)
+#define SIOCIFGCLONERS  _IOWR('i', 129, struct if_clonereq) /* get cloners */
+#endif /* !KERNEL || KERNEL_PRIVATE */
+#ifdef KERNEL_PRIVATE
+/* See sockio_private.h for extended ioctls */
+#endif /* KERNEL_PRIVATE */
+
+#define SIOCGIFASYNCMAP _IOWR('i', 124, struct ifreq)   /* get ppp asyncmap */
+#define SIOCSIFASYNCMAP _IOW('i', 125, struct ifreq)    /* set ppp asyncmap */
+
+
+#define SIOCGIFMAC      _IOWR('i', 130, struct ifreq)   /* deprecated */
+#define SIOCSIFMAC      _IOW('i', 131, struct ifreq)    /* deprecated */
+#define SIOCSIFKPI      _IOW('i', 134, struct ifreq) /* set interface kext param - root only */
+#define SIOCGIFKPI      _IOWR('i', 135, struct ifreq) /* get interface kext param */
+
+#define SIOCGIFWAKEFLAGS _IOWR('i', 136, struct ifreq) /* get interface wake property flags */
+
+#define SIOCGIFFUNCTIONALTYPE   _IOWR('i', 173, struct ifreq) /* get interface functional type */
+
+#define SIOCSIF6LOWPAN  _IOW('i', 196, struct ifreq)    /* set 6LOWPAN config */
+#define SIOCGIF6LOWPAN  _IOWR('i', 197, struct ifreq)   /* get 6LOWPAN config */
+
+#define SIOCGIFDIRECTLINK _IOWR('i', 222, struct ifreq) /* get DIRECTLINK */
+
+#if defined(PRIVATE) && !defined(MODULES_SUPPORTED)
+#include <sys/sockio_private.h>
+#endif /* PRIVATE */
+
+#endif /* !_SYS_SOCKIO_H_ */

--- a/swiftcore-macho/sdk/overlay-posix/sys/ttycom.h
+++ b/swiftcore-macho/sdk/overlay-posix/sys/ttycom.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2000-2002 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/* Copyright (c) 1997 Apple Computer, Inc. All Rights Reserved */
+/*-
+ * Copyright (c) 1982, 1986, 1990, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the University of
+ *      California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ttycom.h	8.1 (Berkeley) 3/28/94
+ */
+
+#ifndef _SYS_TTYCOM_H_
+#define _SYS_TTYCOM_H_
+
+#include <sys/ioccom.h>
+/*
+ * Tty ioctl's except for those supported only for backwards compatibility
+ * with the old tty driver.
+ */
+
+/*
+ * Window/terminal size structure.  This information is stored by the kernel
+ * in order to provide a consistent interface, but is not used by the kernel.
+ */
+struct winsize {
+	unsigned short  ws_row;         /* rows, in characters */
+	unsigned short  ws_col;         /* columns, in characters */
+	unsigned short  ws_xpixel;      /* horizontal size, pixels */
+	unsigned short  ws_ypixel;      /* vertical size, pixels */
+};
+
+#define TIOCMODG        _IOR('t', 3, int)       /* get modem control state */
+#define TIOCMODS        _IOW('t', 4, int)       /* set modem control state */
+#define         TIOCM_LE        0001            /* line enable */
+#define         TIOCM_DTR       0002            /* data terminal ready */
+#define         TIOCM_RTS       0004            /* request to send */
+#define         TIOCM_ST        0010            /* secondary transmit */
+#define         TIOCM_SR        0020            /* secondary receive */
+#define         TIOCM_CTS       0040            /* clear to send */
+#define         TIOCM_CAR       0100            /* carrier detect */
+#define         TIOCM_CD        TIOCM_CAR
+#define         TIOCM_RNG       0200            /* ring */
+#define         TIOCM_RI        TIOCM_RNG
+#define         TIOCM_DSR       0400            /* data set ready */
+                                                /* 8-10 compat */
+#define TIOCEXCL         _IO('t', 13)           /* set exclusive use of tty */
+#define TIOCNXCL         _IO('t', 14)           /* reset exclusive use of tty */
+                                                /* 15 unused */
+#define TIOCFLUSH       _IOW('t', 16, int)      /* flush buffers */
+                                                /* 17-18 compat */
+#define TIOCGETA        _IOR('t', 19, struct termios) /* get termios struct */
+#define TIOCSETA        _IOW('t', 20, struct termios) /* set termios struct */
+#define TIOCSETAW       _IOW('t', 21, struct termios) /* drain output, set */
+#define TIOCSETAF       _IOW('t', 22, struct termios) /* drn out, fls in, set */
+#ifdef KERNEL
+#define TIOCGETA_32     _IOR('t', 19, struct termios32) /* get termios struct */
+#define TIOCSETA_32     _IOW('t', 20, struct termios32) /* set termios struct */
+#define TIOCSETAW_32    _IOW('t', 21, struct termios32) /* drain output, set */
+#define TIOCSETAF_32    _IOW('t', 22, struct termios32) /* drn out, fls in, set */
+#define TIOCGETA_64     _IOR('t', 19, struct user_termios)
+#define TIOCSETA_64     _IOW('t', 20, struct user_termios)
+#define TIOCSETAW_64    _IOW('t', 21, struct user_termios)
+#define TIOCSETAF_64    _IOW('t', 22, struct user_termios)
+#endif  /* KERNEL */
+#define TIOCGETD        _IOR('t', 26, int)      /* get line discipline */
+#define TIOCSETD        _IOW('t', 27, int)      /* set line discipline */
+#define TIOCIXON         _IO('t', 129)          /* internal input VSTART */
+#define TIOCIXOFF        _IO('t', 128)          /* internal input VSTOP */
+                                                /* 127-124 compat */
+#define TIOCSBRK         _IO('t', 123)          /* set break bit */
+#define TIOCCBRK         _IO('t', 122)          /* clear break bit */
+#define TIOCSDTR         _IO('t', 121)          /* set data terminal ready */
+#define TIOCCDTR         _IO('t', 120)          /* clear data terminal ready */
+#define TIOCGPGRP       _IOR('t', 119, int)     /* get pgrp of tty */
+#define TIOCSPGRP       _IOW('t', 118, int)     /* set pgrp of tty */
+                                                /* 117-116 compat */
+#define TIOCOUTQ        _IOR('t', 115, int)     /* output queue size */
+#define TIOCSTI         _IOW('t', 114, char)    /* simulate terminal input */
+#define TIOCNOTTY        _IO('t', 113)          /* void tty association */
+#define TIOCPKT         _IOW('t', 112, int)     /* pty: set/clear packet mode */
+#define         TIOCPKT_DATA            0x00    /* data packet */
+#define         TIOCPKT_FLUSHREAD       0x01    /* flush packet */
+#define         TIOCPKT_FLUSHWRITE      0x02    /* flush packet */
+#define         TIOCPKT_STOP            0x04    /* stop output */
+#define         TIOCPKT_START           0x08    /* start output */
+#define         TIOCPKT_NOSTOP          0x10    /* no more ^S, ^Q */
+#define         TIOCPKT_DOSTOP          0x20    /* now do ^S ^Q */
+#define         TIOCPKT_IOCTL           0x40    /* state change of pty driver */
+#define TIOCSTOP         _IO('t', 111)          /* stop output, like ^S */
+#define TIOCSTART        _IO('t', 110)          /* start output, like ^Q */
+#define TIOCMSET        _IOW('t', 109, int)     /* set all modem bits */
+#define TIOCMBIS        _IOW('t', 108, int)     /* bis modem bits */
+#define TIOCMBIC        _IOW('t', 107, int)     /* bic modem bits */
+#define TIOCMGET        _IOR('t', 106, int)     /* get all modem bits */
+                                                /* 105 unused */
+#define TIOCGWINSZ      _IOR('t', 104, struct winsize)  /* get window size */
+#define TIOCSWINSZ      _IOW('t', 103, struct winsize)  /* set window size */
+#define TIOCUCNTL       _IOW('t', 102, int)     /* pty: set/clr usr cntl mode */
+#define TIOCSTAT         _IO('t', 101)          /* simulate ^T status message */
+#define         UIOCCMD(n)      _IO('u', n)     /* usr cntl op "n" */
+#define TIOCSCONS       _IO('t', 99)            /* 4.2 compatibility */
+#define TIOCCONS        _IOW('t', 98, int)      /* become virtual console */
+#define TIOCSCTTY        _IO('t', 97)           /* become controlling tty */
+#define TIOCEXT         _IOW('t', 96, int)      /* pty: external processing */
+#define TIOCSIG          _IO('t', 95)           /* pty: generate signal */
+#define TIOCDRAIN        _IO('t', 94)           /* wait till output drained */
+#define TIOCMSDTRWAIT   _IOW('t', 91, int)      /* modem: set wait on close */
+#define TIOCMGDTRWAIT   _IOR('t', 90, int)      /* modem: get wait on close */
+#define TIOCTIMESTAMP   _IOR('t', 89, struct timeval)   /* enable/get timestamp
+	                                                 * of last input event */
+#define TIOCDCDTIMESTAMP _IOR('t', 88, struct timeval)  /* enable/get timestamp
+	                                                 * of last DCd rise */
+#ifdef KERNEL
+#define TIOCTIMESTAMP_32        _IOR('t', 89, struct user32_timeval)
+#define TIOCDCDTIMESTAMP_32     _IOR('t', 88, struct user32_timeval)
+#define TIOCTIMESTAMP_64        _IOR('t', 89, struct user64_timeval)
+#define TIOCDCDTIMESTAMP_64     _IOR('t', 88, struct user64_timeval)
+#endif
+#define TIOCSDRAINWAIT  _IOW('t', 87, int)      /* set ttywait timeout */
+#define TIOCGDRAINWAIT  _IOR('t', 86, int)      /* get ttywait timeout */
+#define TIOCDSIMICROCODE _IO('t', 85)           /* download microcode to
+	                                         * DSI Softmodem */
+#define TIOCPTYGRANT    _IO('t', 84)            /* grantpt(3) */
+#define TIOCPTYGNAME    _IOC(IOC_OUT, 't', 83, 128)     /* ptsname(3) */
+#define TIOCPTYUNLK     _IO('t', 82)            /* unlockpt(3) */
+#ifdef KERNEL
+#define TIOCREVOKE       _IO('t', 81)
+#define TIOCREVOKECLEAR  _IO('t', 80)
+#endif
+
+#define TTYDISC         0               /* termios tty line discipline */
+#define TABLDISC        3               /* tablet discipline */
+#define SLIPDISC        4               /* serial IP discipline */
+#define PPPDISC         5               /* PPP discipline */
+
+#endif /* !_SYS_TTYCOM_H_ */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Operator rerun of the PR #15 command on the 16 vCPU x86 EC2 box (main `f5ce1985`) printed `build_stdlib rc=0` while ninja failed:

```
FAILED: stdlib/public/Platform/OSX/x86_64/Darwin.o
.../LibcOverlayShims.h:31:10: error: 'semaphore.h' file not found
.../Platform.swift:14:8: error: could not build Objective-C module 'SwiftOverlayShims'
ninja: error: unknown target 'swiftObjectiveC-macosx-x86_64'
build_stdlib rc=0
```

The same host also printed `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST` even though it **is** the operator x86 host and has the ported loader at `/opt/openuikit/x86-verify/openuikit/machorun`.

Rebased on current `main` (`a395032c`, PR #14 merged after #15).

## What changed

1. **Ninja rc.** Every ninja invocation goes through `ninja_checked` (`PIPESTATUS[0]`, not tee). The core ELF gold wall (`-fuse-ld=gold`) is the only allowed ninja failure. Overlay failures exit non-zero. Test: `scripts/test_ninja_rc.sh`.

2. **Darwin overlay headers.** Overlay ninja uses sysroot `$W/sdk/MacOSX.sdk` (`/root/work/sdk/MacOSX.sdk` on the operator box). Staged Apple's headers from the **same pins as `machorun/sdk/SOURCES.tsv`** (not stand-ins, not into `machorun/sdk/`):

   | dest | from |
   |---|---|
   | `usr/include/semaphore.h` | `apple-oss-distributions/Libc` tag `Libc-1752.120.2` commit `4e34d0559e3a1b081afeb8604d9e204a1f31321d` path `include/semaphore.h` |
   | `usr/include/sys/ioctl.h` | `xnu` tag `xnu-12377.121.6` commit `ac9718fb1af618d5ce8678d0dc6e8a58f252216f` path `bsd/sys/ioctl.h` |
   | `usr/include/sys/ioccom.h` | same xnu pin, `bsd/sys/ioccom.h` |
   | `usr/include/sys/ttycom.h` | same xnu pin, `bsd/sys/ttycom.h` |
   | `usr/include/sys/filio.h` | same xnu pin, `bsd/sys/filio.h` |
   | `usr/include/sys/sockio.h` | same xnu pin, `bsd/sys/sockio.h` |

   `stage_overlay_posix.sh` refuse-overwrites. `semaphore.h` is Apple's POSIX wrapper over the already-staged Darwin `sys/semaphore.h` (`sem_t` is `typedef int`).

3. **Overlay target list.** Names come from `ninja -t targets`. Missing required overlays (`_Concurrency`, `Synchronization`, `_StringProcessing`, `_Builtin_float`) print `CANNOT_OVERLAY_TARGET_ABSENT` and exit 2. `swiftObjectiveC-macosx-*` is not a CMake target on Linux (Apple picks it up from the Xcode SDK); print `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` and **do not invoke ninja** on that name. `-DSWIFT_BUILD_SDK_OVERLAY=OFF` is overwritten by Swift 6.2.4 from `SWIFT_BUILD_DYNAMIC_SDK_OVERLAY` (TRUE on Linux), so `swiftDarwin-macosx-x86_64` **is** in the graph.

4. **Loader probe.** `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST` is printed only after a failed positive probe for an ELF machorun that can run an x86_64 Mach-O on this host (candidates include `/opt/openuikit/x86-verify/openuikit/machorun`). When the loader is present, `hello_swiftcore` is actually run; output + `hello_swiftcore machorun exit=` are printed.

Arm64 `libswiftCore` is untouched (`dd01686e…12708cb`).

## Verification (this 4 vCPU VM)

| check | result |
|---|---|
| `test_ninja_rc.sh` | **PASS** — failing core ninja → rc=1, no `build_stdlib done`; overlay ninja after gold wall → rc=1 |
| `test_overlay_targets.sh` | **PASS** — live `/tmp/overlay-cmake-proof` graph; ObjectiveC is `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS`, not ninja'd; missing `_StringProcessing` → `CANNOT_OVERLAY_TARGET_ABSENT` rc=2 |
| `test_overlay_posix.sh` | **PASS** — 6 Apple headers staged with tag+commit; refuse-overwrite |
| `test_probe_machorun.sh` | **PASS** — in-tree ELF machorun probed; non-loader rejected |
| `test_overlay_siblings.sh` / `test_toolchain.sh` / `test_configure_arch.sh` / `test_staged_slice.sh` | **PASS** — arm64 pin intact |
| `LibcOverlayShims.h` `-fsyntax-only` against staged sysroot | **rc=0** — `semaphore.h` wall closed |
| `ninja Darwin.o` | no `semaphore.h` / no `SwiftOverlayShims`; next wall `underlying Objective-C module 'Darwin' not found` (`@_exported import Darwin`, Xcode Darwin.modulemap) |
| `verify_hello.sh` | compile+link OK; **probed** `/workspace/machorun/build/machorun`; **ran** hello; printed output + `hello_swiftcore machorun exit=73`; **no** `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST`. Exit 73 is `___isPlatformVersionAtLeast` undefined in this VM's darwin tree (operator tree may differ). |

[failing ninja makes build_stdlib exit non-zero](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_ninja_rc.png)
[overlay targets from ninja -t targets](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_overlay_targets.png)
[Apple POSIX headers staged with provenance](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaged_overlay_headers.png)
[machorun loader probe](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_probe_machorun.png)
[hello_swiftcore actually run under machorun](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_hello_machorun.png)
[Darwin.o next wall after semaphore.h](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdarwin_o_next_wall.png)

## Still needs the operator 16 vCPU rerun

Same command as PR #15:

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

This VM did **not** ninja `_Concurrency` / `_StringProcessing` / `Synchronization` dylibs (libdispatch wall + RAM). Darwin.o will now get past `semaphore.h` and fail at the Xcode Darwin clang module (`CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` class) unless that host has module maps we do not. Hello under `/opt/openuikit/x86-verify/openuikit/machorun` with that host's darwin tree is the execution check this VM cannot substitute (`___isPlatformVersionAtLeast` here).

Expect: no `build_stdlib rc=0` after a failed ninja; no `unknown target 'swiftObjectiveC-macosx-x86_64'`; no `CURSOR_ENV_CANNOT_EXECUTE_X86_SWIFT_GUEST` on that host if the loader probe succeeds.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35369cc-b509-457d-83ef-c090127c9afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

