### PR TITLE
Produce x86_64 ud_guest through foundation-macho's committed linker

### DIFF
--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -90,7 +90,7 @@ NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
 | `build_objc4.sh` / `build_quartz.sh` | yes — unblocks the `objc` fixture | same |
 | `scripts/x86/stage_fe_sysroot.sh` | headers + x86 dylibs + Darwin family modulemaps + x86 `libswiftCore`/`Swift.swiftmodule`/`_Builtin_float` into `usr/lib/swift`; restages when input shas change; `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` unless textual Darwin overlays exist in the arm64 `sysroot_fe4` | same |
 | FoundationEssentials / collections / OpenCombine / `build_full.sh` | x86 `libswiftCore` + `Swift.swiftmodule` are in artifacts; `_Concurrency` overlay is not (libdispatch wall). `os-module-x86` is built into `build/full-x86_64/foundation/os` before `build_fe.sh`. `fe-imports` names missing `_Concurrency`/`_StringProcessing`/… instead of compiling 202 files | needs x86 libswiftCore + `_Concurrency` + `_StringProcessing` + Darwin overlays + os-module |
-| rung a `run_ud_guest.sh` | cannot run a real FE guest without x86 libswiftCore + named MACHORUN_ROOT + `ud_guest` binary | smoke 14/14 + persist under the ported loader |
+| rung a `run_ud_guest.sh` | `ud-guest-x86` links `scratch/ud-guest-x86_64/bin/ud_guest` through `link_ud_guest.sh` (tbd-first). Runtime still needs the nine overlay dylibs at load. Missing CF objects: `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib`. | smoke 14/14 + persist under the ported loader once overlays land |
 | rung b Focus widget + onboarding | scripts retargeted; `NEEDS_X86_OPENCOMBINE` resolved by `export-x86_64/` (arm64 SHA untouched) | same gates under the ported loader |
 | rung c Reminder scene | inner script no longer refuses x86-on-x86; still needs Reminder 22-source inventory | one `UIWindow` + three paced turns |
 
@@ -191,3 +191,22 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    script stages fonts there and under `$W/build/swiftui-guest/fonts`; phase2
    tries `ln -sfn $W /w` and CANNOT if it cannot. Compiler argv never uses
    the `/w` spelling for `-module-cache-path`.
+9. `ud-guest-x86` produces the x86_64 `#87` guest binary through
+   foundation-macho's committed pipeline rather than asking the operator to
+   hand-stage it. Work tree is `scratch/ud-guest-x86_64` (never unsuffixed
+   `scratch/ud-guest`). FE objects are **reused** from
+   `build/full-x86_64/foundation` (same `build_fe.sh` / collections / os /
+   cshims argv phase2 already ran) and staged into that tree's `$W/fe` the
+   way `stage_fe_guest.sh` laid out the arm64 #87 container. Port + runner
+   compile use `build_ud_score_guest.sh`'s argv (`COMPILE_TRIPLE` macos15,
+   `-O -wmo`, `CFPreferencesMinimal`). Link is **only**
+   `foundation-macho/scripts/link_ud_guest.sh` (macos13 `TRIPLE`, tbd-first
+   `-L` order). `fm_unimplemented.o` is compiled once into essentials/ with
+   `build_full.sh`'s clang argv. `libswiftcompat.dylib` comes from an existing
+   x86 Mach-O or `swiftcore-macho/scripts/build_compat.sh`. `libCFTest.dylib`
+   has no committed x86 object recipe (`/work/cfobjc` is shell-history only);
+   missing it is `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib`. Any other
+   missing piece is `CANNOT_UD_GUEST_<FILE> file=<basename>`. On success the
+   binary is exported as `UD_GUEST_BIN` for rung a, with
+   `bin/ud_guest.otool.txt` (`MH_MAGIC_64 X86_64` + expected loads). Overlay
+   dylibs are not required at link time; rung a still needs them at load.

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -658,3 +658,6 @@ phase2_stage_x86_base_mrroot() {
     done
 }
 
