### PR TITLE
Onboarding umbrella: helpers map on argv, project Dispatch module

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -204,6 +204,7 @@ validate_bundle "$WIDGET_INPUT" "$EXPECTED_WIDGET_FILES" \
 rm -rf -- "$OUT"
 mkdir -p "$PACKAGE/include/CPortableIO" "$PACKAGE/include/CSTBTrueType" \
     "$PACKAGE/include/CHostClock" "$PACKAGE/include/COpenCombineHelpers" \
+    "$PACKAGE/include/COpenDispatch" \
     "$PACKAGE/include/CQuartz" "$PACKAGE/include/CoreFoundation" \
     "$MODULE_CACHE" "$AUDIT" "$OUT/fonts"
 
@@ -302,6 +303,7 @@ cp -a "$W/full/foundation/include/COpenFoundationCore" \
     "$PACKAGE/include/COpenFoundationCore"
 cp "$OPENCOMBINE_HELPERS/include/COpenCombineHelpers.h" \
     "$OPENCOMBINE_HELPERS/include/module.modulemap" "$PACKAGE/include/COpenCombineHelpers/"
+cp -a "$W/full/dispatch/include/." "$PACKAGE/include/COpenDispatch/"
 # Darwin CoreFoundation clang module: the header comes from the Darwin sysroot
 # only. Never -I the host toolchain's lib/swift (that is the Linux overlay
 # that pulls /usr/lib/swift/CoreFoundation/CoreFoundation.h and setjmp.h).
