### PR TITLE
Onboarding FI: collections, os, and CShims on the swiftc search path

### DIFF
--- a/full/foundationinternationalization/build_foundation_internationalization.sh
+++ b/full/foundationinternationalization/build_foundation_internationalization.sh
@@ -19,6 +19,9 @@ LINK_SDK_VERSION=${LINK_SDK_VERSION:-$MIN_OS}
 APPLE_SWIFT_USER_OVERLAYS=${APPLE_SWIFT_USER_OVERLAYS:-}
 DYLIB_INSTALL_PREFIX=${DYLIB_INSTALL_PREFIX:-@rpath}
 FOUNDATION_ICU_JOBS=${FOUNDATION_ICU_JOBS:-8}
+COLLECTIONS=${COLLECTIONS:-}
+OSMOD=${OSMOD:-}
+CSHIMS=${CSHIMS:-}
 
 EXPECTED_FOUNDATION_COMMIT=c6793ef0c19c2cbaeba5a0e52078f129afc7dcfc
 EXPECTED_FOUNDATION_TREE=4651798679b98e27383ca3626434fb128f191486
@@ -61,6 +64,30 @@ done
     || die 'staged SDK/module/library/runtime roots are incomplete'
 [ -f "$STAGE/lib/libFoundationEssentials.dylib" ] \
     || die 'libFoundationEssentials.dylib must be linked first'