+# shellcheck source=ud_guest.inc
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ud_guest.inc"
+

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -803,6 +803,44 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 6d. x86_64 ud_guest via foundation-macho's committed linker. Work tree is
+#     scratch/ud-guest-x86_64 (never the unsuffixed arm64 path). FE objects
+#     are reused from build/full-x86_64/foundation; this does not compile FE
+#     again. Link-time does not need the nine overlay dylibs (tbd-first);
+#     rung a still needs them at load.
+echo "==== ud-guest-x86 (committed $PHASE2_UD_GUEST_LINKER) ===="
+UD_GUEST_ITEM_OK=0
+ud_report=$(phase2_try_ud_guest \
+    "$W" \
+    "$FE_OUT" \
+    "$SYS" \
+    "$TARGET" \
+    "$MC" \
+    "$MACHORUN/darwin/usr/lib" \
+    "$MACHORUN/build/machorun" \
+    || true)
+case "$ud_report" in
+    OK\ bin=*)
+        UD_GUEST_BIN=${ud_report#*bin=}
+        UD_GUEST_BIN=${UD_GUEST_BIN%% *}
+        UD_GUEST_W=$W/scratch/ud-guest-x86_64
+        export UD_GUEST_BIN UD_GUEST_W
+        note ud-guest-x86 cold-built "$ud_report"
+        UD_GUEST_ITEM_OK=1
+        echo "  $ud_report"
+        ;;
+    CANNOT_UD_GUEST_*)
+        ud_marker=${ud_report#CANNOT_UD_GUEST_}
+        ud_marker=${ud_marker%% *}
+        ud_rest=${ud_report#CANNOT_UD_GUEST_${ud_marker} }
+        cannot ud-guest-x86 "UD_GUEST_$ud_marker" "$ud_rest"
+        ;;
+    *)
+        cannot ud-guest-x86 UD_GUEST_UNKNOWN "ud-guest-x86 produced: ${ud_report:-empty}"
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
 # 7. Rungs. Reuse committed gates. Never invent new denominators.
 echo "==== rungs (committed runners only) ===="
 
@@ -897,7 +935,7 @@ if [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] && [ "$LIBSWIFTCORE_X86" -eq 1 ]
         fi
     else
         cannot rung-a-ud_guest UD_GUEST_BINARY \
-            "no x86_64 ud_guest Mach-O. Committed linker is foundation-macho/scripts/link_ud_guest.sh (objects in \$W/fe of a named foundation-macho work tree). Will not invent a second linker. Operator: stage CF+FE objects, link_ud_guest.sh, then re-run; or set UD_GUEST_BIN."
+            "no x86_64 ud_guest Mach-O after ud-guest-x86. Committed linker is foundation-macho/scripts/link_ud_guest.sh against scratch/ud-guest-x86_64 (never a second linker). See ENV_PREPARE ud-guest-x86 CANNOT_UD_GUEST_* file=."
         RUNG_A_DETAIL="no ud_guest binary"
     fi
 else

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -59,7 +59,8 @@ expect_file "$GUEST"
 
 echo "== bash -n"
 for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
-    "$ROOT/full/foundation/fe_sysroot_measurement.inc"; do
+    "$ROOT/full/foundation/fe_sysroot_measurement.inc" \
+    "$ROOT/scripts/x86/ud_guest.inc"; do
     if bash -n "$s"; then
         ok "bash -n $(basename "$s")"
     else
@@ -770,6 +771,144 @@ else
     ok "tbd-stubs is not host=x86_64 CANNOT_GENERATE_TBD"
 fi
 rm -rf "$PREP_FIX"
+
+echo "== ud-guest-x86 uses committed linker, suffixed tree, reused FE objects"
+UDINC=$ROOT/scripts/x86/ud_guest.inc
+expect_file "$UDINC"
+expect_grep 'ud-guest-x86' "$PHASE2" "phase2 item ud-guest-x86"
+expect_grep 'phase2_try_ud_guest' "$PHASE2" "phase2 invokes the ud-guest producer"
+expect_grep 'foundation-macho/scripts/link_ud_guest.sh' "$UDINC" \
+    "producer names the committed linker"
+expect_grep 'foundation-macho/scripts/link_ud_guest.sh' "$PHASE2" \
+    "phase2 still names the committed linker"
+expect_not_grep 'build_fe.sh' "$UDINC" \
+    "ud-guest-x86 does not compile FE a second time"
+expect_grep 'scratch/ud-guest-x86_64' "$UDINC" "work tree is suffixed"
+expect_grep 'refusing unsuffixed/arm64 ud-guest work tree' "$UDINC" \
+    "unsuffixed work tree is a named CANNOT"
+expect_grep 'export UD_GUEST_BIN' "$PHASE2" "successful link exports UD_GUEST_BIN for rung a"
+expect_grep 'CANNOT_UD_GUEST_' "$UDINC" "refusal markers use CANNOT_UD_GUEST_"
+expect_grep 'file=libCFTest.dylib' "$UDINC" "CF hole names file=libCFTest.dylib"
+expect_grep 'file=UserDefaultsGuest.o' "$UDINC" "port hole names file=UserDefaultsGuest.o"
+expect_grep 'file=runner.o' "$UDINC" "runner hole names file=runner.o"
+expect_grep 'build_ud_score_guest.sh' "$UDINC" "port/runner argv follows the committed scoreboard compile"
+expect_grep 'build_full.sh argv -O1 -nostdinc' "$UDINC" \
+    "fm_unimplemented uses build_full.sh clang argv"
+expect_grep 'build_cftest_harness.sh' "$UDINC" "CF path names the committed CF linker"
+expect_grep 'Will not invent a CF compiler or a stub' "$UDINC" \
+    "does not invent a CF compiler"
+for load in libswiftCore libswiftDarwin libswift_StringProcessing \
+    libswiftSynchronization libswift_errno libobjc libSystem libCFTest libswiftcompat
+do
+    expect_grep "$load" "$UDINC" "expected load $load is in the otool census"
+done
+expect_not_grep 'Operator: stage CF+FE objects, link_ud_guest.sh, then re-run' \
+    "$PHASE2" "rung a no longer asks the operator to hand-stage the binary"
+
+echo "== ud-guest-x86 refusal + staging resolution"
+UDWORK=$(mktemp -d /tmp/phase2-ud-guest.XXXXXX)
+SYS=${SYS:-$ROOT/scratch/sysroot_fe4-x86_64}
+# shellcheck source=common.inc
+. "$COMMON"
+
+unsuf=$(phase2_ud_guest_refuse_unsuffixed "$UDWORK/scratch/ud-guest" || true)
+case "$unsuf" in
+    CANNOT_UD_GUEST_WORKTREE\ file=*reason=refusing\ unsuffixed/arm64*)
+        ok "unsuffixed work tree is CANNOT_UD_GUEST_WORKTREE"
+        ;;
+    *) die_test "unsuffixed refusal got: $unsuf" ;;
+esac
+
+wt=$(phase2_ud_guest_worktree "$UDWORK")
+if [ "$wt" = "$UDWORK/scratch/ud-guest-x86_64" ]; then
+    ok "worktree helper is scratch/ud-guest-x86_64"
+else
+    die_test "worktree helper got $wt"
+fi
+
+missing=$(phase2_ud_guest_stage_fe "$UDWORK/foundation" "$wt" || true)
+case "$missing" in
+    CANNOT_UD_GUEST_FOUNDATIONESSENTIALS\ file=FoundationEssentials.o*)
+        ok "missing FE object is CANNOT_UD_GUEST_FOUNDATIONESSENTIALS file=FoundationEssentials.o"
+        ;;
+    *) die_test "missing FE refusal got: $missing" ;;
+esac
+
+if [ -d "$SYS/usr/include" ]; then
+    fe=$UDWORK/foundation
+    mkdir -p "$fe/essentials" "$fe/collections" "$fe/os" "$fe/cshims"
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/essentials/FoundationEssentials.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/collections/OrderedCollections.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/collections/InternalCollectionsUtilities.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/collections/_RopeModule.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/os/os.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/cshims/platform_shims.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/cshims/string_shims.o" -x c -
+    echo 'int ud_guest_probe=1;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$fe/cshims/uuid.o" -x c -
+    : > "$fe/essentials/FoundationEssentials.swiftmodule"
+    : > "$fe/os/os.swiftmodule"
+    staged=$(phase2_ud_guest_stage_fe "$fe" "$wt" || true)
+    case "$staged" in
+        OK\ fe-staged*)
+            if [ -f "$wt/fe/module/FoundationEssentials.o" ] \
+                && [ -f "$wt/fe/collections/OrderedCollections.o" ] \
+                && [ -f "$wt/fe/collections/_RopeModule.o" ] \
+                && [ -f "$wt/fe/_RopeModule.o" ] \
+                && [ -f "$wt/fe/os/os.o" ] \
+                && [ -f "$wt/fe/cshims/uuid.o" ] \
+                && phase2_is_x86_macho "$wt/fe/module/FoundationEssentials.o"; then
+                ok "staging maps build/full-x86_64/foundation into scratch/ud-guest-x86_64/fe"
+            else
+                die_test "staged layout incomplete under $wt/fe"
+            fi
+            ;;
+        *) die_test "staging resolution got: $staged" ;;
+    esac
+else
+    die_test "x86 sysroot missing; cannot compile staging fixtures"
+fi
+
+cfreport=$(phase2_ud_guest_ensure_cftest "$wt" "$ROOT" || true)
+case "$cfreport" in
+    CANNOT_UD_GUEST_LIBCFTEST\ file=libCFTest.dylib*)
+        ok "absent libCFTest.dylib is CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib"
+        ;;
+    *) die_test "libCFTest refusal got: $cfreport" ;;
+esac
+
+# A provided x86 dylib is accepted (resolution path for the CF hole).
+echo 'int ud_cftest=1;' | clang-18 -target x86_64-apple-macos15.0 \
+    -isysroot "$SYS" -c -o "$UDWORK/cftest.o" -x c -
+clang-18 -target x86_64-apple-macos15.0 -isysroot "$SYS" \
+    -fuse-ld=lld -B /usr/lib/llvm-18/bin -nostdlib -dynamiclib \
+    -install_name /usr/lib/libCFTest.dylib \
+    "$UDWORK/cftest.o" -o "$UDWORK/libCFTest.dylib" 2>/dev/null \
+    || clang-18 -target x86_64-apple-macos15.0 -isysroot "$SYS" \
+        -fuse-ld=lld -B /usr/lib/llvm-18/bin -dynamiclib \
+        -install_name /usr/lib/libCFTest.dylib \
+        "$UDWORK/cftest.o" -o "$UDWORK/libCFTest.dylib"
+if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
+    UD_CFTEST_DYLIB=$UDWORK/libCFTest.dylib
+    cfok=$(phase2_ud_guest_ensure_cftest "$wt" "$ROOT" || true)
+    if [ -z "$cfok" ] && [ -f "$wt/lib/libCFTest.dylib" ] \
+        && phase2_is_x86_macho "$wt/lib/libCFTest.dylib"; then
+        ok "UD_CFTEST_DYLIB stages an x86 libCFTest.dylib into the suffixed tree"
+    else
+        die_test "UD_CFTEST_DYLIB resolution got: '$cfok'"
+    fi
+    unset UD_CFTEST_DYLIB
+else
+    die_test "could not emit an x86 libCFTest.dylib fixture"
+fi
+rm -rf "$UDWORK"
 
 echo
 echo "test_phase2: pass=$pass fail=$fail"

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -781,16 +781,19 @@ expect_grep 'foundation-macho/scripts/link_ud_guest.sh' "$UDINC" \
     "producer names the committed linker"
 expect_grep 'foundation-macho/scripts/link_ud_guest.sh' "$PHASE2" \
     "phase2 still names the committed linker"