@@ -328,8 +330,10 @@ LD=(ld64.lld-18 -arch "$ARCH" -platform_version macos 15.0 15.0
 PACKAGE_CINC=(-Xcc -I"$PACKAGE/include/CPortableIO"
     -Xcc -I"$PACKAGE/include/CSTBTrueType"
     -Xcc -I"$PACKAGE/include/CHostClock"
-    -Xcc -I"$PACKAGE/include/COpenCombineHelpers"
     -Xcc -fmodule-map-file="$PACKAGE/include/COpenCombineHelpers/module.modulemap"
+    -Xcc -I"$PACKAGE/include/COpenCombineHelpers"
+    -Xcc -fmodule-map-file="$PACKAGE/include/COpenDispatch/module.modulemap"
+    -Xcc -I"$PACKAGE/include/COpenDispatch"
     -Xcc -I"$PACKAGE/include/CQuartz"
     -Xcc -fmodule-map-file="$PACKAGE/include/COpenFoundationCore/module.modulemap"
     -Xcc -I"$PACKAGE/include/COpenFoundationCore"
@@ -537,12 +541,54 @@ done
     -emit-object -o "$OUT/corefoundation.o" \
     "${COREFOUNDATION_GUEST_SOURCES[@]}"
 
+echo '== compile the project Dispatch module before the Foundation umbrella'
+clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
+    -fvisibility=hidden -Wall -Wextra -Werror \
+    -I "$PACKAGE/include/COpenDispatch" \
+    -c "$W/full/dispatch/OpenDispatchBridge.c" \
+    -o "$OUT/open-dispatch-bridge.o"
+"${SWIFTC[@]}" -parse-as-library "${PACKAGE_CINC[@]}" \
+    -I "$PACKAGE" \
+    -module-name Dispatch -module-link-name Dispatch -emit-module \
+    -emit-module-path "$PACKAGE/Dispatch.swiftmodule" \
+    -emit-object -o "$OUT/dispatch.o" "$W/full/dispatch/Dispatch.swift"
+"${LD[@]}" -dylib -dead_strip -ignore_auto_link -undefined dynamic_lookup \
+    -install_name @rpath/libDispatch.dylib -rpath @loader_path \
+    -o "$PACKAGE/libDispatch.dylib" \
+    "$OUT/dispatch.o" "$OUT/open-dispatch-bridge.o" \
+    -L"$PACKAGE" -lOpenCombine \
+    -L"$MRROOT/darwin/usr/lib" -L/usr/lib/swift \
+    -lswiftCore \
+    "$SYS/usr/lib/swift/libswiftSynchronization.tbd" \
+    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
+    "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
+    -L/usr/lib -lSystem "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
+[ -f "$PACKAGE/Dispatch.swiftmodule" ] && [ ! -L "$PACKAGE/Dispatch.swiftmodule" ] \
+    || die 'project Dispatch swiftmodule is missing after build'
+[ -f "$PACKAGE/libDispatch.dylib" ] && [ ! -L "$PACKAGE/libDispatch.dylib" ] \
+    || die 'libDispatch.dylib is missing after build'
+
 echo '== compile the bounded Foundation umbrella after SwiftUI'
-"${SWIFTC[@]}" -parse-as-library "${PACKAGE_CINC[@]}" "${FE_FLAGS[@]}" \
-    -I "$PACKAGE" -module-name Foundation \
-    -emit-module -emit-module-path "$PACKAGE/Foundation.swiftmodule" \
-    -emit-object -o "$OUT/foundation.o" \
-    "${FOUNDATION_GUEST_SOURCES[@]}"
+[ -f "$PACKAGE/include/COpenCombineHelpers/module.modulemap" ] && \
+    [ ! -L "$PACKAGE/include/COpenCombineHelpers/module.modulemap" ] \
+    && [ -f "$PACKAGE/include/COpenCombineHelpers/COpenCombineHelpers.h" ] && \
+    [ ! -L "$PACKAGE/include/COpenCombineHelpers/COpenCombineHelpers.h" ] \
+    || die 'packaged COpenCombineHelpers module map is missing from PACKAGE/include'
+umbrella_swiftc=(
+    "${SWIFTC[@]}" -parse-as-library "${PACKAGE_CINC[@]}" "${FE_FLAGS[@]}"
+    -Xcc -fmodule-map-file="$PACKAGE/include/COpenCombineHelpers/module.modulemap"
+    -Xcc -I"$PACKAGE/include/COpenCombineHelpers"
+    -I "$PACKAGE"
+    -module-name Foundation
+    -emit-module -emit-module-path "$PACKAGE/Foundation.swiftmodule"
+    -emit-object -o "$OUT/foundation.o"
+)
+{
+    printf 'umbrella-swiftc'
+    printf ' %q' "${umbrella_swiftc[@]}"
+    printf '\n'
+}
+"${umbrella_swiftc[@]}" "${FOUNDATION_GUEST_SOURCES[@]}"
 llvm-nm-18 -u -j "$OUT/foundation.o" | LC_ALL=C sort -u \
     > "$AUDIT/foundation-undefined-symbols.txt"
 foundation_string_processing_undefineds=$(awk \
@@ -632,7 +678,7 @@ echo '== package ten reusable guest dylibs'
     -L"$MRROOT/darwin/usr/lib" -L/usr/lib/swift -lswiftCore -lswiftObjectiveC \
     "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
     -L"$PACKAGE" -lFoundationEssentials -lFoundationInternationalization \
-    -lOpenUIKit -lCombine -lOpenCombine \
+    -lDispatch -lOpenUIKit -lCombine -lOpenCombine \
     -L"$SYS/usr/lib/swift" "${FOUNDATION_RUNTIME_LINK_FLAGS[@]}" \
     -L/usr/lib -lSystem -lobjc "$MRROOT/darwin/usr/lib/libquartz.dylib" \
     "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
@@ -685,7 +731,7 @@ clang-18 -target "$TARGET" -isysroot "$SYS" -O2 \
     "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
 
 for dylib in FoundationEssentials OpenCoreGraphics OpenUIKit Foundation \
-    FoundationInternationalization OpenCombine Combine Symbols SwiftUI Widget \
+    FoundationInternationalization Dispatch OpenCombine Combine Symbols SwiftUI Widget \
     Onboarding; do
     llvm-otool-18 -hv "$PACKAGE/lib$dylib.dylib" \
         | grep -Eq "MH_MAGIC_64[[:space:]]+${OTOOL_CPU}.*[[:space:]]DYLIB" \
@@ -704,6 +750,26 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     > "$AUDIT/runtime-closure.manifest"
 
 echo '== run exact Focus interaction path on Linux/machorun'
+echo '== build Linux Dispatch host bridge'
+HOST_BRIDGE_DIR=$OUT/host
+DISPATCH_HOST=$HOST_BRIDGE_DIR/libOpenDispatchHost.so
+EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST
+host_bridge_args=(
+    --repo "$W"
+    --host-dir "$HOST_BRIDGE_DIR"
+    --work-dir "$OUT/host-work"
+    --attestation-dir "$AUDIT"
+    --ledger-style focus-onboarding
+    --refuse-prefix 'focus_onboarding_guest: '
+)
+if [ "$(uname -m)" = aarch64 ] || [ "$(uname -m)" = arm64 ]; then
+    host_bridge_args+=(--host-abi ELF64-AArch64)
+else
+    host_bridge_args+=(--skip-runtime-pin --host-abi "ELF64-$(uname -m)")
+fi
+bash "$W/full/dispatch/build_host_bridge.sh" "${host_bridge_args[@]}"
+[ -f "$DISPATCH_HOST" ] && [ ! -L "$DISPATCH_HOST" ] \
+    || die "Linux Dispatch host helper is missing: $DISPATCH_HOST"
 if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
     echo "focus_onboarding_guest: compile/link may proceed on this VM; execution of arm64 guests cannot" >&2
     bash "${W:-$(git rev-parse --show-toplevel)}/.cursor/refuse-arm64-execution.sh" \
@@ -711,6 +777,8 @@ if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm
 fi
 (
     cd "$OUT"
+    LD_LIBRARY_PATH="$HOST_BRIDGE_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}" \
     MACHORUN_ROOT="$MRROOT" "$MRROOT/machorun" ./focus_onboarding_guest \
         "$OUT/Focus_Onboarding.bundle" \
         "$OUT/Focus_Widget.bundle" \
@@ -742,7 +810,7 @@ validate_bundle "$RESOURCE_INPUT/Focus_Widget.bundle" "$EXPECTED_WIDGET_FILES" \
     printf 'widget-bundle-accessor\t%s\n' \
         "$(hash_file "$W/full/swiftui/FocusWidgetBundle.generated.swift")"
     for dylib in FoundationEssentials OpenCoreGraphics OpenUIKit Foundation \
-        OpenCombine Combine Symbols SwiftUI Widget Onboarding; do
+        Dispatch OpenCombine Combine Symbols SwiftUI Widget Onboarding; do
         printf 'lib%s\t%s\n' "$dylib" "$(hash_file "$PACKAGE/lib$dylib.dylib")"
     done
     printf 'onboarding-resources\t%s\n' "$(tree_digest "$OUT/Focus_Onboarding.bundle")"

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -323,15 +323,66 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
     def test_umbrella_compile_passes_opencombine_helpers_module_map(self) -> None:
         text = BUILD.read_text()
         self.assertIn(
-            '-Xcc -fmodule-map-file="$PACKAGE/include/COpenCombineHelpers/module.modulemap"',
+            'cp "$OPENCOMBINE_HELPERS/include/COpenCombineHelpers.h"',
             text,
         )
-        self.assertIn('-Xcc -I"$PACKAGE/include/COpenCombineHelpers"', text)
+        self.assertIn(
+            '"$OPENCOMBINE_HELPERS/include/module.modulemap" '
+            '"$PACKAGE/include/COpenCombineHelpers/"',
+            text,
+        )
+        self.assertIn(
+            'packaged COpenCombineHelpers module map is missing from PACKAGE/include',
+            text,
+        )
         umbrella = text.split(
             "== compile the bounded Foundation umbrella after SwiftUI", 1
         )[1].split("== FoundationGuest/UIKit notification identity compile proof", 1)[0]
+        self.assertIn('umbrella_swiftc=(', umbrella)
+        self.assertIn('printf \'umbrella-swiftc\'', umbrella)
+        self.assertIn('printf \' %q\' "${umbrella_swiftc[@]}"', umbrella)
+        self.assertIn('"${umbrella_swiftc[@]}"', umbrella)
         self.assertIn('"${PACKAGE_CINC[@]}"', umbrella)
-        self.assertIn('"${SWIFTC[@]}"', umbrella)
+        self.assertIn(
+            '-Xcc -fmodule-map-file="$PACKAGE/include/COpenCombineHelpers/module.modulemap"',
+            umbrella,
+        )
+        self.assertIn('-Xcc -I"$PACKAGE/include/COpenCombineHelpers"', umbrella)
+        package_cinc = text.split("PACKAGE_CINC=(", 1)[1].split("FE_OUT=", 1)[0]
+        self.assertIn(
+            '-Xcc -fmodule-map-file="$PACKAGE/include/COpenCombineHelpers/module.modulemap"',
+            package_cinc,
+        )
+        self.assertIn('-Xcc -I"$PACKAGE/include/COpenCombineHelpers"', package_cinc)
+
+    def test_umbrella_imports_project_dispatch_not_sysroot(self) -> None:
+        text = BUILD.read_text()
+        self.assertNotIn("-disable-implicit-swift-module-map", text)
+        self.assertNotIn("SWIFT_FORCE_MODULE_LOADING", text)
+        dispatch = text.split(
+            "== compile the project Dispatch module before the Foundation umbrella", 1
+        )[1].split("== compile the bounded Foundation umbrella after SwiftUI", 1)[0]
+        umbrella = text.split(
+            "== compile the bounded Foundation umbrella after SwiftUI", 1
+        )[1].split("== FoundationGuest/UIKit notification identity compile proof", 1)[0]
+        self.assertIn('"$W/full/dispatch/Dispatch.swift"', dispatch)
+        self.assertIn('"$W/full/dispatch/OpenDispatchBridge.c"', dispatch)
+        self.assertIn('-module-name Dispatch', dispatch)
+        self.assertIn('-emit-module-path "$PACKAGE/Dispatch.swiftmodule"', dispatch)
+        self.assertIn('-I "$PACKAGE"', dispatch)
+        self.assertNotIn("-I \"$SYS/usr/lib/swift\"", dispatch)
+        self.assertNotIn("-I$SYS/usr/lib/swift", dispatch)
+        self.assertNotIn("-I \"$SYS/usr/lib/swift\"", umbrella)
+        self.assertNotIn("-I$SYS/usr/lib/swift", umbrella)
+        self.assertIn('-I "$PACKAGE"', umbrella)
+        package_index = umbrella.index('-I "$PACKAGE"')
+        sys_index = umbrella.find("$SYS/usr/lib/swift")
+        if sys_index != -1:
+            self.assertLess(package_index, sys_index)
+        self.assertIn("project Dispatch swiftmodule is missing after build", dispatch)
+        swiftc = text.split("SWIFTC=(", 1)[1].split("LD=(", 1)[0]
+        self.assertNotIn("-I \"$SYS/usr/lib/swift\"", swiftc)
+        self.assertNotIn("-I$SYS/usr/lib/swift", swiftc)
 
     def test_darwin_compiles_do_not_include_host_toolchain_swift(self) -> None:
         text = BUILD.read_text()

--- a/scripts/env/ledger.py
+++ b/scripts/env/ledger.py
@@ -42,6 +42,15 @@ STYLES: dict[str, dict[str, str]] = {
         "tree": "{label} tree {actual}, expected {expected}",
         "dirty": "{label} checkout is dirty: {status}",
     },
+    "focus-onboarding": {
+        "prefix": "focus_onboarding_guest: ",
+        "missing": "missing regular {label}: {path}",
+        "mismatch": "{label} drifted: {actual}",
+        "not_git": "{label} is not a Git checkout: {repo}",
+        "commit": "{label} commit {actual}, expected {expected}",
+        "tree": "{label} tree {actual}, expected {expected}",
+        "dirty": "{label} checkout is dirty: {status}",
+    },
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Onboarding on the arm64 authority at `2b06a71c` gets through FI and first-party CoreFoundation, then the bounded Foundation umbrella fails with:

```
<unknown>:0: error: missing required module 'COpenCombineHelpers'   (x2)
full/appshim/FoundationGuest.swift:9:19: error: failed to build module 'Dispatch'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 6.2.1 …', while this compiler is 'Swift version 6.2.4 …')
```

COpenCombineHelpers was only named inside `PACKAGE_CINC`; the umbrella argv and the packaged `PACKAGE/include` copy were not fail-closed. `@_exported import Dispatch` resolved to the sysroot's Apple 6.2.1 `Dispatch.swiftinterface`. The project does not use that overlay.

## Change

- Copy COpenCombineHelpers into `$PACKAGE/include`, put `-Xcc -fmodule-map-file="$PACKAGE/include/COpenCombineHelpers/module.modulemap" -Xcc -I"$PACKAGE/include/COpenCombineHelpers"` on the umbrella argv itself (and still via `PACKAGE_CINC`), refuse if the map is missing, and print `umbrella-swiftc` with `%q` so the operator can see the invocation.
- Compile `full/dispatch/Dispatch.swift` with the same 6.2.4 toolchain into `$PACKAGE/Dispatch.swiftmodule` (plus the OpenDispatch C bridge / `libDispatch.dylib`), before the umbrella. The umbrella keeps `-I "$PACKAGE"` and does not put `-I $SYS/usr/lib/swift` ahead of it. The SDK version check stays enabled.
- Preload `full/dispatch/build_host_bridge.sh` for the Linux run, same shared helper the widget gate uses.

## Tests

- `test_umbrella_compile_passes_opencombine_helpers_module_map` — helpers map on the umbrella argv, packaged under `PACKAGE/include`, argv printed.
- `test_umbrella_imports_project_dispatch_not_sysroot` — Dispatch module path is `$PACKAGE/Dispatch.swiftmodule` from `full/dispatch/Dispatch.swift`; `-I $SYS/usr/lib/swift` is not ahead of `-I "$PACKAGE"`.

## Operator rerun

Same gate, current main plus this commit:

```bash
full/swiftui/build_focus_onboarding_guest.sh <normalized-bundles-directory>
```

After CoreFoundation, next `==` lines are `== compile the project Dispatch module before the Foundation umbrella`, then `== compile the bounded Foundation umbrella after SwiftUI`. The log should include a `umbrella-swiftc` argv line. PASS marker: `FOCUS_ONBOARDING_MACHO_GUEST_OK sources=12 pages=2 touches=3 uuid=full telemetry=…`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

