### PR TITLE
Stage the FileManager header set on x86 from one shared list

### DIFF
--- a/full/foundation/fe_sysroot_measurement.inc
+++ b/full/foundation/fe_sysroot_measurement.inc
@@ -1,0 +1,39 @@
+# fe_sysroot_measurement.inc -- shared FE sysroot measurement-header helpers.
+# Sourced by full/foundation/stage_fe_sysroot.sh (Darwin) and the x86 sibling
+# (via scripts/x86/common.inc). The header set lives in
+# fe_sysroot_measurement_headers.txt; do not duplicate that list in a stager.
+
+if [ -n "${FE_SYSROOT_MEASUREMENT_INC:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+FE_SYSROOT_MEASUREMENT_INC=1
+
+_fe_meas_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FE_SYSROOT_MEASUREMENT_HEADERS_FILE=${FE_SYSROOT_MEASUREMENT_HEADERS_FILE:-$_fe_meas_dir/fe_sysroot_measurement_headers.txt}
+unset _fe_meas_dir
+
+# Print one relative usr/include path per line (comments and blanks skipped).
+fe_sysroot_measurement_headers() {
+    local f=${1:-$FE_SYSROOT_MEASUREMENT_HEADERS_FILE}
+    [ -f "$f" ] || {
+        echo "fe_sysroot_measurement_headers: missing $f" >&2
+        return 1
+    }
+    grep -vE '^[[:space:]]*(#|$)' "$f"
+}
+
+# Append the measurement-only vm_copy declaration. Do not replace mach/vm_map.h.
+fe_sysroot_append_vm_copy() {
+    local vm_h=$1
+    [ -f "$vm_h" ] || return 0
+    if grep -q 'vm_copy' "$vm_h"; then
+        return 0
+    fi
+    cat >> "$vm_h" <<'EOF'
+/* APPENDED by fe_sysroot_append_vm_copy -- MEASUREMENT ONLY.
+   Not in machorun's sdk/; see full/foundation/stage_fe_sysroot.sh. */
+extern kern_return_t vm_copy(vm_map_t target_task, vm_address_t source_address,
+                             vm_size_t size, vm_address_t dest_address);
+EOF
+    echo "  ~ mach/vm_map.h  [appended vm_copy decl -- MEASUREMENT ONLY]"
+}

--- a/full/foundation/fe_sysroot_measurement_headers.txt
+++ b/full/foundation/fe_sysroot_measurement_headers.txt
@@ -1,0 +1,15 @@
+# Headers staged for FoundationEssentials measurement (stage_absent).
+# Both stagers read this file; do not duplicate the list in either script.
+# complex.h comes from full/sdk-gaps. The rest come from the Darwin SDK
+# (arm64 stager) or from scratch/sysroot_fe4 (x86 stager).
+# vm_copy is not a file copy: both stagers call fe_sysroot_append_vm_copy.
+complex.h
+sysdir.h
+sys/xattr.h
+copyfile.h
+removefile.h
+fts.h
+pwd.h
+grp.h
+sys/utsname.h
+sys/quota.h

--- a/full/foundation/stage_fe_sysroot.sh
+++ b/full/foundation/stage_fe_sysroot.sh
@@ -25,6 +25,8 @@
 set -euo pipefail
 [ "$(uname -s)" = "Darwin" ] || { echo "macOS only (reads Xcode + machorun)" >&2; exit 1; }
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=fe_sysroot_measurement.inc
+. "$ROOT/full/foundation/fe_sysroot_measurement.inc"
 MACHORUN=${MACHORUN:-$HOME/machorun}
 SDK=$(xcrun --show-sdk-path --sdk macosx)
 SYS=${SYS:-$ROOT/scratch/sysroot_fe4}
@@ -59,37 +61,40 @@ rm -rf "$SYS/usr/lib/swift/os.swiftmodule"
 # what lets the port be measured at all; it is not a fix, and each one belongs
 # on full/sdk-gaps/README.md's list.
 echo "== gaps staged for measurement (each is a real machorun sdk/ gap):"
-stage_absent complex.h "$ROOT/full/sdk-gaps/usr/include" "clean-room stub; clang's own tgmath.h includes it unconditionally"
-stage_absent sysdir.h  "$SDK/usr/include" "79 lines; libSystem ALREADY exports _sysdir_start/_get_next_search_path_enumeration -- the implementation is there and only the declaration is missing"
-
-# THE FILEMANAGER SET.  108 of the errors in the first correctly-configured
-# whole-module run were ONE class -- eight absent headers -- confined to nine
-# files (FileOperations, Platform, FileManager+*, ProcessInfo, Data+Reading/
-# Writing).  Unlike sysdir.h these are NOT declaration-only gaps: libSystem
-# exports none of copyfile/fcopyfile, removefile*, fts_*, {get,set,list,fget,
-# fset}xattr, getgrnam_r/getgrgid_r, uname or quotactl.  (It DOES export
-# getpwnam_r and getpwuid_r, so pwd.h alone is declaration-only.)  Staging them
-# lets the rest of the module be measured; it does not make FileManager work,
-# and a build using them will fail at the LINK with those symbols undefined.
-for h in sys/xattr.h copyfile.h removefile.h fts.h pwd.h grp.h sys/utsname.h sys/quota.h; do
-    stage_absent "$h" "$SDK/usr/include" "FileManager set -- header AND libSystem implementation both absent (pwd.h: header only)"
-done
+# THE FILEMANAGER SET (plus complex.h / sysdir.h). Shared list:
+# full/foundation/fe_sysroot_measurement_headers.txt. 108 of the errors in the
+# first correctly-configured whole-module run were ONE class -- eight absent
+# headers -- confined to nine files (FileOperations, Platform, FileManager+*,
+# ProcessInfo, Data+Reading/Writing). Unlike sysdir.h these are NOT
+# declaration-only gaps: libSystem exports none of copyfile/fcopyfile,
+# removefile*, fts_*, {get,set,list,fget,fset}xattr, getgrnam_r/getgrgid_r,
+# uname or quotactl. (It DOES export getpwnam_r and getpwuid_r, so pwd.h alone
+# is declaration-only.) Staging them lets the rest of the module be measured;
+# it does not make FileManager work, and a build using them will fail at the
+# LINK with those symbols undefined.
+while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    case "$h" in
+        complex.h)
+            stage_absent "$h" "$ROOT/full/sdk-gaps/usr/include" \
+                "clean-room stub; clang's own tgmath.h includes it unconditionally"
+            ;;
+        sysdir.h)
+            stage_absent "$h" "$SDK/usr/include" \
+                "79 lines; libSystem ALREADY exports _sysdir_start/_get_next_search_path_enumeration -- the implementation is there and only the declaration is missing"
+            ;;
+        *)
+            stage_absent "$h" "$SDK/usr/include" \
+                "FileManager set -- header AND libSystem implementation both absent (pwd.h: header only)"
+            ;;
+    esac
+done < <(fe_sysroot_measurement_headers)
 
 # vm_copy: machorun's mach/vm_map.h declares vm_allocate/deallocate/protect/
