### PR TITLE
Wire Darwin-target dispatch into Concurrency; overlay scoreboard attempts all five

### DIFF
--- a/swiftcore-macho/docs/CONCURRENCY.md
+++ b/swiftcore-macho/docs/CONCURRENCY.md
@@ -19,6 +19,18 @@
 >
 > **Superseded claims, explicitly struck:**
 >
+> * *The `Concurrency/dispatch` ninja node dissolves by `-DSWIFT_ENABLE_DISPATCH=OFF`*
+>   (the closing note of this document) — **NO LONGER THE DARWIN-TARGET ANSWER.**
+>   That flag turns the dispatch executor off. A Darwin stdlib target must keep
+>   `SWIFT_ENABLE_DISPATCH=ON` (CMake default; `StdlibOptions.cmake:217-241`) so
+>   `DispatchGlobalExecutor.cpp` / `DispatchExecutor.swift` still compile, and
+>   skip the CMake `LINK_LIBRARIES dispatch` append when
+>   `SWIFT_PRIMARY_VARIANT_SDK` is in `SWIFT_DARWIN_PLATFORMS` — the same path a
+>   Darwin *host* takes, because `Libdispatch.cmake:49-56` does not build
+>   libdispatch for Darwin SDKs and Darwin `libSystem` re-exports it. That is
+>   swiftcore-macho `apply_patches.py` patch 8. `-DSWIFT_ENABLE_DISPATCH=OFF` +
+>   `singlethreaded` remains a recorded Linux-target / investigation recipe only.
+>
 > * *Part 5, "blocked on making Mach headers opt-in in machorun's sysroot"* —
 >   **NO LONGER TRUE.** Patch 3 superseded it by including the real Mach headers
 >   rather than restubbing them, with `HAVE_MACH 0` still governing whether IPC

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -16,7 +16,7 @@ for target 'x86_64-apple-macos'; found: arm64-apple-macos` because
 | toolchain | Swift 6.2.4 (`swift-6.2.4-RELEASE`) | `docs/BUILD_LOG.md` L3–6; this VM `swift --version` |
 | source tag | `swift-6.2.4-RELEASE` | BUILD_LOG; `scripts/bootstrap_box.sh` |
 | source commit | `ee343b46aef81c3ac7c5d7960cb35a41a88c5a9b` | BUILD_LOG (`ee343b46`); `full/observation/UPSTREAM.md` (full hash) |
-| patches | `scripts/apply_patches.py` 1–5 + 7; 6 (isa widen) **off** | apply_patches.py; patch 5 via `SWIFTCORE_MACHO_LEGACY_IMAGE_REG=1` |
+| patches | `scripts/apply_patches.py` 1–5 + 7 + 8; 6 (isa widen) **off** | apply_patches.py; patch 5 via `SWIFTCORE_MACHO_LEGACY_IMAGE_REG=1`; patch 8 is Darwin-target `dispatch` LINK_LIBRARIES |
 | host of original build | Ubuntu 24.04 **aarch64**, 64 vCPU Graviton4 | BUILD_LOG |
 | `libswiftCore.dylib` | Mach-O 64-bit **arm64**, 9 908 448 bytes, install name `/usr/lib/swift/libswiftCore.dylib` | `file` + `llvm-otool-18 -D` on 2026-09-03 |
 | sha256 | `dd01686e06c81a21755bb864b43dad446c011e6c60c6b387b3b332c0a12708cb` | `artifacts/arm64.manifest.json` (33 files) |
@@ -96,12 +96,14 @@ swift_StringProcessing-macosx-x86_64` forty lines into the log.
 to `/opt/swift624`; `guest_arch.inc` also accepts `command -v swiftc`.
 
 That is bootstrap → x86 libSystem+objc4+.tbd → `stage_sdk.sh` →
-`apply_patches.py` (legacy image-reg) → `configure.sh` →
+`apply_patches.py` (legacy image-reg + patch 8 Darwin-target dispatch) →
+`configure.sh` (`-DSWIFT_ENABLE_DISPATCH=ON` when `SWIFTCORE_BUILD_DISPATCH=1`) →
 `ninja swiftCore-macosx-x86_64` → overlay ninja names from `ninja -t targets`
-(a failing overlay ninja **exits non-zero**; the core gold wall is the only
-allowed ninja failure) → `link_macho_dylib.sh` (wall 7: ninja emits ELF `.so`)
-→ `verify.sh` → `stage_artifacts.sh` → compile+link hello → **run hello
-under machorun if a loader probe succeeds**.
+(every selected overlay is attempted independently; scoreboard
+`OVERLAY <name> built|FAILED|CANNOT_*`; rc non-zero if any failed; the core
+gold wall is the only ninja failure that is allowed) → `link_macho_dylib.sh`
+(wall 7: ninja emits ELF `.so`) → `verify.sh` → `stage_artifacts.sh` →
+compile+link hello → **run hello under machorun if a loader probe succeeds**.
 
 Expected sizes (measured; x86_64 from this VM, arm64 from the Graviton sibling):
 
@@ -165,13 +167,68 @@ is not.
 |---|---|---|
 | Swift / libswiftCore | **yes** — staged | — |
 | `_Builtin_float` swiftmodule | **yes** — staged | `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
-| `_Concurrency` | **no** until operator reruns with fetched libdispatch | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing; else BUILD_LOG §16 |
+| `_Concurrency` | **graph:** Darwin-target configure must not emit ninja input `stdlib/public/Concurrency/dispatch`. Operator 16 vCPU still has to compile it. | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing. Missing CMake `dispatch` node was host-vs-target: `Concurrency/CMakeLists.txt:26-36` + `AddSwiftStdlib.cmake:1058-1072`; `Libdispatch.cmake:49-56` does not build dispatch for OSX. Patch 8 skips that LINK_LIBRARIES append when `SWIFT_PRIMARY_VARIANT_SDK` ∈ `SWIFT_DARWIN_PLATFORMS`. Headers from the staged SDK `<dispatch/dispatch.h>`; link via libSystem re-exports (`machorun/darwin/src/libsystem.c` `mr_init_libdispatch`). **Do not** `-DSWIFT_ENABLE_DISPATCH=OFF`. |
 | `_StringProcessing` / `Synchronization` | fetch + explicit `-D` paths; CMake no longer sees `()` | `CANNOT_FETCH_STRING_PROCESSING_SOURCE`; `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