-expect_not_grep 'build_fe.sh' "$UDINC" \
-    "ud-guest-x86 does not compile FE a second time"
+if grep -E '^[^#]*build_fe\.sh' "$UDINC" >/dev/null; then
+    die_test "ud-guest-x86 invokes build_fe.sh"
+else
+    ok "ud-guest-x86 does not compile FE a second time"
+fi
 expect_grep 'scratch/ud-guest-x86_64' "$UDINC" "work tree is suffixed"
 expect_grep 'refusing unsuffixed/arm64 ud-guest work tree' "$UDINC" \
     "unsuffixed work tree is a named CANNOT"
 expect_grep 'export UD_GUEST_BIN' "$PHASE2" "successful link exports UD_GUEST_BIN for rung a"
 expect_grep 'CANNOT_UD_GUEST_' "$UDINC" "refusal markers use CANNOT_UD_GUEST_"
-expect_grep 'file=libCFTest.dylib' "$UDINC" "CF hole names file=libCFTest.dylib"
-expect_grep 'file=UserDefaultsGuest.o' "$UDINC" "port hole names file=UserDefaultsGuest.o"
-expect_grep 'file=runner.o' "$UDINC" "runner hole names file=runner.o"
+expect_grep 'LIBCFTEST libCFTest.dylib' "$UDINC" "CF hole names file=libCFTest.dylib"
+expect_grep 'USERDEFAULTSGUEST UserDefaultsGuest.o' "$UDINC" "port hole names file=UserDefaultsGuest.o"
+expect_grep 'RUNNER runner.o' "$UDINC" "runner hole names file=runner.o"
 expect_grep 'build_ud_score_guest.sh' "$UDINC" "port/runner argv follows the committed scoreboard compile"
 expect_grep 'build_full.sh argv -O1 -nostdinc' "$UDINC" \
     "fm_unimplemented uses build_full.sh clang argv"

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -1,0 +1,477 @@
+# scripts/x86/ud_guest.inc -- phase2 item ud-guest-x86.
+# Sourced from common.inc. Not executed.
+#
+# Produces x86_64 ud_guest through foundation-macho's committed pipeline:
+#   objects in $W/scratch/ud-guest-x86_64/fe  (never scratch/ud-guest)
+#   libCFTest.dylib + libswiftcompat.dylib in that tree's lib/
+#   link via foundation-macho/scripts/link_ud_guest.sh  (no second linker)
+#   binary at $W/scratch/ud-guest-x86_64/bin/ud_guest, handed to rung a as
+#   UD_GUEST_BIN.
+#
+# FE objects are reused from build/full-x86_64/foundation (the same
+# build_fe.sh / build_collections.sh / build_os_module.sh / build_cshims.sh
+# argv phase2 already ran). This item does not invoke those scripts.
+#
+# Pipeline input differences vs foundation-macho #87 (see PHASE2.md):
+#   * FE compile flags are identical (full/foundation/build_*.sh); only
+#     TARGET/SYS/MC/OUT differ (x86 suffix vs historical arm64 scratch/fe4_*).
+#   * removefile_compat.o is compiled by phase2 into essentials/ and is NOT
+#     an input to link_ud_guest.sh (the #87 guest never linked it).
+#   * uuid_compat.o is a build_full.sh input and is NOT on the #87 link line.
+#   * fm_unimplemented.o is compiled once into essentials/ with build_full.sh's
+#     clang argv, then staged; not recompiled with different flags.
+#   * Port + runner compile argv matches build_ud_score_guest.sh (COMPILE_TRIPLE
+#     macos15, -O -wmo, -I fe/{module,collections,os} + CFPreferencesMinimal).
+#   * Link TRIPLE is macos13 (foundation-macho/scripts/guest_arch.inc).
+#   * SDK is scratch/sysroot_fe4-x86_64, exposed as $ud_w/fe/sysroot because
+#     link_ud_guest.sh defaults SDK=$W/fe/sysroot.
+
+if [ -n "${PHASE2_UD_GUEST_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+PHASE2_UD_GUEST_INC=1
+
+PHASE2_UD_GUEST_LINKER=foundation-macho/scripts/link_ud_guest.sh
+PHASE2_UD_GUEST_EXPECTED_LOADS=(
+    libswiftCore
+    libswiftDarwin
+    libswift_StringProcessing
+    libswiftSynchronization
+    libswift_errno
+    libobjc
+    libSystem
+    libCFTest
+    libswiftcompat
+)
+
+phase2_ud_guest_worktree() {
+    local tree=$1
+    printf '%s/scratch/ud-guest-x86_64\n' "$tree"
+}
+
+phase2_ud_guest_refuse_unsuffixed() {
+    local dest=$1
+    case "$dest" in
+        */scratch/ud-guest-x86_64)
+            return 0
+            ;;
+        *)
+            printf 'CANNOT_UD_GUEST_WORKTREE file=%s reason=refusing unsuffixed/arm64 ud-guest work tree\n' \
+                "$dest"
+            return 1
+            ;;
+    esac
+}
+
+# One line: CANNOT_UD_GUEST_<MARKER> file=<basename> <rest>
+phase2_ud_guest_cannot() {
+    local marker=$1 file=$2
+    shift 2
+    printf 'CANNOT_UD_GUEST_%s file=%s %s\n' "$marker" "$file" "$*"
+}
+
+phase2_ud_guest_stage_file() {
+    # stage_file <src> <dest> <file> <MARKER> [macho]
+    # macho=1 (default) requires X86_64 Mach-O; macho=0 for swiftmodules.
+    local src=$1 dest=$2 file=$3 marker=$4 macho=${5:-1}
+    if [ ! -f "$src" ]; then
+        phase2_ud_guest_cannot "$marker" "$file" "missing at $src"
+        return 1
+    fi
+    if [ "$macho" = 1 ] && ! phase2_is_x86_macho "$src"; then
+        phase2_ud_guest_cannot "$marker" "$file" "not X86_64 Mach-O: $src"
+        return 1
+    fi
+    mkdir -p "$(dirname "$dest")"
+    ln -f "$src" "$dest" 2>/dev/null || cp -a "$src" "$dest"
+}
+
+# Map build/full-x86_64/foundation -> $ud_w/fe as stage_fe_guest.sh does for
+# the #87 tree. Hardlink when possible; never rebuild FE.
+phase2_ud_guest_stage_fe() {
+    local fe_out=$1 ud_w=$2
+    local report
+
+    phase2_ud_guest_refuse_unsuffixed "$ud_w" || return 1
+    mkdir -p "$ud_w/fe/module" "$ud_w/fe/collections" "$ud_w/fe/os" "$ud_w/fe/cshims"
+
+    phase2_ud_guest_stage_file \
+        "$fe_out/essentials/FoundationEssentials.o" \
+        "$ud_w/fe/module/FoundationEssentials.o" \
+        FoundationEssentials.o FOUNDATIONESSENTIALS || return 1
+    phase2_ud_guest_stage_file \
+        "$fe_out/essentials/FoundationEssentials.swiftmodule" \
+        "$ud_w/fe/module/FoundationEssentials.swiftmodule" \
+        FoundationEssentials.swiftmodule FOUNDATIONESSENTIALS 0 || return 1
+    if [ -f "$fe_out/essentials/FoundationEssentials.swiftdoc" ]; then
+        phase2_ud_guest_stage_file \
+            "$fe_out/essentials/FoundationEssentials.swiftdoc" \
+            "$ud_w/fe/module/FoundationEssentials.swiftdoc" \
+            FoundationEssentials.swiftdoc FOUNDATIONESSENTIALS 0 || true
+    fi
+
+    phase2_ud_guest_stage_file \
+        "$fe_out/collections/OrderedCollections.o" \
+        "$ud_w/fe/collections/OrderedCollections.o" \
+        OrderedCollections.o ORDEREDCOLLECTIONS || return 1
+    phase2_ud_guest_stage_file \
+        "$fe_out/collections/InternalCollectionsUtilities.o" \
+        "$ud_w/fe/collections/InternalCollectionsUtilities.o" \
+        InternalCollectionsUtilities.o INTERNALCOLLECTIONSUTILITIES || return 1
+    phase2_ud_guest_stage_file \
+        "$fe_out/collections/_RopeModule.o" \
+        "$ud_w/fe/collections/_RopeModule.o" \
+        _RopeModule.o ROPEMODULE || return 1
+    # link_ud_guest.sh also looks at $W/fe/_RopeModule.o (optional duplicate).
+    phase2_ud_guest_stage_file \
+        "$fe_out/collections/_RopeModule.o" \
+        "$ud_w/fe/_RopeModule.o" \
+        _RopeModule.o ROPEMODULE || return 1
+
+    phase2_ud_guest_stage_file \
+        "$fe_out/os/os.o" "$ud_w/fe/os/os.o" os.o OS || return 1
+    if [ -f "$fe_out/os/os.swiftmodule" ]; then
+        phase2_ud_guest_stage_file \
+            "$fe_out/os/os.swiftmodule" "$ud_w/fe/os/os.swiftmodule" \
+            os.swiftmodule OS 0 || return 1
+    fi
+
+    phase2_ud_guest_stage_file \
+        "$fe_out/cshims/platform_shims.o" \
+        "$ud_w/fe/cshims/platform_shims.o" \
+        platform_shims.o PLATFORM_SHIMS || return 1
+    phase2_ud_guest_stage_file \
+        "$fe_out/cshims/string_shims.o" \
+        "$ud_w/fe/cshims/string_shims.o" \
+        string_shims.o STRING_SHIMS || return 1
+    phase2_ud_guest_stage_file \
+        "$fe_out/cshims/uuid.o" \
+        "$ud_w/fe/cshims/uuid.o" \
+        uuid.o UUID || return 1
+
+    printf 'OK fe-staged dest=%s\n' "$ud_w/fe"
+}
+
+# Same clang argv as full/scripts/build_full.sh for fm_unimplemented.c.
+phase2_ud_guest_compile_fm_unimplemented() {
+    local sys=$1 dest=$2 target=$3 src_tree=$4
+    mkdir -p "$(dirname "$dest")"
+    clang-18 -target "$target" -isysroot "$sys" -O1 -nostdinc \
+        -DOPEN_FOUNDATION_UUID_COMPAT=1 \
+        -c "$src_tree/full/foundation/fm_unimplemented.c" \
+        -o "$dest"
+}
+
+phase2_ud_guest_ensure_fm_unimplemented() {
+    local fe_out=$1 sys=$2 target=$3 src_tree=$4 ud_w=$5
+    local src=$fe_out/essentials/fm_unimplemented.o
+    if [ -f "$src" ] && phase2_is_x86_macho "$src"; then
+        :
+    else
+        local st
+        set +e
+        phase2_ud_guest_compile_fm_unimplemented "$sys" "$src" "$target" "$src_tree"
+        st=$?
+        set -e
+        if [ "$st" -ne 0 ]; then
+            phase2_ud_guest_cannot FM_UNIMPLEMENTED fm_unimplemented.o \
+                "clang exit $st (build_full.sh argv -O1 -nostdinc -DOPEN_FOUNDATION_UUID_COMPAT=1)"
+            return 1
+        fi
+        if [ ! -f "$src" ] || ! phase2_is_x86_macho "$src"; then
+            phase2_ud_guest_cannot FM_UNIMPLEMENTED fm_unimplemented.o \
+                "not X86_64 Mach-O after compile: $src"
+            return 1
+        fi
+    fi
+    phase2_ud_guest_stage_file \
+        "$src" "$ud_w/fe/fm_unimplemented.o" \
+        fm_unimplemented.o FM_UNIMPLEMENTED
+}
+
+phase2_ud_guest_point_sysroot() {
+    local sys=$1 ud_w=$2
+    if [ ! -d "$sys/usr/lib" ]; then
+        phase2_ud_guest_cannot SYSROOT sysroot "missing x86 FE sysroot at $sys"
+        return 1
+    fi
+    mkdir -p "$ud_w/fe"
+    rm -f "$ud_w/fe/sysroot"
+    ln -sfn "$sys" "$ud_w/fe/sysroot"
+}
+
+# Port compile: same shape as foundation-macho/scripts/build_ud_score_guest.sh
+# (COMPILE_TRIPLE, -O -wmo, CFPreferencesMinimal -I). Module name is the
+# import the runner uses.
+phase2_ud_guest_compile_port() {
+    local ud_w=$1 repo=$2 sdk=$3 compile_triple=$4 mc=$5
+    local src_ud=$repo/foundation-macho/src/overlay/UserDefaults.swift
+    local src_bridge=$repo/foundation-macho/src/overlay/UserDefaultsBridge_Guest.swift
+    local out=$ud_w/fe/UserDefaultsGuest.o
+    local err log st
+    if [ ! -f "$src_ud" ] || [ ! -f "$src_bridge" ]; then
+        phase2_ud_guest_cannot USERDEFAULTSGUEST UserDefaultsGuest.o \
+            "missing overlay sources under foundation-macho/src/overlay"
+        return 1
+    fi
+    mkdir -p "$ud_w/fe" "$mc"
+    log=$(mktemp)
+    set +e
+    swiftc -c -O -wmo -parse-as-library \
+        -module-name PortedUserDefaultsGuest \
+        -emit-module -emit-module-path "$ud_w/fe/PortedUserDefaultsGuest.swiftmodule" \
+        -target "$compile_triple" -sdk "$sdk" \
+        -runtime-compatibility-version none \
+        -module-cache-path "$mc" \
+        -I "$ud_w/fe/module" -I "$ud_w/fe" -I "$ud_w/fe/collections" -I "$ud_w/fe/os" \
+        -I "$repo/foundation-macho/include/CFPreferencesMinimal" \
+        "$src_ud" "$src_bridge" \
+        -o "$out" >"$log" 2>&1
+    st=$?
+    set -e
+    if [ "$st" -ne 0 ] || [ ! -f "$out" ] || ! phase2_is_x86_macho "$out"; then
+        err=$(phase2_flatten < "$log")
+        rm -f "$log"
+        phase2_ud_guest_cannot USERDEFAULTSGUEST UserDefaultsGuest.o \
+            "swiftc exit $st $err"
+        return 1
+    fi
+    rm -f "$log"
+}
+
+# Smoke runner: top-level code must be named main.swift (same as the
+# scoreboard recipe in build_ud_score_guest.sh).
+phase2_ud_guest_compile_runner() {
+    local ud_w=$1 repo=$2 sdk=$3 compile_triple=$4 mc=$5
+    local src=$repo/foundation-macho/tests/ud_guest_runner.swift
+    local builddir=$ud_w/fe/runner-src
+    local out=$ud_w/fe/runner.o
+    local log err st
+    if [ ! -f "$src" ]; then
+        phase2_ud_guest_cannot RUNNER runner.o \
+            "missing foundation-macho/tests/ud_guest_runner.swift"
+        return 1
+    fi
+    rm -rf "$builddir"
+    mkdir -p "$builddir" "$mc"
+    cp "$src" "$builddir/main.swift"
+    log=$(mktemp)
+    set +e
+    swiftc -c -O -wmo \
+        -module-name ud_guest \
+        -target "$compile_triple" -sdk "$sdk" \
+        -runtime-compatibility-version none \
+        -module-cache-path "$mc" \
+        -I "$ud_w/fe/module" -I "$ud_w/fe" -I "$ud_w/fe/collections" -I "$ud_w/fe/os" \
+        -I "$repo/foundation-macho/include/CFPreferencesMinimal" \
+        "$builddir/main.swift" \
+        -o "$out" >"$log" 2>&1
+    st=$?
+    set -e
+    if [ "$st" -ne 0 ] || [ ! -f "$out" ] || ! phase2_is_x86_macho "$out"; then
+        err=$(phase2_flatten < "$log")
+        rm -f "$log"
+        phase2_ud_guest_cannot RUNNER runner.o "swiftc exit $st $err"
+        return 1
+    fi
+    rm -f "$log"
+}
+
+phase2_ud_guest_find_x86_dylib() {
+    local name=$1
+    shift
+    local c
+    for c in "$@"; do
+        [ -n "$c" ] || continue
+        [ -f "$c" ] || continue
+        phase2_is_x86_macho "$c" || continue
+        printf '%s\n' "$c"
+        return 0
+    done
+    return 1
+}
+
+phase2_ud_guest_ensure_swiftcompat() {
+    local repo=$1 sys=$2 ud_w=$3 mrlib=$4 loader=$5
+    local dest=$ud_w/lib/libswiftcompat.dylib
+    local found src_dir
+    mkdir -p "$ud_w/lib"
+    found=$(phase2_ud_guest_find_x86_dylib libswiftcompat.dylib \
+        "${UD_SWIFTCOMPAT_DYLIB:-}" \
+        "$dest" \
+        "$mrlib/libswiftcompat.dylib" \
+        "$repo/scratch/mrroot-x86_64/darwin/usr/lib/libswiftcompat.dylib" \
+        || true)
+    if [ -n "$found" ]; then
+        [ "$found" = "$dest" ] || cp -a "$found" "$dest"
+        return 0
+    fi
+    src_dir=$repo/swiftcore-macho/sdk/compat
+    if [ ! -f "$src_dir/swiftcompat.c" ] || [ ! -f "$src_dir/shim.cpp" ]; then
+        phase2_ud_guest_cannot LIBSWIFTCOMPAT libswiftcompat.dylib \
+            "no x86_64 Mach-O and swiftcore-macho/sdk/compat sources missing"
+        return 1
+    fi
+    # Committed recipe: swiftcore-macho/scripts/build_compat.sh
+    local log st
+    log=$(mktemp)
+    set +e
+    W="$ud_w" \
+        SDK="$sys" \
+        SRC="$src_dir" \
+        MRLIB="$mrlib" \
+        LOADER="$loader" \
+        OUT="$dest" \
+        NM=llvm-nm-18 \
+        bash "$repo/swiftcore-macho/scripts/build_compat.sh" >"$log" 2>&1
+    st=$?
+    set -e
+    if [ "$st" -ne 0 ] || [ ! -f "$dest" ] || ! phase2_is_x86_macho "$dest"; then
+        phase2_ud_guest_cannot LIBSWIFTCOMPAT libswiftcompat.dylib \
+            "build_compat.sh exit $st (committed swiftcore-macho recipe; artifacts/libswiftcompat.dylib is arm64) $(phase2_flatten < "$log")"
+        rm -f "$log"
+        return 1
+    fi
+    rm -f "$log"
+}
+
+phase2_ud_guest_ensure_cftest() {
+    local ud_w=$1 repo=$2
+    local dest=$ud_w/lib/libCFTest.dylib
+    local found
+    mkdir -p "$ud_w/lib"
+    found=$(phase2_ud_guest_find_x86_dylib libCFTest.dylib \
+        "${UD_CFTEST_DYLIB:-}" \
+        "$dest" \
+        "$repo/scratch/ud-guest-x86_64/lib/libCFTest.dylib" \
+        || true)
+    if [ -n "$found" ]; then
+        [ "$found" = "$dest" ] || cp -a "$found" "$dest"
+        return 0
+    fi
+    # /work/cfobjc has no committed compile recipe (docs/CF_PREFERENCES_EXECUTION.md).
+    # build_cftest_harness.sh only relinks objects that already exist. Do not
+    # invent a second CF compiler or a stub dylib.
+    phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+        "no x86_64 Mach-O. Committed CF linker is foundation-macho/scripts/build_cftest_harness.sh; cfobjc objects have no committed recipe (shell-history only). Will not invent a CF compiler or a stub. Operator: provide UD_CFTEST_DYLIB=x86_64 libCFTest.dylib."
+    return 1
+}
+
+phase2_ud_guest_link() {
+    local repo=$1 ud_w=$2 sys=$3 out=$4
+    local linker=$repo/$PHASE2_UD_GUEST_LINKER
+    local log=$ud_w/bin/ud_guest.link.log
+    local st
+    if [ ! -f "$linker" ]; then
+        phase2_ud_guest_cannot UD_GUEST ud_guest "missing committed linker $linker"
+        return 1
+    fi
+    mkdir -p "$(dirname "$out")"
+    set +e
+    W="$ud_w" SDK="$sys" OUT="$out" LLD_BIN=/usr/lib/llvm-18/bin \
+        bash "$linker" >"$log" 2>&1
+    st=$?
+    set -e
+    if [ "$st" -ne 0 ] || [ ! -f "$out" ]; then
+        phase2_ud_guest_cannot UD_GUEST ud_guest \
+            "link_ud_guest.sh exit $st $(phase2_flatten < "$log")"
+        return 1
+    fi
+    if ! phase2_is_x86_macho "$out"; then
+        phase2_ud_guest_cannot UD_GUEST ud_guest "linked file is not X86_64 Mach-O: $out"
+        return 1
+    fi
+}
+
+phase2_ud_guest_write_otool_evidence() {
+    local bin=$1 evid=$2
+    {
+        echo "== llvm-otool-18 -hv"
+        llvm-otool-18 -hv "$bin"
+        echo
+        echo "== llvm-otool-18 -L"
+        llvm-otool-18 -L "$bin"
+    } >"$evid"
+}
+
+phase2_ud_guest_check_loads() {
+    local evid=$1
+    local name
+    for name in "${PHASE2_UD_GUEST_EXPECTED_LOADS[@]}"; do
+        if ! grep -q "$name" "$evid"; then
+            phase2_ud_guest_cannot UD_GUEST ud_guest \
+                "otool -L missing expected load $name (evidence $evid)"
+            return 1
+        fi
+    done
+    if ! grep -q 'MH_MAGIC_64[[:space:]]\+X86_64' "$evid"; then
+        phase2_ud_guest_cannot UD_GUEST ud_guest \
+            "otool -hv missing MH_MAGIC_64 X86_64 (evidence $evid)"
+        return 1
+    fi
+    return 0
+}
+
+# Main producer. Prints one line:
+#   OK bin=... evid=...
+#   CANNOT_UD_GUEST_<MARKER> file=... ...
+phase2_try_ud_guest() {
+    local repo=$1
+    local fe_out=$2
+    local sys=$3
+    local target=$4
+    local mc=$5
+    local mrlib=$6
+    local loader=$7
+    local ud_w out evid report
+    local compile_triple
+
+    ud_w=$(phase2_ud_guest_worktree "$repo")
+    report=$(phase2_ud_guest_refuse_unsuffixed "$ud_w" || true)
+    case "$report" in
+        CANNOT_*) printf '%s\n' "$report"; return 1 ;;
+    esac
+    # foundation-macho guest_arch: compile macos15, link macos13. Source in a
+    # subshell so TRIPLE/ARCH do not clobber full/scripts/guest_arch.inc.
+    compile_triple=$(
+        # shellcheck disable=SC1091
+        . "$repo/foundation-macho/scripts/guest_arch.inc"
+        printf '%s\n' "${COMPILE_TRIPLE:-$target}"
+    )
+
+    mkdir -p "$ud_w/fe" "$ud_w/lib" "$ud_w/bin"
+
+    report=$(phase2_ud_guest_point_sysroot "$sys" "$ud_w" || true)
+    case "$report" in CANNOT_*) printf '%s\n' "$report"; return 1 ;; esac
+
+    report=$(phase2_ud_guest_stage_fe "$fe_out" "$ud_w" || true)
+    case "$report" in CANNOT_*) printf '%s\n' "$report"; return 1 ;; esac
+
+    report=$(phase2_ud_guest_ensure_fm_unimplemented \
+        "$fe_out" "$sys" "$target" "$repo" "$ud_w" || true)
+    case "$report" in CANNOT_*) printf '%s\n' "$report"; return 1 ;; esac
+
+    if ! phase2_ud_guest_compile_port "$ud_w" "$repo" "$sys" "$compile_triple" "$mc"; then
+        return 1
+    fi
+    if ! phase2_ud_guest_compile_runner "$ud_w" "$repo" "$sys" "$compile_triple" "$mc"; then
+        return 1
+    fi
+
+    report=$(phase2_ud_guest_ensure_swiftcompat "$repo" "$sys" "$ud_w" "$mrlib" "$loader" || true)
+    case "$report" in CANNOT_*) printf '%s\n' "$report"; return 1 ;; esac
+
+    report=$(phase2_ud_guest_ensure_cftest "$ud_w" "$repo" || true)
+    case "$report" in CANNOT_*) printf '%s\n' "$report"; return 1 ;; esac
+
+    out=$ud_w/bin/ud_guest
+    if ! phase2_ud_guest_link "$repo" "$ud_w" "$sys" "$out"; then
+        return 1
+    fi
+    evid=$ud_w/bin/ud_guest.otool.txt
+    phase2_ud_guest_write_otool_evidence "$out" "$evid"
+    if ! phase2_ud_guest_check_loads "$evid"; then
+        return 1
+    fi
+    printf 'OK bin=%s evid=%s linker=%s\n' "$out" "$evid" "$PHASE2_UD_GUEST_LINKER"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #23 merged (main `191d6dbd`). Operator rerun: substrate items are satisfied; rungs b/c stop only at `mrroot-fe-overlays-x86 CANNOT_X86_OVERLAYS_NOT_BUILT` (nine overlay dylibs, agent `bc-d35369cc`, not this PR). Rung a had no owner:

```
ENV_PREPARE rung-a-ud_guest CANNOT_UD_GUEST_BINARY reason=no x86_64 ud_guest Mach-O. Committed linker is foundation-macho/scripts/link_ud_guest.sh …
Operator: stage CF+FE objects, link_ud_guest.sh, then re-run; or set UD_GUEST_BIN.
```

## What changed

phase2 item **`ud-guest-x86`** produces the x86_64 `#87` guest through foundation-macho's committed pipeline. It does not invent a second linker.

- Work tree is `scratch/ud-guest-x86_64` (never unsuffixed `scratch/ud-guest`).
- FE objects are **reused** from `build/full-x86_64/foundation` (same `build_fe.sh` / collections / os / cshims argv). Not compiled twice.
- Port + runner compile use `build_ud_score_guest.sh`'s argv (`COMPILE_TRIPLE` macos15, `-O -wmo`, `CFPreferencesMinimal`).
- Link is only `foundation-macho/scripts/link_ud_guest.sh` (macos13 `TRIPLE`, tbd-first `-L`).
- On success: `UD_GUEST_BIN=$W/scratch/ud-guest-x86_64/bin/ud_guest` for rung a, plus `ud_guest.otool.txt` (`MH_MAGIC_64 X86_64` and expected loads: libswiftCore, libswiftDarwin, libswift_StringProcessing, libswiftSynchronization, libswift_errno, libobjc, libSystem, libCFTest, libswiftcompat).
- Any piece that cannot be built is `CANNOT_UD_GUEST_<FILE> file=<basename>`. `libCFTest.dylib` has no committed x86 object recipe (`/work/cfobjc` is shell-history only) → `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib`. Provide `UD_CFTEST_DYLIB` when an x86 CF dylib exists.

Pipeline input differences vs #87 / `build_full.sh` (in `scripts/x86/PHASE2.md` item 9):

- `removefile_compat.o` is compiled by phase2 into essentials/ and is **not** a `link_ud_guest.sh` input.
- `uuid_compat.o` is a `build_full.sh` input and is **not** on the #87 link line.
- `fm_unimplemented.o` uses `build_full.sh`'s clang argv once, then is staged.

Rung a still needs the nine overlay dylibs **at load**. This PR delivers the binary and otool evidence so overlays landing do not need another PR.

Widget RUN-step / Dispatch `LD_PRELOAD` is untouched. `machorun/` is not edited.

## Operator

```bash
bash x86_stage_inputs_phase2.sh
```

Expect `ENV_PREPARE ud-guest-x86` either `cold-built bin=…/scratch/ud-guest-x86_64/bin/ud_guest` or a `CANNOT_UD_GUEST_* file=` naming the missing piece (on a tree without x86 CF objects that is `file=libCFTest.dylib`). Rung a then consumes `UD_GUEST_BIN`.

## Tests

- `bash scripts/x86/test_phase2.sh` — **223/223**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