-# remap and NOT vm_copy, and libSystem exports none either.  Appended rather
-# than shadowed -- replacing the whole header with Apple's would silently swap
-# a clean-room file for an Xcode one.  Platform.swift:63 has a `memmove`
-# fallback for exactly this call, so the cheapest real fix in machorun is a
-# vm_copy that reports failure, or one that memmoves.
-if ! grep -q 'vm_copy' "$SYS/usr/include/mach/vm_map.h"; then
-    cat >> "$SYS/usr/include/mach/vm_map.h" <<'EOF'
-/* APPENDED by full/foundation/stage_fe_sysroot.sh -- MEASUREMENT ONLY.
-   Not in machorun's sdk/ and not exported by libSystem; see that script. */
-extern kern_return_t vm_copy(vm_map_t target_task, vm_address_t source_address,
-                             vm_size_t size, vm_address_t dest_address);
-EOF
-    echo "  ~ mach/vm_map.h  [appended vm_copy decl -- MEASUREMENT ONLY, no implementation exists]"
-fi
+# remap and NOT vm_copy. Appended rather than shadowed -- replacing the whole
+# header with Apple's would silently swap a clean-room file for an Xcode one.
+# Platform.swift:63 has a `memmove` fallback for exactly this call.
+fe_sysroot_append_vm_copy "$SYS/usr/include/mach/vm_map.h"
 
 # ---- the ObjectiveC Clang module (must precede the generator) ---------------
 for h in NSObject.h NSObjCRuntime.h Protocol.h; do cp "$OBJC4/$h" "$SYS/usr/include/objc/$h"; done

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -95,16 +95,40 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    that names the generator; enumerate from the arm64 sysroot, do not hard-code
    the 44 shim names). After restage, every `header "…"` path in every staged
    modulemap must resolve; otherwise `CANNOT_DARWIN_MODULEMAP_HEADERS` with
-   `missing=`. Apple's Darwin overlay is textual `.swiftinterface` (no prebuilt
+   `missing=`. The FileManager/sdk-gap measurement set (`complex.h`, `sysdir.h`,
+   `sys/xattr.h`, `copyfile.h`, `removefile.h`, `fts.h`, `pwd.h`, `grp.h`,
+   `sys/utsname.h`, `sys/quota.h`) is a **shared list** in
+   `full/foundation/fe_sysroot_measurement_headers.txt` — both stagers read it;
+   neither duplicates the literal. x86 `stage_absent`s missing members from
+   arm64 `scratch/sysroot_fe4` (same rule as `_modules`). `vm_copy` is appended
+   to `mach/vm_map.h` by the shared helper, not copied as a file. After restage
+   every path in that list must exist in the x86 sysroot; otherwise
+   `CANNOT_FE_MEASUREMENT_HEADERS` with `missing=` (the operator's 14 FE errors
+   were all `removefile.h`). Apple's Darwin overlay is textual `.swiftinterface` (no prebuilt
    `.swiftmodule` on the arm64 sysroot). Arm64 compiles that interface with
    Swift 6.2.4; the 6.2.1-vs-6.2.4 "SDK is not supported" line is the fallback
    when Clang Darwin fails (missing maps or missing `_modules` headers), not a
    flag. x86 takes the same compile-the-interface path. Idempotency keys on
-   input shas (artifact, generator, overlay text) written to `.phase2-stage-inputs`
-   (recipe `stage_fe_sysroot_x86.2`); a sysroot staged before those inputs
+   input shas (artifact, generator, overlay text, **measurement-header list**)
+   written to `.phase2-stage-inputs`
+   (recipe `stage_fe_sysroot_x86.3`); a sysroot staged before those inputs
    existed is restaged, and the CANNOT/cold-built line names which input
    changed. Apple's `os.swiftmodule` is not copied (FE uses
    `full/foundation/os-module`).
+   `build_fe.sh` is Swift-only on both arches. Arm64 compiles
+   `full/foundation/removefile_compat.c` in `full/scripts/build_full.sh` and
+   links `removefile_compat.o` with `FoundationEssentials.o`. The x86 runner
+   compiles that same `.c` (same clang argv) into
+   `build/full-x86_64/foundation/essentials/removefile_compat.o` after a
+   successful `build_fe.sh`. Darwin userland already `EXPORT`s
+   `copyfile`/`fcopyfile`, `fts_*`, xattr, `getgrnam_r`, `uname`, `quotactl`
+   (and stub `removefile*`; the `.o` wins at link). Next operator **link** of
+   FE is still expected to miss, unless `fm_unimplemented.o` / `uuid_compat.o`
+   are also in the link (arm64 `build_full.sh` compiles both; phase2 does not):
+   `chflags`, `confstr`, `fchmod`, `getattrlist`, `link`, `mktemp`,
+   `sysctlbyname`, `utimes`, `uuid_generate_random`, `uuid_parse`,
+   `uuid_unparse_upper`. `vm_copy` is in machorun `darwin/src/mach.c` (should
+   resolve from x86 libSystem). Confirm or refute that list on the next rerun.
 2. OpenCombine: `scripts/x86/build_opencombine.sh` writes `export-x86_64/`.
    Source hashes from `policy.json` still apply. Object SHAs stay the arm64
    durable pin in `export/`. Focus/core-package scripts hash those objects

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -11,6 +11,11 @@ if [ -n "${PHASE2_COMMON_INC:-}" ]; then
 fi
 PHASE2_COMMON_INC=1
 