-| `swiftDarwin` | sysroot now has Apple `semaphore.h` + `sys/ioctl.h` closure from Libc-1752.120.2 / xnu-12377.121.6 (same pins as machorun/sdk/SOURCES.tsv). **LibcOverlayShims.h compiles** (`clang -fsyntax-only` rc=0; Darwin.o no longer reports `semaphore.h` file not found). Next Darwin.o wall: `underlying Objective-C module 'Darwin' not found` (`@_exported import Darwin` — Xcode Darwin.modulemap, `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS`). | ninja failure now **exits non-zero** (no false green). Absent target: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
+| `swiftDarwin` | sysroot now has Apple `semaphore.h` + `sys/ioctl.h` closure from Libc-1752.120.2 / xnu-12377.121.6 (same pins as machorun/sdk/SOURCES.tsv). **LibcOverlayShims.h compiles** (`clang -fsyntax-only` rc=0; Darwin.o no longer reports `semaphore.h` file not found). Next Darwin.o wall: `underlying Objective-C module 'Darwin' not found` (`@_exported import Darwin` — Xcode Darwin.modulemap, `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS`). | ninja failure is `OVERLAY swiftDarwin-macosx-* FAILED` (other overlays still run). Absent target: `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` |
 | `swiftObjectiveC` | **no** — not a CMake target on Linux | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` (do not invoke `ninja` on the missing name) |
 
 Ninja rc tests: `scripts/test_ninja_rc.sh`, `scripts/test_overlay_targets.sh`,
-`scripts/test_overlay_posix.sh`, `scripts/test_probe_machorun.sh`.
+`scripts/test_overlay_scoreboard.sh` (injected Concurrency failure still
+attempts the other four), `scripts/test_dispatch_graph.sh` (patch 8 + optional
+ninja graph), `scripts/test_overlay_posix.sh`, `scripts/test_probe_machorun.sh`.
+
+### Darwin-target `dispatch` (patch 8)
+
+The operator rerun of PR #18 died at:
+
+```
+ninja: error: 'stdlib/public/Concurrency/dispatch', needed by
+  'stdlib/public/Concurrency/OSX/x86_64/_Concurrency.o', missing and no known rule to make it
+```
+
+That path is **not** `add_subdirectory(SWIFT_PATH_TO_LIBDISPATCH_SOURCE)`.
+`cmake/modules/Libdispatch.cmake:49-56` skips Darwin SDKs ("Darwin targets have
+libdispatch available, do not build it"). The IMPORTED `dispatch-<subdir>-<arch>`
+and `dispatch` ALIAS (`Libdispatch.cmake:157-168`, `258-261`) exist only for
+non-Darwin SDKs whose sdk equals `SWIFT_HOST_VARIANT_SDK`.
+
+`stdlib/public/Concurrency/CMakeLists.txt:26-36` keys off **host**
+`CMAKE_SYSTEM_NAME STREQUAL Darwin`. On Linux it `list(APPEND
+swift_concurrency_link_libraries dispatch)` and `add_swift_target_library`
+passes that as `LINK_LIBRARIES` (line 256) into `handle_swift_sources DEPENDS`
+(`AddSwiftStdlib.cmake:1058-1072`). A non-target DEPENDS name is a path
+relative to the current source dir → `stdlib/public/Concurrency/dispatch`.
+
+A Darwin host skips the block: SDK `<dispatch/dispatch.h>` and libSystem
+re-exports. Patch 8 does the same when `SWIFT_PRIMARY_VARIANT_SDK` is in
+`SWIFT_DARWIN_PLATFORMS`, and keeps `SWIFT_ENABLE_DISPATCH=ON` so the dispatch
+executor sources still compile. machorun's Darwin userland already builds
+Apple's libdispatch from source; `libsystem.c` `mr_init_libdispatch` dlsyms
+`libdispatch_init` the way Darwin libSystem does.
+
+### Overlay scoreboard
+
+The overlay loop used to `ninja_checked` under `set -e`, so the first failing
+target aborted before Synchronization / `_StringProcessing` / `_Builtin_float`
+/ Darwin. It now attempts every name in `OVERLAY_NINJA_TARGETS`, then prints:
+
+```
+OVERLAY swift_Concurrency-macosx-x86_64 FAILED
+OVERLAY swiftSynchronization-macosx-x86_64 built
+OVERLAY swift_StringProcessing-macosx-x86_64 built
+OVERLAY swift_Builtin_float-macosx-x86_64 built
+OVERLAY swiftDarwin-macosx-x86_64 FAILED
+OVERLAY swiftObjectiveC-macosx-x86_64 CANNOT_STAGE_XCODE_DARWIN_OVERLAYS
+```
+
+plus `ls` of `lib/swift/macosx/` (dylibs and ELF `.so`). Overall rc stays
+non-zero if any overlay FAILED or a required target was `CANNOT_*`.
+
+**Operator 16 vCPU must confirm:** Concurrency ninja no longer dies on the
+missing `Concurrency/dispatch` node; all five selected overlays are attempted
+with scoreboard lines; produced dylibs/`*.so` are listed; overall rc reflects
+any *real* compile/link wall (Darwin clang module, gold `.so`, …). This VM
+proves the ninja graph and the scoreboard harness, not a full overlay compile.
 
 ## 5. Layout
 

--- a/swiftcore-macho/patches/generated/swift-6.2.4-darwin-on-linux.patch
+++ b/swiftcore-macho/patches/generated/swift-6.2.4-darwin-on-linux.patch
@@ -58,10 +58,24 @@ index 8ec33e9a..a539b01f 100644
      if(SWIFT_PREBUILT_SWIFT)
        set(swift_compiler_tool "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc${HOST_EXECUTABLE_SUFFIX}")
 diff --git a/stdlib/public/Concurrency/CMakeLists.txt b/stdlib/public/Concurrency/CMakeLists.txt
-index d3a50110..f5b14cce 100644
+index d3a50110..8c7aafc2 100644
 --- a/stdlib/public/Concurrency/CMakeLists.txt
 +++ b/stdlib/public/Concurrency/CMakeLists.txt
-@@ -161,7 +161,9 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
+@@ -24,7 +24,12 @@ endif()
+ set(swift_concurrency_incorporate_object_libraries_so swiftThreading)
+ 
+ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
+-  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
++  # Darwin host: SDK <dispatch.h> + libSystem re-exports. Linux host + Darwin
++  # *target* (SWIFT_PRIMARY_VARIANT_SDK in SWIFT_DARWIN_PLATFORMS): same —
++  # Libdispatch.cmake will not create a `dispatch` CMake target for OSX.
++  # Keep SWIFT_ENABLE_DISPATCH ON so the dispatch executor sources compile.
++  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
++     NOT "${SWIFT_PRIMARY_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
+     include_directories(AFTER
+                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
+ 
+@@ -161,7 +166,9 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
    TaskSleepDuration.swift
    UnimplementedExecutor.swift
    CooperativeExecutor.swift
@@ -72,7 +86,7 @@ index d3a50110..f5b14cce 100644
    PlatformExecutorLinux.swift
    PlatformExecutorWindows.swift
    PlatformExecutorOpenBSD.swift
-@@ -182,6 +184,7 @@ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
+@@ -182,6 +189,7 @@ if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
    set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_SWIFT_SOURCES
      DispatchExecutor.swift
      CFExecutor.swift

--- a/swiftcore-macho/scripts/apply_patches.py
+++ b/swiftcore-macho/scripts/apply_patches.py
@@ -262,4 +262,62 @@ edit("stdlib/public/Concurrency/CMakeLists.txt",
   )""",
      "Darwin executor moves into the dispatch branch")
 
+# ---------------------------------------------------------------------------
+# 8. Darwin *target* must not CMake-link a `dispatch` target that Linux-host
+#    libdispatch never creates.
+#
+# SWIFT_ENABLE_DISPATCH defaults TRUE (CMakeLists.txt:767-769). That sets
+# SWIFT_CONCURRENCY_USES_DISPATCH and SWIFT_CONCURRENCY_GLOBAL_EXECUTOR=dispatch
+# (stdlib/cmake/modules/StdlibOptions.cmake:217-241). The concurrency sources
+# that need that executor (DispatchGlobalExecutor.cpp, DispatchExecutor.swift,
+# CFExecutor.swift, PlatformExecutorDarwin.swift) must stay compiled.
+#
+# cmake/modules/Libdispatch.cmake:49-56 does **not** ExternalProject-build
+# dispatch for SWIFT_DARWIN_PLATFORMS ("Darwin targets have libdispatch
+# available, do not build it"). The IMPORTED `dispatch-<subdir>-<arch>`
+# target and the `dispatch` ALIAS (Libdispatch.cmake:157-168, 258-261) exist
+# only for non-Darwin SDKs, and only when sdk == SWIFT_HOST_VARIANT_SDK.
+#
+# Concurrency/CMakeLists.txt:26-36 keys off CMAKE_SYSTEM_NAME STREQUAL
+# Darwin (the *host*). On a Linux host it appends LINK_LIBRARIES `dispatch`
+# (line 256). add_swift_target_library then passes that name through
+# handle_swift_sources DEPENDS (AddSwiftStdlib.cmake:1058-1072). CMake treats
+# a non-target DEPENDS name as a path relative to the current source dir, so
+# ninja wants stdlib/public/Concurrency/dispatch with no rule — the operator
+# wall on x86_64. A Darwin *host* skips the block: SDK headers + libSystem
+# re-exports. A Darwin *target* on Linux must do the same; do not stub a
+# dispatch dylib and do not force OSX into DISPATCH_SDKS.
+# ---------------------------------------------------------------------------
+edit("stdlib/public/Concurrency/CMakeLists.txt",
+"""if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    include_directories(AFTER
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
+
+    # FIXME: we can't rely on libdispatch having been built for the
+    # target at this point in the process.  Currently, we're relying
+    # on soft-linking.
+    list(APPEND swift_concurrency_link_libraries
+      dispatch)
+  endif()
+""",
+"""if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
+  # Darwin host: SDK <dispatch.h> + libSystem re-exports. Linux host + Darwin
+  # *target* (SWIFT_PRIMARY_VARIANT_SDK in SWIFT_DARWIN_PLATFORMS): same —
+  # Libdispatch.cmake will not create a `dispatch` CMake target for OSX.
+  # Keep SWIFT_ENABLE_DISPATCH ON so the dispatch executor sources compile.
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+     NOT "${SWIFT_PRIMARY_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
+    include_directories(AFTER
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
+
+    # FIXME: we can't rely on libdispatch having been built for the
+    # target at this point in the process.  Currently, we're relying
+    # on soft-linking.
+    list(APPEND swift_concurrency_link_libraries
+      dispatch)
+  endif()
+""",
+     "Darwin target does not CMake-link a missing dispatch target")
+
 print("patches applied")

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -51,7 +51,9 @@ mkdir -p "$W"
 step() { printf '\n==== %s ====\n' "$*"; }
 
 # Every ninja invocation reports its status. The core target may hit the
-# expected ELF gold wall (BUILD_LOG wall 7); overlay targets may not.
+# expected ELF gold wall (BUILD_LOG wall 7). Overlay targets are attempted
+# independently (scoreboard OVERLAY <name> built|FAILED|CANNOT_*); any
+# overlay failure keeps the script rc non-zero.
 run_stdlib_ninja() {
   step "ninja $SWIFTCORE_NINJA_CORE -j$NINJA_JOBS"
   ninja_checked --allow-gold-wall "$W/build.log" -C "$B" -j "$NINJA_JOBS" \
@@ -63,12 +65,39 @@ run_stdlib_ninja() {
     exit 0
   fi
   if [ "${SWIFTCORE_OVERLAYS:-0}" = 1 ]; then
+    local sel_rc=0 ninja_st=0 overlay_rc=0 t
+    # Attempt every selected overlay even if select named a CANNOT, so one
+    # operator run measures all five. ninja itself rebuilds real deps of
+    # the requested target; we do not skip later names because an earlier
+    # ninja failed.
+    set +e
     overlay_select_targets "$B" "$SWIFTCORE_DARWIN_ARCH"
-    local t
-    for t in "${OVERLAY_NINJA_TARGETS[@]}"; do
-      step "ninja overlay $t"
-      ninja_checked "$W/build.log" -C "$B" -j "$NINJA_JOBS" "$t"
-    done
+    sel_rc=$?
+    set -e
+    if [ "$sel_rc" -ne 0 ]; then
+      overlay_rc=$sel_rc
+    fi
+    if [ ${#OVERLAY_NINJA_TARGETS[@]} -gt 0 ]; then
+      for t in "${OVERLAY_NINJA_TARGETS[@]}"; do
+        step "ninja overlay $t"
+        ninja_st=0
+        ninja_checked "$W/build.log" -C "$B" -j "$NINJA_JOBS" "$t" || ninja_st=$?
+        if [ "$ninja_st" -eq 0 ]; then
+          OVERLAY_STATUS[$t]=built
+        else
+          OVERLAY_STATUS[$t]=FAILED
+          if [ "$overlay_rc" -eq 0 ]; then
+            overlay_rc=$ninja_st
+          fi
+        fi
+      done
+    fi
+    overlay_print_scoreboard "$SWIFTCORE_DARWIN_ARCH"
+    overlay_list_products "$B/lib/swift/macosx"
+    if [ "$overlay_rc" -ne 0 ]; then
+      echo "overlay: FAILED rc=$overlay_rc" >&2
+      return "$overlay_rc"
+    fi
   fi
 }
 
@@ -168,7 +197,8 @@ fi
 # ---------------------------------------------------------------------------
 # 6. Build. The ninja link edge is ELF (.so); that is expected (BUILD_LOG wall 7)
 #    and is the only ninja failure that is allowed to continue. Overlay ninja
-#    failures (unknown target, missing header, compile error) exit non-zero.
+#    failures are recorded on the scoreboard; every selected overlay is still
+#    attempted, then the script exits non-zero if any failed.
 # ---------------------------------------------------------------------------
 run_stdlib_ninja
 

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -116,7 +116,14 @@ if [ "$OVERLAY_STRING" = ON ]; then
   STRING_FLAG=(-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE="$STRING_PROCESSING_SRC")
 fi
 if [ "${SWIFTCORE_BUILD_DISPATCH:-0}" = 1 ]; then
-  DISPATCH_FLAG=(-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="$LIBDISPATCH_SRC")
+  # Path satisfies StdlibOptions.cmake:224-226 on a non-Darwin host.
+  # ENABLE_DISPATCH stays ON (CMake default TRUE) so the Darwin concurrency
+  # overlay still compiles the dispatch executor; patch 8 stops CMake from
+  # linking a `dispatch` target that Libdispatch.cmake never creates for OSX.
+  DISPATCH_FLAG=(
+    -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE="$LIBDISPATCH_SRC"
+    -DSWIFT_ENABLE_DISPATCH=ON
+  )
 fi
 
 CMAKE_ARGS=(

--- a/swiftcore-macho/scripts/ninja_checked.inc
+++ b/swiftcore-macho/scripts/ninja_checked.inc
@@ -29,10 +29,14 @@ ninja_checked() {
     mkdir -p "$(dirname "$log")"
     local chunk
     chunk=$(mktemp)
+    # Save/restore errexit: this function must not `set -e` on the caller,
+    # or an overlay loop that wants to continue after a failure cannot.
+    local errexit_was_on=0
+    case $- in *e*) errexit_was_on=1 ;; esac
     set +e
     "$ninja_bin" "$@" 2>&1 | tee -a "$log" | tee "$chunk"
     local st=${PIPESTATUS[0]}
-    set -e
+    if [ "$errexit_was_on" = 1 ]; then set -e; fi
     echo "ninja $* exit=$st"
     if [ "$st" -eq 0 ]; then
         rm -f "$chunk"

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -42,6 +42,8 @@ overlay_xcode_only_target() {
 
 # Fill OVERLAY_NINJA_TARGETS. Print CANNOT_* for missing names. Exit 2 if a
 # required overlay is absent. Never emit a name that is not in `ninja -t targets`.
+# OVERLAY_STATUS[target] is built|FAILED|CANNOT_<reason> (CANNOT filled here;
+# built/FAILED filled by the caller after each independent ninja).
 #
 # overlay_select_targets <build_dir> <arch>
 overlay_select_targets() {
@@ -49,6 +51,8 @@ overlay_select_targets() {
     local arch=${2:?overlay_select_targets: arch}
     local dump n have
     OVERLAY_NINJA_TARGETS=()
+    declare -gA OVERLAY_STATUS
+    OVERLAY_STATUS=()
 
     if [ -n "${NINJA_TARGETS_DUMP:-}" ]; then
         dump=$(cat "$NINJA_TARGETS_DUMP")
@@ -70,18 +74,26 @@ overlay_select_targets() {
         fi
         if overlay_xcode_only_target "$n"; then
             echo "CANNOT_STAGE_XCODE_DARWIN_OVERLAYS target=$n reason=not in ninja -t targets; Swift 6.2.4 does not create an ObjectiveC overlay CMake target on Linux (Apple picks it up from the Xcode SDK)"
+            OVERLAY_STATUS[$n]=CANNOT_STAGE_XCODE_DARWIN_OVERLAYS
             continue
         fi
         if overlay_required_target "$n"; then
             echo "CANNOT_OVERLAY_TARGET_ABSENT target=$n reason=not in ninja -t targets; required overlay was not created by this CMake configuration" >&2
+            OVERLAY_STATUS[$n]=CANNOT_OVERLAY_TARGET_ABSENT
             missing_required=1
             continue
         fi
         # Darwin (and any other optional Platform overlay): named refusal, skip.
         echo "CANNOT_STAGE_XCODE_DARWIN_OVERLAYS target=$n reason=not in ninja -t targets"
+        OVERLAY_STATUS[$n]=CANNOT_STAGE_XCODE_DARWIN_OVERLAYS
     done < <(overlay_candidate_targets "$arch")
 
     if [ "$missing_required" = 1 ]; then
+        if [ ${#OVERLAY_NINJA_TARGETS[@]} -gt 0 ]; then
+            echo "overlay_select: will ninja ${OVERLAY_NINJA_TARGETS[*]}"
+        else
+            echo "overlay_select: will ninja"
+        fi
         return 2
     fi
     if [ ${#OVERLAY_NINJA_TARGETS[@]} -eq 0 ]; then
@@ -90,4 +102,35 @@ overlay_select_targets() {
     fi
     echo "overlay_select: will ninja ${OVERLAY_NINJA_TARGETS[*]}"
     return 0
+}
+
+# OVERLAY <ninja-target> built|FAILED|CANNOT_<reason>
+overlay_print_scoreboard() {
+    local arch=${1:?overlay_print_scoreboard: arch}
+    local n st
+    echo "==== overlay scoreboard ===="
+    while IFS= read -r n; do
+        [ -n "$n" ] || continue
+        st=${OVERLAY_STATUS[$n]:-UNKNOWN}
+        echo "OVERLAY $n $st"
+    done < <(overlay_candidate_targets "$arch")
+}
+
+# ls of produced overlay dylibs / ELF .so under lib/swift/macosx.
+overlay_list_products() {
+    local root=${1:?overlay_list_products: macosx dir}
+    echo "==== overlay products $root ===="
+    if [ ! -d "$root" ]; then
+        echo "(absent)"
+        return 0
+    fi
+    ls -la "$root"
+    local d
+    for d in "$root"/*/; do
+        [ -d "$d" ] || continue
+        echo "-- $d --"
+        ls -la "$d"
+    done
+    echo "-- libswift*.dylib / libswift*.so --"
+    find "$root" \( -name 'libswift*.dylib' -o -name 'libswift*.so' \) -print | sort
 }

--- a/swiftcore-macho/scripts/stage_artifacts.sh
+++ b/swiftcore-macho/scripts/stage_artifacts.sh
@@ -143,7 +143,7 @@ payload = {
             "commit": dispatch_commit,
         },
     },
-    "patches": "scripts/apply_patches.py 1-5+7; patch 5 via SWIFTCORE_MACHO_LEGACY_IMAGE_REG=1; patch 6 (isa widen) off",
+    "patches": "scripts/apply_patches.py 1-5+7+8; patch 5 via SWIFTCORE_MACHO_LEGACY_IMAGE_REG=1; patch 6 (isa widen) off; patch 8 Darwin-target skips CMake dispatch link lib",
     "flags": {
         "SWIFTCORE_DARWIN_ARCH": arch,
         "SWIFT_SDK_OSX_ARCHITECTURES": arch,
@@ -155,6 +155,7 @@ payload = {
         "SWIFTCORE_MACHO_LEGACY_IMAGE_REG": "1",
         "SWIFT_PATH_TO_STRING_PROCESSING_SOURCE": "pinned sibling",
         "SWIFT_PATH_TO_LIBDISPATCH_SOURCE": "pinned sibling",
+        "SWIFT_ENABLE_DISPATCH": "ON",
     },
     "toolchain": "Swift version 6.2.4 (swift-6.2.4-RELEASE)",
     "host": os.uname().machine + "-unknown-linux-gnu",

--- a/swiftcore-macho/scripts/test_dispatch_graph.sh
+++ b/swiftcore-macho/scripts/test_dispatch_graph.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Patch 8: a Darwin *target* on a Linux host must not CMake-link `dispatch`.
+# That name becomes ninja input stdlib/public/Concurrency/dispatch with no rule
+# (operator log line 905). Do not stub the target; skip the LINK_LIBRARIES
+# append the way a Darwin host does (libSystem re-exports).
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+fail=0
+SWIFT=${SWIFT:-$HOME/work/swift}
+CMAKE=$SWIFT/stdlib/public/Concurrency/CMakeLists.txt
+
+echo "=== patch 8 is in apply_patches.py ==="
+grep -q 'Darwin target does not CMake-link a missing dispatch target' \
+  "$SCRIPT_DIR/apply_patches.py" \
+  && echo "  OK  apply_patches.py has patch 8" \
+  || { echo "  FAIL missing patch 8 tag"; fail=1; }
+
+echo
+echo "=== apply_patches.py against $SWIFT ==="
+if [ -f "$CMAKE" ]; then
+  python3 "$SCRIPT_DIR/apply_patches.py" "$SWIFT"
+  grep -q 'NOT "${SWIFT_PRIMARY_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS' "$CMAKE" \
+    && echo "  OK  Darwin-target skip is in Concurrency/CMakeLists.txt" \
+    || { echo "  FAIL Darwin-target condition missing from $CMAKE"; fail=1; }
+  set +e
+  python3 - "$CMAKE" <<'PY'
+from pathlib import Path
+import sys
+s = Path(sys.argv[1]).read_text()
+old = '''if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    include_directories(AFTER
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})'''
+if old in s:
+    print("  FAIL unpatched host-only CMAKE_SYSTEM_NAME guard still present")
+    raise SystemExit(1)
+print("  OK  host-only dispatch LINK_LIBRARIES guard is gone")
+PY
+  [ $? -eq 0 ] || fail=1
+  set -e
+else
+  echo "  skip apply (no $CMAKE)"
+fi
+
+echo
+echo "=== ninja graph must not depend on stdlib/public/Concurrency/dispatch ==="
+NINJA_FILE=${SWIFTCORE_DISPATCH_GRAPH_NINJA:-}
+if [ -z "$NINJA_FILE" ] && [ -f /tmp/dispatch-graph-proof/build.ninja ]; then
+  NINJA_FILE=/tmp/dispatch-graph-proof/build.ninja
+fi
+if [ -n "$NINJA_FILE" ] && [ -f "$NINJA_FILE" ]; then
+  set +e
+  python3 - "$NINJA_FILE" <<'PY'
+from pathlib import Path
+import sys
+p = Path(sys.argv[1])
+text = p.read_text()
+needle = "stdlib/public/Concurrency/dispatch"
+hits = []
+for i, line in enumerate(text.splitlines(), 1):
+    if needle in line and "_Concurrency.o" in line:
+        hits.append(i)
+if hits:
+    print(f"  FAIL {p} still has {needle} on _Concurrency.o lines {hits[:5]}")
+    raise SystemExit(1)
+print(f"  OK  {p} has no {needle} input on _Concurrency.o")
+PY
+  [ $? -eq 0 ] || fail=1
+  set -e
+  cache=$(dirname "$NINJA_FILE")/CMakeCache.txt
+  if [ -f "$cache" ]; then
+    grep -q 'SWIFT_ENABLE_DISPATCH:BOOL=ON' "$cache" \
+      && echo "  OK  SWIFT_ENABLE_DISPATCH=ON" \
+      || { echo "  FAIL ENABLE_DISPATCH not ON in CMakeCache"; fail=1; }
+    grep -q 'SWIFT_CONCURRENCY_GLOBAL_EXECUTOR:STRING=dispatch' "$cache" \
+      && echo "  OK  GLOBAL_EXECUTOR=dispatch (executor sources stay compiled)" \
+      || { echo "  FAIL GLOBAL_EXECUTOR is not dispatch"; fail=1; }
+  fi
+  if command -v ninja >/dev/null 2>&1; then
+    graph_dir=$(dirname "$NINJA_FILE")
+    set +e
+    q=$(ninja -C "$graph_dir" -t query stdlib/public/Concurrency/OSX/x86_64/_Concurrency.o 2>&1)
+    qs=$?
+    set -e
+    printf '%s\n' "$q" | head -40
+    if [ "$qs" -eq 0 ]; then
+      printf '%s\n' "$q" | grep -q 'stdlib/public/Concurrency/dispatch' \
+        && { echo "  FAIL ninja -t query still lists Concurrency/dispatch"; fail=1; } \
+        || echo "  OK  ninja -t query has no Concurrency/dispatch input"
+    else
+      echo "  skip ninja -t query rc=$qs"
+    fi
+  fi
+else
+  echo "  skip (set SWIFTCORE_DISPATCH_GRAPH_NINJA or configure /tmp/dispatch-graph-proof)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- Darwin-target dispatch is libSystem, not a CMake/ninja dispatch node"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_ninja_rc.sh
+++ b/swiftcore-macho/scripts/test_ninja_rc.sh
@@ -143,6 +143,20 @@ printf '%s\n' "$out" | grep -q 'build_stdlib done' \
 printf '%s\n' "$out" | grep -E 'ninja overlay swiftObjectiveC|will ninja.*swiftObjectiveC' \
   && { echo "  FAIL asked ninja for swiftObjectiveC"; fail=1; } \
   || echo "  OK  did not invoke missing ObjectiveC target"
+# Fail-fast is gone: every selected overlay is still attempted.
+for t in swift_Concurrency-macosx-x86_64 swiftSynchronization-macosx-x86_64 \
+         swift_StringProcessing-macosx-x86_64 swift_Builtin_float-macosx-x86_64 \
+         swiftDarwin-macosx-x86_64; do
+  printf '%s\n' "$out" | grep -q "ninja overlay $t" \
+    && echo "  OK  attempted $t" \
+    || { echo "  FAIL did not attempt $t"; fail=1; }
+  printf '%s\n' "$out" | grep -q "OVERLAY $t FAILED" \
+    && echo "  OK  scoreboard FAILED $t" \
+    || { echo "  FAIL missing OVERLAY $t FAILED"; fail=1; }
+done
+printf '%s\n' "$out" | grep -q 'OVERLAY swiftObjectiveC-macosx-x86_64 CANNOT_STAGE_XCODE_DARWIN_OVERLAYS' \
+  && echo "  OK  scoreboard ObjectiveC CANNOT" \
+  || { echo "  FAIL missing ObjectiveC scoreboard CANNOT"; fail=1; }
 
 echo
 if [ "$fail" -eq 0 ]; then

--- a/swiftcore-macho/scripts/test_overlay_scoreboard.sh
+++ b/swiftcore-macho/scripts/test_overlay_scoreboard.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# One operator run must attempt every selected overlay. An injected Concurrency
+# failure must not skip Synchronization / _StringProcessing / _Builtin_float /
+# Darwin. rc stays non-zero; the scoreboard names each outcome.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+build=$SCRIPT_DIR/build_stdlib.sh
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fake=$tmp/bin
+mkdir -p "$fake" "$tmp/work/build/lib/swift/macosx/x86_64"
+
+cat > "$fake/ninja" <<'EOF'
+#!/bin/bash
+args=("$@")
+targets_mode=0
+target=""
+i=0
+while [ $i -lt ${#args[@]} ]; do
+  a=${args[$i]}
+  case "$a" in
+    -C)
+      # Honour -C so we can drop dummy dylibs where overlay_list_products looks.
+      builddir=${args[$((i+1))]}
+      i=$((i+2)); continue ;;
+    -j) i=$((i+2)); continue ;;
+    -t)
+      i=$((i+1))
+      if [ "${args[$i]:-}" = targets ]; then targets_mode=1; fi
+      i=$((i+1)); continue
+      ;;
+    *) target=$a; i=$((i+1)); continue ;;
+  esac
+done
+
+if [ "$targets_mode" = 1 ]; then
+  cat <<'T'
+swiftCore-macosx-x86_64: phony
+swift_Concurrency-macosx-x86_64: phony
+swiftSynchronization-macosx-x86_64: phony
+swift_StringProcessing-macosx-x86_64: phony
+swift_Builtin_float-macosx-x86_64: phony
+swiftDarwin-macosx-x86_64: phony
+T
+  exit 0
+fi
+
+if [[ "$target" == swiftCore-* ]]; then
+  echo "clang++: error: invalid linker name in argument '-fuse-ld=gold'"
+  echo "ninja: build stopped: subcommand failed."
+  exit 1
+fi
+
+prod=${builddir:-.}/lib/swift/macosx/x86_64
+mkdir -p "$prod"
+
+if [[ "$target" == swift_Concurrency-* ]]; then
+  echo "ninja: error: 'stdlib/public/Concurrency/dispatch', needed by 'stdlib/public/Concurrency/OSX/x86_64/_Concurrency.o', missing and no known rule to make it"
+  echo "ninja: build stopped: subcommand failed."
+  exit 1
+fi
+
+case "$target" in
+  swiftSynchronization-*)
+    touch "$prod/libswiftSynchronization.so"
+    echo "built $target" ;;
+  swift_StringProcessing-*)
+    touch "$prod/libswift_StringProcessing.so"
+    echo "built $target" ;;
+  swift_Builtin_float-*)
+    touch "$prod/libswift_Builtin_float.so"
+    echo "built $target" ;;
+  swiftDarwin-*)
+    touch "$prod/libswiftDarwin.so"
+    echo "built $target" ;;
+  *)
+    echo "built $target" ;;
+esac
+exit 0
+EOF
+chmod +x "$fake/ninja"
+
+set +e
+out=$(
+  env PATH="$fake:$PATH" NINJA="$fake/ninja" \
+    SWIFTCORE_NINJA_HARNESS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    SWIFTCORE_OVERLAYS=1 \
+    W="$tmp/work" B="$tmp/work/build" \
+    bash "$build" 2>&1
+)
+rc=$?
+set -e
+printf '%s\n' "$out"
+echo "--- scoreboard injected-failure rc=$rc ---"
+
+[ "$rc" -ne 0 ] && echo "  OK  rc=$rc (any overlay failure is non-zero)" \
+  || { echo "  FAIL expected nonzero"; fail=1; }
+
+printf '%s\n' "$out" | grep -q 'build_stdlib done' \
+  && { echo "  FAIL printed done after overlay failure"; fail=1; } \
+  || echo "  OK  did not claim done"
+
+# Attempt order: all five selected names, Concurrency first, others still run.
+for t in swift_Concurrency-macosx-x86_64 swiftSynchronization-macosx-x86_64 \
+         swift_StringProcessing-macosx-x86_64 swift_Builtin_float-macosx-x86_64 \
+         swiftDarwin-macosx-x86_64; do
+  printf '%s\n' "$out" | grep -q "ninja overlay $t" \
+    && echo "  OK  attempted $t" \
+    || { echo "  FAIL did not attempt $t"; fail=1; }
+done
+
+printf '%s\n' "$out" | grep -q 'OVERLAY swift_Concurrency-macosx-x86_64 FAILED' \
+  && echo "  OK  Concurrency FAILED" \
+  || { echo "  FAIL Concurrency not FAILED"; fail=1; }
+for t in swiftSynchronization-macosx-x86_64 swift_StringProcessing-macosx-x86_64 \
+         swift_Builtin_float-macosx-x86_64 swiftDarwin-macosx-x86_64; do
+  printf '%s\n' "$out" | grep -q "OVERLAY $t built" \
+    && echo "  OK  $t built" \
+    || { echo "  FAIL missing OVERLAY $t built"; fail=1; }
+done
+printf '%s\n' "$out" | grep -q 'OVERLAY swiftObjectiveC-macosx-x86_64 CANNOT_STAGE_XCODE_DARWIN_OVERLAYS' \
+  && echo "  OK  ObjectiveC CANNOT" \
+  || { echo "  FAIL missing ObjectiveC CANNOT"; fail=1; }
+
+printf '%s\n' "$out" | grep -q 'libswiftSynchronization.so' \
+  && echo "  OK  ls lists Synchronization so" \
+  || { echo "  FAIL products ls missing Synchronization"; fail=1; }
+printf '%s\n' "$out" | grep -q 'libswiftDarwin.so' \
+  && echo "  OK  ls lists Darwin so" \
+  || { echo "  FAIL products ls missing Darwin"; fail=1; }
+printf '%s\n' "$out" | grep -q 'libswift_Concurrency' \
+  && { echo "  FAIL Concurrency product listed after injected miss"; fail=1; } \
+  || echo "  OK  no Concurrency dylib/so in products"
+
+# Fail-fast regression: later overlays must appear *after* the Concurrency failure.
+conc_fail_line=$(printf '%s\n' "$out" | grep -n 'OVERLAY swift_Concurrency-macosx-x86_64 FAILED' | head -1 | cut -d: -f1)
+sync_line=$(printf '%s\n' "$out" | grep -n 'ninja overlay swiftSynchronization-macosx-x86_64' | head -1 | cut -d: -f1)
+if [ -n "$conc_fail_line" ] && [ -n "$sync_line" ] && [ "$sync_line" -gt "$conc_fail_line" ]; then
+  echo "  OK  Synchronization attempted after Concurrency FAILED"
+elif [ -n "$conc_fail_line" ] && [ -n "$sync_line" ]; then
+  # ninja overlay happens before scoreboard; scoreboard is after the loop.
+  # Check ninja overlay Synchronization exists and ninja overlay Darwin exists
+  # even though Concurrency ninja FAILED rc= is in the log.
+  echo "  OK  scoreboard is after the loop (ninja overlay lines precede OVERLAY lines)"
+else
+  echo "  FAIL could not place Concurrency FAILED vs Synchronization attempt"
+  fail=1
+fi
+
+# ninja overlay Synchronization must still run even though Concurrency printed FAILED rc=
+if printf '%s\n' "$out" | grep -q 'ninja: FAILED rc='; then
+  # Count overlay ninja invocations via the step banner.
+  n_overlay=$(printf '%s\n' "$out" | grep -c '^==== ninja overlay ' || true)
+  [ "$n_overlay" -eq 5 ] && echo "  OK  5 overlay ninja steps (not fail-fast)" \
+    || { echo "  FAIL overlay ninja steps=$n_overlay want 5"; fail=1; }
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- overlay scoreboard attempts every selected target after an injected failure"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_overlay_siblings.sh
+++ b/swiftcore-macho/scripts/test_overlay_siblings.sh
@@ -67,6 +67,9 @@ printf '%s\n' "$dump" | grep -F -- "-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE=$fa
 printf '%s\n' "$dump" | grep -F -- "-DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=$fake/libdispatch" >/dev/null \
   && echo "  OK  LIBDISPATCH_SOURCE path" \
   || { echo "  FAIL missing LIBDISPATCH -D"; fail=1; }
+printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_DISPATCH=ON" >/dev/null \
+  && echo "  OK  ENABLE_DISPATCH=ON with BUILD_DISPATCH" \
+  || { echo "  FAIL missing SWIFT_ENABLE_DISPATCH=ON"; fail=1; }
 printf '%s\n' "$dump" | grep -F -- "-DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=ON" >/dev/null \
   && echo "  OK  STRING_PROCESSING=ON" \
   || { echo "  FAIL STRING_PROCESSING not ON"; fail=1; }

--- a/swiftcore-macho/scripts/test_overlay_targets.sh
+++ b/swiftcore-macho/scripts/test_overlay_targets.sh
@@ -19,9 +19,10 @@ swiftDarwin-macosx-x86_64: phony
 swiftCore-macosx-x86_64: phony
 EOF
 set +e
-out=$(NINJA_TARGETS_DUMP="$tmp/targets" overlay_select_targets /no/build x86_64 2>&1)
+NINJA_TARGETS_DUMP="$tmp/targets" overlay_select_targets /no/build x86_64 >"$tmp/out1" 2>&1
 rc=$?
 set -e
+out=$(cat "$tmp/out1")
 printf '%s\n' "$out"
 [ "$rc" -eq 0 ] && echo "  OK  rc=0" || { echo "  FAIL rc=$rc"; fail=1; }
 printf '%s\n' "$out" | grep -q 'will ninja.*swiftDarwin-macosx-x86_64' \
@@ -31,6 +32,9 @@ printf '%s\n' "$out" | grep -q 'CANNOT_STAGE_XCODE_DARWIN_OVERLAYS target=swiftO
 printf '%s\n' "$out" | grep -q 'will ninja.*swiftObjectiveC' \
   && { echo "  FAIL ObjectiveC still in will-ninja list"; fail=1; } \
   || echo "  OK  ObjectiveC not ninja'd"
+[ "${OVERLAY_STATUS[swiftObjectiveC-macosx-x86_64]:-}" = CANNOT_STAGE_XCODE_DARWIN_OVERLAYS ] \
+  && echo "  OK  OVERLAY_STATUS ObjectiveC CANNOT" \
+  || { echo "  FAIL OVERLAY_STATUS ObjectiveC=${OVERLAY_STATUS[swiftObjectiveC-macosx-x86_64]:-unset}"; fail=1; }
 
 echo
 echo "=== missing required _StringProcessing is CANNOT_OVERLAY_TARGET_ABSENT ==="
@@ -41,14 +45,21 @@ swift_Builtin_float-macosx-x86_64: phony
 swiftDarwin-macosx-x86_64: phony
 EOF
 set +e
-out=$(NINJA_TARGETS_DUMP="$tmp/targets" overlay_select_targets /no/build x86_64 2>&1)
+NINJA_TARGETS_DUMP="$tmp/targets" overlay_select_targets /no/build x86_64 >"$tmp/out2" 2>&1
 rc=$?
 set -e
+out=$(cat "$tmp/out2")
 printf '%s\n' "$out"
 [ "$rc" -eq 2 ] && echo "  OK  rc=2" || { echo "  FAIL rc=$rc want 2"; fail=1; }
 printf '%s\n' "$out" | grep -q 'CANNOT_OVERLAY_TARGET_ABSENT target=swift_StringProcessing-macosx-x86_64' \
   && echo "  OK  named the missing required target" \
   || { echo "  FAIL missing CANNOT_OVERLAY_TARGET_ABSENT"; fail=1; }
+[ "${OVERLAY_STATUS[swift_StringProcessing-macosx-x86_64]:-}" = CANNOT_OVERLAY_TARGET_ABSENT ] \
+  && echo "  OK  OVERLAY_STATUS StringProcessing CANNOT" \
+  || { echo "  FAIL OVERLAY_STATUS StringProcessing=${OVERLAY_STATUS[swift_StringProcessing-macosx-x86_64]:-unset}"; fail=1; }
+printf '%s\n' "${OVERLAY_NINJA_TARGETS[*]}" | grep -q 'swift_Concurrency-macosx-x86_64' \
+  && echo "  OK  still selected Concurrency for ninja" \
+  || { echo "  FAIL missing required did not keep other ninja targets"; fail=1; }
 
 echo
 echo "=== live ninja -t targets from overlay-cmake-proof (if present) ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #18's operator rerun on the 16 vCPU x86 box was an honest `build_stdlib rc=1`. Two separate defects:

1. `ninja: error: 'stdlib/public/Concurrency/dispatch', needed by '.../_Concurrency.o', missing and no known rule to make it`
2. The overlay loop stopped at that first failure, so Synchronization / `_StringProcessing` / `_Builtin_float` / Darwin were never attempted. `/root/work/build/lib/swift/macosx/` held no overlay dylibs.

## 1. Dispatch is libSystem on a Darwin *target*, not a CMake `dispatch` node

This is **not** `add_subdirectory(SWIFT_PATH_TO_LIBDISPATCH_SOURCE)` and it is **not** `-DSWIFT_ENABLE_DISPATCH=OFF`.

Cited at Swift pin `ee343b46` (`swift-6.2.4-RELEASE`):

| file | lines | what it does |
|---|---|---|
| `CMakeLists.txt` | 767–769 | `SWIFT_ENABLE_DISPATCH` defaults **TRUE** |
| `stdlib/cmake/modules/StdlibOptions.cmake` | 217–241 | that sets `SWIFT_CONCURRENCY_USES_DISPATCH` and `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR=dispatch` |
| `stdlib/public/Concurrency/CMakeLists.txt` | 26–36, 256 | on a **non-Darwin host**, `list(APPEND swift_concurrency_link_libraries dispatch)` then `LINK_LIBRARIES` |
| `stdlib/cmake/modules/AddSwiftStdlib.cmake` | 1058–1072 | `handle_swift_sources DEPENDS` includes `LINK_LIBRARIES`; a non-target name is a path relative to the current source dir → `stdlib/public/Concurrency/dispatch` |
| `cmake/modules/Libdispatch.cmake` | 49–56 | **Darwin SDKs are skipped** ("Darwin targets have libdispatch available, do not build it") |
| `cmake/modules/Libdispatch.cmake` | 157–168, 258–261 | IMPORTED `dispatch-<subdir>-<arch>` and the `dispatch` ALIAS exist only for non-Darwin SDKs whose sdk equals `SWIFT_HOST_VARIANT_SDK` |

A Darwin *host* already skips the LINK_LIBRARIES append: SDK `<dispatch/dispatch.h>` + libSystem re-exports. Patch 8 does the same when `SWIFT_PRIMARY_VARIANT_SDK` is in `SWIFT_DARWIN_PLATFORMS`. `SWIFT_ENABLE_DISPATCH=ON` stays on so `DispatchGlobalExecutor.cpp` / `DispatchExecutor.swift` / `CFExecutor.swift` / `PlatformExecutorDarwin.swift` still compile. machorun's Darwin userland already builds Apple's libdispatch from source; `machorun/darwin/src/libsystem.c` `mr_init_libdispatch` dlsyms `libdispatch_init` the way Darwin libSystem does.

**Do not stub a `dispatch` target. Do not force OSX into `DISPATCH_SDKS`.**

Configure-level proof on this VM (reconfigure `/tmp/dispatch-graph-proof`):

- `SWIFT_ENABLE_DISPATCH:BOOL=ON`, `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR:STRING=dispatch`
- `build.ninja` has **0** `stdlib/public/Concurrency/dispatch` inputs on `_Concurrency.o`
- `ninja -t query` lists Swift sources only; `DispatchGlobalExecutor.cpp` / `DispatchExecutor.swift` remain in the graph
- stale `$HOME/work/build` (pre-patch) still had the missing node (1 hit)

## 2. Overlay scoreboard

`build_stdlib.sh` now attempts every selected overlay independently (ninja still rebuilds real inter-target deps of the requested name). `ninja_checked` restores the caller's errexit flag so a FAILED overlay cannot abort the loop. After the loop:

```
OVERLAY swift_Concurrency-macosx-x86_64 FAILED
OVERLAY swiftSynchronization-macosx-x86_64 built
OVERLAY swift_StringProcessing-macosx-x86_64 built
OVERLAY swift_Builtin_float-macosx-x86_64 built
OVERLAY swiftDarwin-macosx-x86_64 built
OVERLAY swiftObjectiveC-macosx-x86_64 CANNOT_STAGE_XCODE_DARWIN_OVERLAYS
```

plus `ls` of `lib/swift/macosx/` (`*.dylib` / `*.so`). Overall rc stays non-zero if any overlay FAILED or a required target was `CANNOT_*`.

Harness: `scripts/test_overlay_scoreboard.sh` injects the operator's missing-`dispatch` error on Concurrency and still ninjas the other four.

## Operator 16 vCPU must confirm

Same command:

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

- Concurrency ninja **no longer** dies on missing `stdlib/public/Concurrency/dispatch`
- All five selected overlays are attempted; scoreboard lines for each (ObjectiveC stays `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS`)
- `ls` of produced dylibs / `.so` under `lib/swift/macosx/`
- Overall rc reflects any *real* compile/link wall (Darwin clang module, gold `.so`, …)

This VM did not full-ninja the overlay objects (4 vCPU / 15 GiB).

[Dispatch graph proof: no Concurrency/dispatch ninja input](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdispatch_graph_proof.png)
[Overlay scoreboard continues after injected Concurrency failure](https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_scoreboard_injected_failure.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35369cc-b509-457d-83ef-c090127c9afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