+for name in COLLECTIONS OSMOD CSHIMS; do
+    value=${!name}
+    [ -n "$value" ] || continue
+    case "$value" in /*) ;; *) die "$name path must be absolute: $value" ;; esac
+    [ -d "$value" ] || die "$name directory is missing: $value"
+done
+if [ -n "$COLLECTIONS" ]; then
+    for module in InternalCollectionsUtilities OrderedCollections _RopeModule; do
+        [ -f "$COLLECTIONS/$module.swiftmodule" ] && [ ! -L "$COLLECTIONS/$module.swiftmodule" ] \
+            && [ -f "$COLLECTIONS/$module.o" ] && [ ! -L "$COLLECTIONS/$module.o" ] \
+            || die "COLLECTIONS is missing $module.swiftmodule/.o: $COLLECTIONS"
+    done
+fi
+if [ -n "$OSMOD" ]; then
+    [ -f "$OSMOD/os.swiftmodule" ] && [ ! -L "$OSMOD/os.swiftmodule" ] \
+        && [ -f "$OSMOD/os.o" ] && [ ! -L "$OSMOD/os.o" ] \
+        || die "OSMOD is missing os.swiftmodule/.o: $OSMOD"
+fi
+if [ -n "$CSHIMS" ]; then
+    for object in platform_shims string_shims uuid; do
+        [ -f "$CSHIMS/$object.o" ] && [ ! -L "$CSHIMS/$object.o" ] \
+            || die "CSHIMS is missing $object.o: $CSHIMS"
+    done
+fi
 
 assert_checkout() {
     local checkout=$1 expected_commit=$2 expected_tree=$3 label=$4
@@ -313,6 +340,8 @@ mapfile -d '' -t INTL_SOURCES < <(
 )
 "${SWIFTC[@]}" -parse-as-library -package-name SwiftFoundation \
     -I "$STAGE/modules" \
+    ${COLLECTIONS:+-I "$COLLECTIONS"} \
+    ${OSMOD:+-I "$OSMOD"} \
     -Xcc -fmodule-map-file="$STAGE/include/FoundationICU/_foundation_unicode/module.modulemap" \
     -Xcc -I"$STAGE/include/FoundationICU" \
     -Xcc -fmodule-map-file="$STAGE/include/_FoundationCShims/module.modulemap" \
@@ -331,6 +360,13 @@ ld64.lld-18 -arch arm64 \
     -rpath @loader_path \
     -o "$STAGE/lib/libFoundationInternationalization.dylib" \
     "$INTL_WORK/FoundationInternationalization.o" \
+    ${COLLECTIONS:+"$COLLECTIONS/InternalCollectionsUtilities.o"} \
+    ${COLLECTIONS:+"$COLLECTIONS/OrderedCollections.o"} \
+    ${COLLECTIONS:+"$COLLECTIONS/_RopeModule.o"} \
+    ${OSMOD:+"$OSMOD/os.o"} \
+    ${CSHIMS:+"$CSHIMS/platform_shims.o"} \
+    ${CSHIMS:+"$CSHIMS/string_shims.o"} \
+    ${CSHIMS:+"$CSHIMS/uuid.o"} \
     -L"$STAGE/lib" -lFoundationEssentials -l_FoundationICU \
     -L"$RUNTIME_LIB" -L"$STAGE/sdk/usr/lib/swift" \
     -lswiftCore -lswiftObjectiveC -lswift_StringProcessing \

--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -507,6 +507,7 @@ done
 env SUPPORT_ROOT="$W" SWIFT_FOUNDATION="$SWIFT_FOUNDATION" \
     SWIFT_FOUNDATION_ICU="$SWIFT_FOUNDATION_ICU" STAGE="$FINTL_STAGE" \
     WORK="$FINTL_WORK" TARGET="$TARGET" MIN_OS=15.0 \
+    COLLECTIONS="$FE_COLLECTIONS" OSMOD="$FE_OS" CSHIMS="$FE_CSHIMS" \
     FOUNDATION_ICU_JOBS="${FOUNDATION_ICU_JOBS:-8}" \
     bash "$FOUNDATION_INTERNATIONALIZATION_BUILDER"
 [ -f "$PACKAGE/FoundationInternationalization.swiftmodule" ] && \
@@ -627,6 +628,7 @@ echo '== package ten reusable guest dylibs'
 "${LD[@]}" -dylib -dead_strip -ignore_auto_link \
     -install_name @rpath/libFoundation.dylib -rpath @loader_path \
     -o "$PACKAGE/libFoundation.dylib" "$OUT/foundation.o" "$OUT/corefoundation.o" \
+    "${FE_OBJECTS[@]}" \
     -L"$MRROOT/darwin/usr/lib" -L/usr/lib/swift -lswiftCore -lswiftObjectiveC \
     "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
     -L"$PACKAGE" -lFoundationEssentials -lFoundationInternationalization \

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -9,6 +9,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 BUILD = ROOT / "full/swiftui/build_focus_onboarding_guest.sh"
+FI_BUILDER = ROOT / "full/foundationinternationalization/build_foundation_internationalization.sh"
 HARNESS = ROOT / "full/swiftui/FocusOnboardingGuestMain.swift"
 UUID_PROBE = ROOT / "full/swiftui/FocusOnboardingUUIDProbe.c"
 UUID_COMPAT = ROOT / "full/foundation/uuid_compat.c"
@@ -51,6 +52,7 @@ def validate_foundation_runtime_contract(source: str) -> None:
 class FocusOnboardingGuestProofTests(unittest.TestCase):
     def test_build_script_has_valid_shell_syntax(self) -> None:
         subprocess.run(["bash", "-n", str(BUILD)], check=True)
+        subprocess.run(["bash", "-n", str(FI_BUILDER)], check=True)
 
     def test_exact_twelve_source_boundary_is_hash_pinned_and_direct(self) -> None:
         text = BUILD.read_text()
@@ -274,6 +276,49 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("libFoundationInternationalization.dylib", build)
         self.assertIn("-lFoundationInternationalization", build)
         self.assertIn("corefoundation_guest_sources.txt", build)
+
+    def test_fi_swiftc_gets_fe_collections_os_and_cshims_includes(self) -> None:
+        subprocess.run(["bash", "-n", str(FI_BUILDER)], check=True)
+        builder = FI_BUILDER.read_text()
+        build = BUILD.read_text()
+        swiftc = builder.split('"${SWIFTC[@]}" -parse-as-library', 1)[1].split(
+            "ld64.lld-18", 1
+        )[0]
+        ld = builder.split(
+            '-o "$STAGE/lib/libFoundationInternationalization.dylib"', 1
+        )[1].split("-L\"$STAGE/lib\"", 1)[0]
+        umbrella_ld = build.split(
+            '== package ten reusable guest dylibs', 1
+        )[1].split('libFoundation.dylib', 1)[1].split(
+            'for install_name in "${FOUNDATION_RUNTIME_INSTALL_NAMES[@]}"', 1
+        )[0]
+        self.assertIn('${COLLECTIONS:+-I "$COLLECTIONS"}', swiftc)
+        self.assertIn('${OSMOD:+-I "$OSMOD"}', swiftc)
+        self.assertIn(
+            '-Xcc -fmodule-map-file="$STAGE/include/_FoundationCShims/module.modulemap"',
+            swiftc,
+        )
+        self.assertIn('-Xcc -I"$STAGE/include/_FoundationCShims"', swiftc)
+        self.assertIn('COLLECTIONS="$FE_COLLECTIONS"', build)
+        self.assertIn('OSMOD="$FE_OS"', build)
+        self.assertIn('CSHIMS="$FE_CSHIMS"', build)
+        self.assertIn(
+            '${COLLECTIONS:+"$COLLECTIONS/InternalCollectionsUtilities.o"}', ld
+        )
+        self.assertIn('${COLLECTIONS:+"$COLLECTIONS/OrderedCollections.o"}', ld)
+        self.assertIn('${COLLECTIONS:+"$COLLECTIONS/_RopeModule.o"}', ld)
+        self.assertIn('${OSMOD:+"$OSMOD/os.o"}', ld)
+        self.assertIn('${CSHIMS:+"$CSHIMS/platform_shims.o"}', ld)
+        self.assertIn('${CSHIMS:+"$CSHIMS/string_shims.o"}', ld)
+        self.assertIn('${CSHIMS:+"$CSHIMS/uuid.o"}', ld)
+        self.assertIn('"${FE_OBJECTS[@]}"', umbrella_ld)
+        fe_flags = build.split("FE_FLAGS=(", 1)[1].split("FE_OBJECTS=(", 1)[0]
+        self.assertIn('-I "$FE_COLLECTIONS"', fe_flags)
+        self.assertIn('-I "$FE_OS"', fe_flags)
+        self.assertIn(
+            '-Xcc -fmodule-map-file="$SWIFT_FOUNDATION/Sources/_FoundationCShims/include/module.modulemap"',
+            fe_flags,
+        )
 
     def test_umbrella_compile_passes_opencombine_helpers_module_map(self) -> None:
         text = BUILD.read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Onboarding on the arm64 authority at `b1c3e259` now gets through prewarm, OpenCombine, Symbols, SwiftUI, and into `== build pinned FoundationInternationalization against the same sysroot`. ICU compiles (constexpr notes from `ualoc.cpp` only), then:

```
scratch/swift-foundation/Sources/FoundationInternationalization/Calendar/Calendar_ICU.swift:14:8: error: missing required modules: 'OrderedCollections', '_RopeModule', 'os'
```

The FI `swiftc` the gate composes only searched `$STAGE/modules` (the onboarding package, which has `FoundationEssentials.swiftmodule` and the CShims map). It did not put the pinned collections and `os` modules on that invocation. Those modules already exist from the FE build at `build/full/foundation/collections/{InternalCollectionsUtilities,OrderedCollections,_RopeModule}.swiftmodule` and `build/full/foundation/os/os.swiftmodule`.

The frameworks lane already flattens those families into `$STAGE/modules` via `copy_module_family`, so it does not hit this. Onboarding does not.

## Change

- The shared FI builder accepts optional `COLLECTIONS` / `OSMOD` / `CSHIMS` (same names as `build_fe.sh`). When set, the FI `swiftc` line gets `-I "$COLLECTIONS" -I "$OSMOD"` next to the existing CShims module map, and the FI dylib links the same `.o` files `build_full.sh` links for FE. Unset keeps the frameworks / true-iOS invocations byte-identical.
- The onboarding gate passes `COLLECTIONS="$FE_COLLECTIONS" OSMOD="$FE_OS" CSHIMS="$FE_CSHIMS"` into that builder, and links `"${FE_OBJECTS[@]}"` into `libFoundation.dylib`.
- `test_fi_swiftc_gets_fe_collections_os_and_cshims_includes` asserts those `-I` paths on the FI `swiftc` line, the gate's env wiring, and the matching link inputs.

## Operator rerun

Same gate, current main plus this commit:

```bash
full/swiftui/build_focus_onboarding_guest.sh <normalized-bundles-directory>
```

After FI compiles, next `==` lines are `== compile first-party CoreFoundation before the Foundation umbrella`, then `== compile the bounded Foundation umbrella after SwiftUI`, then `== FoundationGuest/UIKit notification identity compile proof`.

PASS marker: `FOCUS_ONBOARDING_MACHO_GUEST_OK sources=12 pages=2 touches=3 uuid=full telemetry=…`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