+_phase2_tree=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+# shellcheck source=../../full/foundation/fe_sysroot_measurement.inc
+. "$_phase2_tree/full/foundation/fe_sysroot_measurement.inc"
+unset _phase2_tree
+
 phase2_prepare() {
     printf 'ENV_PREPARE %s %s\n' "$1" "$2"
 }
@@ -106,7 +111,7 @@ phase2_probe_focus_pin() {
 # output directory existing. A sysroot staged before x86 libswiftCore landed
 # would otherwise be reused while OpenCombine looks in usr/lib/swift and finds
 # nothing. Recipe bump forces a restage when the stager itself gains steps.
-PHASE2_SYSROOT_RECIPE=stage_fe_sysroot_x86.2
+PHASE2_SYSROOT_RECIPE=stage_fe_sysroot_x86.3
 PHASE2_SYSROOT_STAMP=.phase2-stage-inputs
 
 phase2_sha_or_absent() {
@@ -137,6 +142,7 @@ phase2_arm_overlay_interface() {
 
 # phase2_sysroot_input_lines <libswiftCore> <Swift.swiftmodule> <_Builtin_float.swiftmodule>
 #                          <gen_darwin_modulemap.py> <Darwin.swiftinterface> <Darwin.modulemap>
+#                          [fe_sysroot_measurement_headers.txt]
 phase2_sysroot_input_lines() {
     printf 'recipe=%s\n' "$PHASE2_SYSROOT_RECIPE"
     printf 'libswiftCore=%s\n' "$(phase2_sha_or_absent "$1")"
@@ -145,6 +151,8 @@ phase2_sysroot_input_lines() {
     printf 'gen_darwin_modulemap.py=%s\n' "$(phase2_sha_or_absent "$4")"
     printf 'Darwin.swiftinterface=%s\n' "$(phase2_sha_or_absent "$5")"
     printf 'Darwin.modulemap=%s\n' "$(phase2_sha_or_absent "$6")"
+    printf 'fe_sysroot_measurement_headers=%s\n' \
+        "$(phase2_sha_or_absent "${7:-$FE_SYSROOT_MEASUREMENT_HEADERS_FILE}")"
 }
 
 phase2_write_sysroot_stamp() {
@@ -199,7 +207,10 @@ phase2_sysroot_complete() {
             || return 1
     fi
     # Maps that name a header which is not on disk are not a working Clang Darwin.
-    phase2_darwin_modulemap_headers_ok "$sys"
+    phase2_darwin_modulemap_headers_ok "$sys" || return 1
+    # FileManager/sdk-gap measurement set (shared list). Missing removefile.h
+    # is the class that failed FE with 14 errors after recipe x86.2.
+    phase2_measurement_headers_ok "$sys"
 }
 
 # Print one `header "…"` path per line. Skip `exclude header`.
@@ -237,6 +248,61 @@ phase2_darwin_modulemap_missing_headers() {
 
 phase2_darwin_modulemap_headers_ok() {
     phase2_darwin_modulemap_missing_headers "$1" >/dev/null
+}
+
+# Comma-separated paths from the shared measurement-header list that are not
+# under $sys/usr/include. Return 1 if any are missing (so a restage that
+# skipped the FileManager set cannot look satisfied).
+phase2_measurement_headers_missing() {
+    local sys=$1 inc=$1/usr/include
+    local h miss=""
+    while IFS= read -r h; do
+        [ -n "$h" ] || continue
+        [ -f "$inc/$h" ] && continue
+        case ",$miss," in
+            *",$h,"*) ;;
+            *) miss="${miss:+$miss,}$h" ;;
+        esac
+    done < <(fe_sysroot_measurement_headers)
+    if [ -n "$miss" ]; then
+        printf '%s\n' "$miss"
+        return 1
+    fi
+    return 0
+}
+
+phase2_measurement_headers_ok() {
+    phase2_measurement_headers_missing "$1" >/dev/null
+}
+
+# stage_absent semantics from arm64 sysroot_fe4: skip if already present
+# (would shadow machorun/sdk or sdk-gaps); copy if the arm64 tree has it.
+phase2_stage_measurement_headers_from_arm() {
+    local sys=$1 arm=$2
+    local h dest
+    while IFS= read -r h; do
+        [ -n "$h" ] || continue
+        dest="$sys/usr/include/$h"
+        if [ -e "$dest" ]; then
+            echo "  REFUSED (already present, would shadow): $h" >&2
+            continue
+        fi
+        [ -f "$arm/usr/include/$h" ] || continue
+        mkdir -p "$(dirname "$dest")"
+        cp "$arm/usr/include/$h" "$dest"
+        echo "  + $h   [measurement set from arm64 sysroot_fe4]"
+    done < <(fe_sysroot_measurement_headers)
+}
+
+# Same clang argv as full/scripts/build_full.sh. build_fe.sh is Swift-only
+# on both arches; arm64 compiles this .c in the full link step, not there.
+phase2_compile_removefile_compat() {
+    local sys=$1 dest=$2 target=$3 src_tree=$4
+    mkdir -p "$(dirname "$dest")"
+    clang-18 -target "$target" -isysroot "$sys" -std=c11 -O2 \
+        -Wall -Wextra -Werror -I "$src_tree/full/foundation" \
+        -c "$src_tree/full/foundation/removefile_compat.c" \
+        -o "$dest"
 }
 
 # Enumerate files the arm64 generator run wrote: Darwin-family maps,

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -324,7 +324,8 @@ sysroot_input_changed() {
     local diff
     diff=$(phase2_sysroot_stamp_diff "$stamp" \
         "$x86_core" "$x86_mod" "$x86_bf" "$gen_py" \
-        "${overlay_if:-}" "$arm_dmap" || true)
+        "${overlay_if:-}" "$arm_dmap" \
+        "$FE_SYSROOT_MEASUREMENT_HEADERS_FILE" || true)
     if [ -n "$diff" ]; then
         printf '%s\n' "$diff"
         return 0
@@ -341,7 +342,7 @@ run_sysroot_stager() {
     if [ "$st" -eq 0 ] && [ -d "$SYS/usr/include" ]; then
         SYSROOT_HEADERS=1
         if phase2_sysroot_complete "$SYS" "$need_core" "$need_bf"; then
-            note sysroot-fe4-x86 cold-built "darwin_headers=ok"
+            note sysroot-fe4-x86 cold-built "darwin_headers=ok measurement_headers=ok"
             SYSROOT_OK=1
         elif [ ! -d "$SYS/usr/lib/swift/Darwin.swiftmodule" ] \
             && [ ! -f "$SYS/usr/lib/swift/Darwin.swiftinterface" ]; then
@@ -353,6 +354,9 @@ run_sysroot_stager() {
         elif ! phase2_darwin_modulemap_headers_ok "$SYS"; then
             cannot sysroot-fe4-x86 DARWIN_MODULEMAP_HEADERS \
                 "Darwin.modulemap present but header paths named by staged modulemaps are absent: missing=$(phase2_darwin_modulemap_missing_headers "$SYS" || true). The Linux fallback must copy generator outputs from the arm64 sysroot including usr/include/_modules, not maps alone."
+        elif ! phase2_measurement_headers_ok "$SYS"; then
+            cannot sysroot-fe4-x86 FE_MEASUREMENT_HEADERS \
+                "FileManager/sdk-gap measurement headers absent after restage: missing=$(phase2_measurement_headers_missing "$SYS" || true). x86 stages this set from arm64 sysroot_fe4 with stage_absent (shared list full/foundation/fe_sysroot_measurement_headers.txt)."
         elif [ "$need_core" -eq 1 ] && { [ ! -f "$SYS/usr/lib/swift/libswiftCore.dylib" ] || ! phase2_is_x86_macho "$SYS/usr/lib/swift/libswiftCore.dylib"; }; then
             cannot sysroot-fe4-x86 STAGE_LIBSWIFTCORE \
                 "x86 libswiftCore is in artifacts but was not staged into $SYS/usr/lib/swift"
@@ -375,14 +379,14 @@ run_sysroot_stager() {
 
 changed=$(sysroot_input_changed || true)
 if [ -z "$changed" ] && phase2_sysroot_complete "$SYS" "$need_core" "$need_bf"; then
-    note sysroot-fe4-x86 satisfied "darwin_headers=ok"
+    note sysroot-fe4-x86 satisfied "darwin_headers=ok measurement_headers=ok"
     SYSROOT_OK=1
     SYSROOT_HEADERS=1
 elif [ -n "$changed" ]; then
     echo "  re-stage sysroot-fe4-x86 (input changed: $(echo "$changed" | tr '\n' ' '))"
     run_sysroot_stager
 elif phase2_sysroot_complete "$SYS" "$need_core" "$need_bf"; then
-    note sysroot-fe4-x86 satisfied "darwin_headers=ok"
+    note sysroot-fe4-x86 satisfied "darwin_headers=ok measurement_headers=ok"
     SYSROOT_OK=1
     SYSROOT_HEADERS=1
 else
@@ -403,6 +407,9 @@ else
     elif [ -f "$SYS/usr/include/Darwin.modulemap" ] \
         && ! phase2_darwin_modulemap_headers_ok "$SYS"; then
         echo "  re-stage sysroot-fe4-x86 (Darwin modulemap headers missing: $(phase2_darwin_modulemap_missing_headers "$SYS" || true))"
+        run_sysroot_stager
+    elif ! phase2_measurement_headers_ok "$SYS"; then
+        echo "  re-stage sysroot-fe4-x86 (measurement headers missing: $(phase2_measurement_headers_missing "$SYS" || true))"
         run_sysroot_stager
     elif [ "$need_core" -eq 1 ] && { [ ! -f "$SYS/usr/lib/swift/libswiftCore.dylib" ] || ! phase2_is_x86_macho "$SYS/usr/lib/swift/libswiftCore.dylib"; }; then
         echo "  re-stage sysroot-fe4-x86 (libswiftCore artifact present, not in sysroot; stamp should have caught this)"
@@ -534,11 +541,46 @@ try_fe_imports() {
 
 try_fe() {
     local out=$FE_OUT/essentials
+    local have_fe=0 have_compat=0
     if [ -f "$out/FoundationEssentials.o" ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
+        have_fe=1
+    fi
+    if [ -f "$out/removefile_compat.o" ] && phase2_is_x86_macho "$out/removefile_compat.o"; then
+        have_compat=1
+    fi
+    if [ "$have_fe" -eq 1 ] && [ "$have_compat" -eq 1 ]; then
         note foundationessentials-x86 satisfied "mc=$MC"
         FE_OK=1
         return 0
     fi
+
+    compile_fe_removefile_compat() {
+        local cst
+        mkdir -p "$out"
+        set +e
+        phase2_compile_removefile_compat "$SYS" "$out/removefile_compat.o" "$TARGET" "$W"
+        cst=$?
+        set -e
+        if [ "$cst" -eq 0 ] && [ -f "$out/removefile_compat.o" ] \
+            && phase2_is_x86_macho "$out/removefile_compat.o"; then
+            return 0
+        fi
+        cannot foundationessentials-x86 BUILD_FE_REMOVEFILE_COMPAT \
+            "removefile_compat.c clang exit $cst (build_fe.sh is Swift-only on both arches; arm64 compiles this in build_full.sh). out=$out"
+        return 1
+    }
+
+    if [ "$have_fe" -eq 1 ]; then
+        [ "$SYSROOT_HEADERS" -eq 1 ] || [ "$SYSROOT_OK" -eq 1 ] || {
+            cannot foundationessentials-x86 NEEDS_X86_SYSROOT "removefile_compat.c needs $SYS"
+            return 1
+        }
+        compile_fe_removefile_compat || return 1
+        note foundationessentials-x86 cold-built "mc=$MC removefile_compat=ok"
+        FE_OK=1
+        return 0
+    fi
+
     [ -d "$SF" ] || { cannot foundationessentials-x86 PINNED_SWIFT_FOUNDATION "no $SF"; return 1; }
     [ "$SYSROOT_OK" -eq 1 ] || { cannot foundationessentials-x86 NEEDS_X86_SYSROOT "FE compile needs $SYS"; return 1; }
     [ "$LIBSWIFTCORE_X86" -eq 1 ] || {
@@ -565,7 +607,8 @@ try_fe() {
     st=$?
     set -e
     if [ "$st" -eq 0 ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
-        note foundationessentials-x86 cold-built "mc=$MC"
+        compile_fe_removefile_compat || return 1
+        note foundationessentials-x86 cold-built "mc=$MC removefile_compat=ok"
         FE_OK=1
         return 0
     fi

--- a/scripts/x86/stage_fe_sysroot.sh
+++ b/scripts/x86/stage_fe_sysroot.sh
@@ -135,13 +135,9 @@ if [ -d "$gaps" ]; then
     done < <(find "$gaps" -type f -print0)
 fi
 
-if ! grep -q 'vm_copy' "$SYS/usr/include/mach/vm_map.h" 2>/dev/null; then
-    cat >> "$SYS/usr/include/mach/vm_map.h" <<'EOF'
-/* APPENDED by scripts/x86/stage_fe_sysroot.sh -- MEASUREMENT ONLY. */
-extern kern_return_t vm_copy(vm_map_t target_task, vm_address_t source_address,
-                             vm_size_t size, vm_address_t dest_address);
-EOF
-fi
+echo "== measurement headers (shared list; stage_absent from arm64 sysroot_fe4)"
+phase2_stage_measurement_headers_from_arm "$SYS" "$ARM_SYS"
+fe_sysroot_append_vm_copy "$SYS/usr/include/mach/vm_map.h"
 
 if [ -f "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" ]; then
     cp "$ARM_SYS/usr/include/_DarwinFoundation2.apinotes" \
@@ -220,7 +216,8 @@ phase2_write_sysroot_stamp "$SYS/$PHASE2_SYSROOT_STAMP" \
     "$x86_core" "$x86_mod" "$x86_bf_mod" \
     "$MACHORUN/scripts/gen_darwin_modulemap.py" \
     "${overlay_if:-}" \
-    "$ARM_SYS/usr/include/Darwin.modulemap"
+    "$ARM_SYS/usr/include/Darwin.modulemap" \
+    "$FE_SYSROOT_MEASUREMENT_HEADERS_FILE"
 echo "  wrote $SYS/$PHASE2_SYSROOT_STAMP (input-keyed; restage when these shas change)"
 
 echo "== $SYS"
@@ -244,6 +241,12 @@ if [ -f "$SYS/usr/include/Darwin.modulemap" ]; then
     fi
 else
     echo "  Darwin.modulemap: ABSENT (underlying Objective-C module Darwin will not be found)"
+fi
+meas_miss=$(phase2_measurement_headers_missing "$SYS" || true)
+if [ -n "$meas_miss" ]; then
+    echo "  measurement headers missing: $meas_miss"
+else
+    echo "  measurement headers: all present"
 fi
 if [ -f "$SYS/usr/lib/swift/libswiftCore.dylib" ]; then
     echo "  libswiftCore: $(phase2_macho_cpu "$SYS/usr/lib/swift/libswiftCore.dylib") at usr/lib/swift/libswiftCore.dylib"

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -57,7 +57,8 @@ expect_file "$OC"
 expect_file "$GUEST"
 
 echo "== bash -n"
-for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh"; do
+for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
+    "$ROOT/full/foundation/fe_sysroot_measurement.inc"; do
     if bash -n "$s"; then
         ok "bash -n $(basename "$s")"
     else
@@ -247,10 +248,48 @@ expect_grep 'DARWIN_CLANG_MODULEMAP' "$PHASE2" \
     "missing Darwin.modulemap is its own CANNOT, not folded into overlays"
 expect_grep 'DARWIN_MODULEMAP_HEADERS' "$PHASE2" \
     "missing modulemap header files are CANNOT_DARWIN_MODULEMAP_HEADERS"
-expect_grep 'stage_fe_sysroot_x86.2' "$COMMON" \
-    "recipe bump restages a maps-only sysroot from x86.1"
+expect_grep 'stage_fe_sysroot_x86.3' "$COMMON" \
+    "recipe bump restages a sysroot that lacked the FileManager header set"
+expect_grep 'fe_sysroot_measurement_headers=' "$COMMON" \
+    "stamp records the shared measurement-header list sha"
+expect_grep 'phase2_measurement_headers_missing' "$COMMON" \
+    "every header in the FileManager/sdk-gap list is checked after restage"
+expect_grep 'FE_MEASUREMENT_HEADERS' "$PHASE2" \
+    "missing measurement headers are CANNOT_FE_MEASUREMENT_HEADERS"
+expect_grep 'phase2_stage_measurement_headers_from_arm' "$STAGE" \
+    "x86 stager stages the shared list from arm64 sysroot_fe4"
+expect_grep 'fe_sysroot_append_vm_copy' "$STAGE" \
+    "x86 stager uses the shared vm_copy append"
+expect_grep 'fe_sysroot_measurement.inc' "$ROOT/full/foundation/stage_fe_sysroot.sh" \
+    "arm64 stager reads the shared measurement inc"
+expect_grep 'fe_sysroot_measurement_headers' "$ROOT/full/foundation/stage_fe_sysroot.sh" \
+    "arm64 stager iterates the shared header list"
+expect_not_grep 'for h in sys/xattr.h copyfile.h removefile.h fts.h pwd.h grp.h sys/utsname.h sys/quota.h' \
+    "$ROOT/full/foundation/stage_fe_sysroot.sh" \
+    "arm64 stager does not duplicate the FileManager header literal"
+expect_not_grep 'for h in sys/xattr.h copyfile.h removefile.h fts.h pwd.h grp.h sys/utsname.h sys/quota.h' \
+    "$STAGE" \
+    "x86 stager does not duplicate the FileManager header literal"
+expect_file "$ROOT/full/foundation/fe_sysroot_measurement_headers.txt"
+expect_file "$ROOT/full/foundation/fe_sysroot_measurement.inc"
+expect_grep 'removefile.h' "$ROOT/full/foundation/fe_sysroot_measurement_headers.txt" \
+    "shared list includes removefile.h"
+expect_grep 'complex.h' "$ROOT/full/foundation/fe_sysroot_measurement_headers.txt" \
+    "shared list includes complex.h"
+expect_grep 'sysdir.h' "$ROOT/full/foundation/fe_sysroot_measurement_headers.txt" \
+    "shared list includes sysdir.h"
+expect_grep 'BUILD_FE_REMOVEFILE_COMPAT' "$PHASE2" \
+    "x86 FE chain compiles removefile_compat.c (build_fe.sh is Swift-only)"
+expect_grep 'phase2_compile_removefile_compat' "$PHASE2" \
+    "phase2 invokes the shared removefile_compat clang helper"
+expect_not_grep 'removefile_compat.c' "$ROOT/full/foundation/build_fe.sh" \
+    "build_fe.sh does not compile removefile_compat.c (Swift-only on both arches)"
+expect_grep 'removefile_compat.c' "$BUILD_FULL" \
+    "arm64 full link compiles removefile_compat.c"
 expect_grep 'usr/include/_modules' "$COMMON" \
     "Linux Darwin fallback copies _modules from the arm64 sysroot"
+
+echo "== measurement headers: shared list, stage_absent from arm64, stamp recipe .3"
 expect_grep 'phase2_darwin_modulemap_missing_headers' "$COMMON" \
     "every header path named by staged modulemaps is checked"
 expect_grep 'compiles Darwin.swiftinterface' "$COMMON" \
@@ -275,12 +314,16 @@ echo f > "$STAMPWORK/bf"
 echo g > "$STAMPWORK/gen"
 echo o > "$STAMPWORK/overlay"
 echo d > "$STAMPWORK/dmap"
+echo list-a > "$STAMPWORK/meas-a"
+echo list-b > "$STAMPWORK/meas-b"
 phase2_write_sysroot_stamp "$STAMPWORK/stamp" \
     "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
-    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap"
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" \
+    "$STAMPWORK/meas-a"
 match=$(phase2_sysroot_stamp_diff "$STAMPWORK/stamp" \
     "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
-    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" && echo MATCH || echo FAIL)
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" \
+    "$STAMPWORK/meas-a" && echo MATCH || echo FAIL)
 if [ "$match" = MATCH ]; then
     ok "stamp matches when inputs are unchanged"
 else
@@ -288,17 +331,29 @@ else
 fi
 diff=$(phase2_sysroot_stamp_diff "$STAMPWORK/stamp" \
     "$STAMPWORK/core-b" "$STAMPWORK/mod" "$STAMPWORK/bf" \
-    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" || true)
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" \
+    "$STAMPWORK/meas-a" || true)
 case "$diff" in
     *"libswiftCore "*) ok "stamp names libswiftCore when the artifact sha changes ($diff)" ;;
     *) die_test "expected libswiftCore old->new, got: $diff" ;;
 esac
 missing_stamp=$(phase2_sysroot_stamp_diff "$STAMPWORK/absent" \
     "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
-    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" || true)
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" \
+    "$STAMPWORK/meas-a" || true)
 case "$missing_stamp" in
     stamp=ABSENT) ok "missing stamp is stamp=ABSENT (restage, do not reuse)" ;;
     *) die_test "missing stamp expected stamp=ABSENT, got: $missing_stamp" ;;
+esac
+meas_diff=$(phase2_sysroot_stamp_diff "$STAMPWORK/stamp" \
+    "$STAMPWORK/core-a" "$STAMPWORK/mod" "$STAMPWORK/bf" \
+    "$STAMPWORK/gen" "$STAMPWORK/overlay" "$STAMPWORK/dmap" \
+    "$STAMPWORK/meas-b" || true)
+case "$meas_diff" in
+    *"fe_sysroot_measurement_headers "*)
+        ok "stamp names fe_sysroot_measurement_headers when the shared list sha changes ($meas_diff)"
+        ;;
+    *) die_test "expected fe_sysroot_measurement_headers old->new, got: $meas_diff" ;;
 esac
 rm -rf "$STAMPWORK"
 
@@ -364,6 +419,88 @@ else
     die_test "expected no missing headers after copy, got: $after"
 fi
 rm -rf "$MMWORK"
+
+echo "== FileManager measurement headers: fail before copy, pass after arm64 stage_absent"
+n_hdr=$(fe_sysroot_measurement_headers | wc -l | tr -d ' ')
+if [ "$n_hdr" = 10 ]; then
+    ok "shared measurement list has 10 headers"
+else
+    die_test "shared measurement list count is $n_hdr, not 10"
+fi
+MHWORK=$(mktemp -d /tmp/phase2-meas-hdr.XXXXXX)
+mkdir -p "$MHWORK/arm/usr/include/sys" "$MHWORK/sys/usr/include/sys" \
+    "$MHWORK/sys/usr/include/mach"
+# Arm64 fixture has the full shared list (what PR #17's sysroot_fe4 carries).
+while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    mkdir -p "$MHWORK/arm/usr/include/$(dirname "$h")"
+    printf '/* ARM %s */\n' "$h" > "$MHWORK/arm/usr/include/$h"
+done < <(fe_sysroot_measurement_headers)
+# x86 restage without removefile.h (the operator failure class).
+while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    [ "$h" = removefile.h ] && continue
+    mkdir -p "$MHWORK/sys/usr/include/$(dirname "$h")"
+    printf '/* X86 %s */\n' "$h" > "$MHWORK/sys/usr/include/$h"
+done < <(fe_sysroot_measurement_headers)
+before_mh=$(phase2_measurement_headers_missing "$MHWORK/sys" || true)
+if [ "$before_mh" = removefile.h ]; then
+    ok "restage without removefile.h fails header-resolve before the compiler ($before_mh)"
+else
+    die_test "expected missing=removefile.h, got: $before_mh"
+fi
+# stage_absent: already-present copyfile.h must not be shadowed.
+printf '/* X86 copyfile.h must survive */\n' > "$MHWORK/sys/usr/include/copyfile.h"
+printf '/* ARM copyfile.h would shadow */\n' > "$MHWORK/arm/usr/include/copyfile.h"
+phase2_stage_measurement_headers_from_arm "$MHWORK/sys" "$MHWORK/arm"
+if [ -f "$MHWORK/sys/usr/include/removefile.h" ] \
+    && grep -q 'ARM removefile.h' "$MHWORK/sys/usr/include/removefile.h" \
+    && grep -q 'X86 copyfile.h must survive' "$MHWORK/sys/usr/include/copyfile.h"; then
+    ok "stage_absent copies missing removefile.h from arm64 and refuses to shadow copyfile.h"
+else
+    die_test "stage_absent did not copy removefile.h / preserve copyfile.h"
+fi
+after_mh=$(phase2_measurement_headers_missing "$MHWORK/sys" && echo NONE || true)
+if [ "$after_mh" = NONE ]; then
+    ok "after restage every header in the shared measurement list exists in the x86 sysroot"
+else
+    die_test "expected no missing measurement headers after copy, got: $after_mh"
+fi
+# vm_copy append (shared helper; not a file copy).
+printf '/* empty vm_map.h */\n' > "$MHWORK/sys/usr/include/mach/vm_map.h"
+fe_sysroot_append_vm_copy "$MHWORK/sys/usr/include/mach/vm_map.h"
+if grep -q 'extern kern_return_t vm_copy' "$MHWORK/sys/usr/include/mach/vm_map.h"; then
+    ok "shared helper appends vm_copy to mach/vm_map.h"
+else
+    die_test "vm_copy was not appended"
+fi
+fe_sysroot_append_vm_copy "$MHWORK/sys/usr/include/mach/vm_map.h"
+vm_n=$(grep -c 'extern kern_return_t vm_copy' "$MHWORK/sys/usr/include/mach/vm_map.h" || true)
+if [ "$vm_n" = 1 ]; then
+    ok "vm_copy append is idempotent"
+else
+    die_test "vm_copy appended twice (count=$vm_n)"
+fi
+rm -rf "$MHWORK"
+
+# Compile removefile_compat.c the way try_fe will (same clang line as build_full.sh).
+if command -v clang-18 >/dev/null && [ -d "$ROOT/scratch/sysroot_fe4-x86_64/usr/include" ]; then
+    COMPAT_OUT=$(mktemp -d /tmp/phase2-removefile-compat.XXXXXX)
+    if phase2_compile_removefile_compat \
+        "$ROOT/scratch/sysroot_fe4-x86_64" \
+        "$COMPAT_OUT/removefile_compat.o" \
+        x86_64-apple-macos15.0 \
+        "$ROOT" \
+        && phase2_is_x86_macho "$COMPAT_OUT/removefile_compat.o"; then
+        ok "removefile_compat.c compiles to X86_64 Mach-O against the x86 sysroot"
+        rm -rf "$COMPAT_OUT"
+    else
+        die_test "removefile_compat.c failed to compile against scratch/sysroot_fe4-x86_64"
+        rm -rf "$COMPAT_OUT"
+    fi
+else
+    echo "SKIP: clang-18 / x86 sysroot not present for removefile_compat compile"
+fi
 
 echo "== os-module-x86 before build_fe + fe-imports census"
 expect_grep 'full/foundation/build_os_module.sh' "$PHASE2" \

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -445,7 +445,14 @@ for s in "$OSMOD_SH" "$COL_SH" "$FE_SH"; do
     fi
 done
 # /w -> physical tree is the same inode; clang treats two spellings as two pcm defs.
-MCWORK=$(mktemp -d /tmp/phase2-modcache.XXXXXX)
+# macOS: /tmp is a symlink to /private/tmp, so mktemp may return /tmp/... while
+# realpath -P returns /private/tmp/.... Reproduce that split on Linux with a
+# tmp -> private/tmp alias, then compare pwd -P paths on both sides.
+MC_HOST=$(mktemp -d /tmp/phase2-modcache-host.XXXXXX)
+mkdir -p "$MC_HOST/private/tmp"
+ln -sfn "$MC_HOST/private/tmp" "$MC_HOST/tmp"
+MC_REAL=$(mktemp -d "$MC_HOST/private/tmp/phase2-modcache.XXXXXX")
+MCWORK="$MC_HOST/tmp/$(basename "$MC_REAL")"
 mkdir -p "$MCWORK/physical/scratch/modcache_fe4-x86_64"
 ln -sfn "$MCWORK/physical" "$MCWORK/wlink"
 via_w=$(phase2_canonical_dir "$MCWORK/wlink/scratch/modcache_fe4-x86_64")
@@ -455,11 +462,16 @@ if [ -n "$via_w" ] && [ "$via_w" = "$via_phys" ]; then
 else
     die_test "canonical cache mismatch via_w=$via_w via_phys=$via_phys"
 fi
-case "$via_w" in
-    "$MCWORK/wlink"*) die_test "canonical cache still uses symlink spelling $via_w" ;;
-    "$MCWORK/physical"*) ok "canonical cache is the physical spelling ($via_w)" ;;
-    *) die_test "canonical cache is neither symlink nor physical: $via_w" ;;
-esac
+phys_canon=$(cd "$MCWORK/physical/scratch/modcache_fe4-x86_64" && pwd -P)
+link_unresolved="$MCWORK/wlink/scratch/modcache_fe4-x86_64"
+if [ "$via_w" = "$link_unresolved" ]; then
+    die_test "canonical cache still uses symlink spelling $via_w"
+fi
+if [ "$via_w" = "$phys_canon" ]; then
+    ok "canonical cache is the physical spelling ($via_w)"
+else
+    die_test "canonical cache is neither symlink nor physical: $via_w (physical=$phys_canon)"
+fi
 # Same canonicalize the os-module script applies on a hand-run with W=/w.
 hand=$(
     unset MC
@@ -486,7 +498,7 @@ if [ "$handed_symlink" = "$via_phys" ]; then
 else
     die_test "passed /w-style MC $handed_symlink != $via_phys"
 fi
-rm -rf "$MCWORK"
+rm -rf "$MC_HOST"
 
 FEWORK=$(mktemp -d /tmp/phase2-fe-imports.XXXXXX)
 mkdir -p "$FEWORK/sys/usr/include" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Operator rerun at main `8e39bb32` (PR #17 merged): restage fired, Darwin `_modules` and `fe-imports` passed. FE then failed with **one** error class — 14 errors, all in `FoundationEssentials/FileManager/FileOperations.swift` — `removefile_state_t` / `removefile` / `REMOVEFILE_*` (plus two consequence errors).

`scratch/sysroot_fe4-x86_64/usr/include/removefile.h` does not exist. The arm64 stager `full/foundation/stage_fe_sysroot.sh` stages that FileManager set with `stage_absent` from the Xcode SDK; `scripts/x86/stage_fe_sysroot.sh` did not.

This PR also keeps the macOS `realpath` module-cache test fix (compare `pwd -P` on both sides).

## What changed

1. **One shared list** — `full/foundation/fe_sysroot_measurement_headers.txt` (`complex.h`, `sysdir.h`, `sys/xattr.h`, `copyfile.h`, `removefile.h`, `fts.h`, `pwd.h`, `grp.h`, `sys/utsname.h`, `sys/quota.h`). Both stagers read it via `fe_sysroot_measurement.inc`. Neither duplicates the `for h in sys/xattr.h …` literal. `vm_copy` is appended by the shared helper, not copied as a file.
2. **x86 restage** — `stage_absent` missing members from arm64 `scratch/sysroot_fe4` (same rule as `_modules`). Recipe **`stage_fe_sysroot_x86.3`**; stamp records `fe_sysroot_measurement_headers=<sha>`.
3. **Header-resolve gate** — after restage, every path in that list must exist in the x86 sysroot. Else `CANNOT_FE_MEASUREMENT_HEADERS reason=missing=…` before the compiler. Missing headers restage even if the stamp otherwise matches.
4. **Link side** — `build_fe.sh` is Swift-only on **both** arches. Arm64 compiles `removefile_compat.c` in `full/scripts/build_full.sh`. Phase 2 now compiles that same `.c` (same clang argv) into `build/full-x86_64/foundation/essentials/removefile_compat.o` after a successful `build_fe.sh`. Confirmed here: X86_64 Mach-O defining `_removefile`, `_removefile_state_alloc`/`_free`/`_get`/`_set`, `_removefile_cancel`, `_removefileat`.

Darwin userland already `EXPORT`s `copyfile`/`fcopyfile`, `fts_*`, xattr, `getgrnam_r`, `uname`, `quotactl` (and stub `removefile*`; the `.o` wins at link). `vm_copy` is in `machorun/darwin/src/mach.c`.

**Still expected missing at x86 FE link** unless `fm_unimplemented.o` / `uuid_compat.o` are also linked (arm64 `build_full.sh` compiles both; phase2 does not):

`chflags`, `confstr`, `fchmod`, `getattrlist`, `link`, `mktemp`, `sysctlbyname`, `utimes`, `uuid_generate_random`, `uuid_parse`, `uuid_unparse_upper`.

Operator: confirm or refute that list on the next rerun.

## Operator

```bash
bash scripts/x86/phase2.sh /opt/openuikit/x86-verify/openuikit
```

Expect restage (`recipe stage_fe_sysroot_x86.2→x86.3` and/or `fe_sysroot_measurement_headers=ABSENT→<sha>`), then `measurement_headers=ok`, then FE compile past `removefile.h`. The arm64 `sysroot_fe4` on that box must still carry the FileManager set (PR #17 already reads it for `_modules`).

## Tests

`bash scripts/x86/test_phase2.sh` — **142/142**. Fixture: restage without `removefile.h` fails header-resolve; `stage_absent` copies it from arm64 and refuses to shadow `copyfile.h`; `removefile_compat.c` compiles to X86_64 Mach-O against the x86 sysroot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

