### PR TITLE
phase2: x86 mrroot layout-complete before build_full

### DIFF
--- a/full/dispatch/swift_linux_lib.inc
+++ b/full/dispatch/swift_linux_lib.inc
@@ -8,22 +8,33 @@
 #   /usr/lib/swift/linux
 #
 # Closed host-runtime set is the same list full/scripts/build_full.sh stages
-# from scratch/mrroot[-x86_64]/host/. Do not add names here without an ABI
-# decision in build_full.sh.
+# from scratch/mrroot[-x86_64]/host/. libdispatch.so and libBlocksRuntime.so
+# are toolchain copies. The four Open* names are project-built ELF helpers
+# (not toolchain copies, never arm64 ELF). Do not add names here without an
+# ABI decision in build_full.sh.
 
 if [ -n "${OPENUIKIT_SWIFT_LINUX_LIB_INC:-}" ]; then
     return 0 2>/dev/null || true
 fi
 OPENUIKIT_SWIFT_LINUX_LIB_INC=1
 
-openuikit_host_runtime_files() {
+openuikit_host_runtime_toolchain_files() {
     printf '%s\n' \
         libdispatch.so \
-        libBlocksRuntime.so \
+        libBlocksRuntime.so
+}
+
+openuikit_host_runtime_built_files() {
+    printf '%s\n' \
         libOpenDispatchHost.so \
         libOpenFoundationInternationalizationHost.so \
         libOpenURLTransportHost.so \
         libOpenRelativeTimeHost.so
+}
+
+openuikit_host_runtime_files() {
+    openuikit_host_runtime_toolchain_files
+    openuikit_host_runtime_built_files
 }
 
 # Print the directory that contains libdispatch.so for the host Swift runtime.

--- a/full/foundationinternationalization/build_foundation_internationalization.sh
+++ b/full/foundationinternationalization/build_foundation_internationalization.sh
@@ -226,10 +226,10 @@ ld64.lld-18 -arch arm64 \
     "$INTL_WORK/open-foundation-internationalization-bridge.o"
 
 INTL_HOST=$STAGE/guest-root/host/libOpenFoundationInternationalizationHost.so
-clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-    -I "$COMPAT_INCLUDE" -shared \
-    "$SUPPORT_ROOT/full/foundationinternationalization/OpenFoundationInternationalizationHost.c" \
-    -o "$INTL_HOST"
+bash "$SUPPORT_ROOT/full/foundationinternationalization/build_host_helper.sh" \
+    --repo "$SUPPORT_ROOT" \
+    --host-dir "$STAGE/guest-root/host" \
+    --include-dir "$COMPAT_INCLUDE"
 clang-18 -std=c11 -O2 -Wall -Wextra -Werror -I "$COMPAT_INCLUDE" \
     "$SUPPORT_ROOT/full/foundationinternationalization/OpenFoundationInternationalizationHost.c" \
     "$SUPPORT_ROOT/full/foundationinternationalization/OpenFoundationInternationalizationHostTests.c" \

--- a/full/foundationinternationalization/build_host_helper.sh
+++ b/full/foundationinternationalization/build_host_helper.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Build Linux libOpenFoundationInternationalizationHost.so.
+# Clang flags stay byte-identical to the host -shared recipe in
+# full/foundationinternationalization/build_foundation_internationalization.sh
+# (COMPAT_INCLUDE). Darwin dylib, host tests, and attestation stay there.
+
+set -euo pipefail
+
+W=''
+HOST_DIR=''
+INCLUDE_DIR=''
+
+usage() {
+    echo "usage: build_host_helper.sh --repo ROOT --host-dir DIR [--include-dir DIR]" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)
+            [ "$#" -ge 2 ] || usage
+            W=$2; shift 2 ;;
+        --host-dir)
+            [ "$#" -ge 2 ] || usage
+            HOST_DIR=$2; shift 2 ;;
+        --include-dir)
+            [ "$#" -ge 2 ] || usage
+            INCLUDE_DIR=$2; shift 2 ;;
+        -h|--help)
+            usage ;;
+        *)
+            echo "build_host_helper.sh: unknown option $1" >&2
+            usage ;;
+    esac
+done
+
+[ -n "$W" ] && [ -n "$HOST_DIR" ] || usage
+[ -n "$INCLUDE_DIR" ] || INCLUDE_DIR=$W/full/foundationinternationalization/include
+
+mkdir -p "$HOST_DIR"
+clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
+    -I "$INCLUDE_DIR" -shared \
+    "$W/full/foundationinternationalization/OpenFoundationInternationalizationHost.c" \
+    -o "$HOST_DIR/libOpenFoundationInternationalizationHost.so"

--- a/full/frameworks/build_core_guest_package.sh
+++ b/full/frameworks/build_core_guest_package.sh
@@ -2256,10 +2256,10 @@ clang-18 -target "$TARGET" -isysroot "$STAGE/sdk" -std=c11 -O2 \
 "${LD[@]}" -dylib -dead_strip -undefined dynamic_lookup \
     -install_name /usr/lib/libOpenURLTransport.dylib \
     -o "$URL_TRANSPORT_DARWIN" "$WORK/open-url-transport-bridge.o"
-clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-    -I "$STAGE/include/COpenURLTransport" -shared \
-    "$W/full/urltransport/OpenURLTransportHost.c" \
-    -o "$URL_TRANSPORT_HOST" -lcurl -pthread
+bash "$W/full/urltransport/build_host_helper.sh" \
+    --repo "$W" \
+    --host-dir "$RUNTIME/host" \
+    --include-dir "$STAGE/include/COpenURLTransport"
 clang-18 -std=c11 -O2 -Wall -Wextra -Werror \
     -I "$STAGE/include/COpenURLTransport" \
     "$W/full/urltransport/OpenURLTransportHost.c" \
@@ -2375,10 +2375,10 @@ clang-18 -target "$TARGET" -isysroot "$STAGE/sdk" -std=c11 -O2 \
 "${LD[@]}" -dylib -dead_strip -undefined dynamic_lookup \
     -install_name /usr/lib/libOpenRelativeTime.dylib \
     -o "$RELATIVE_TIME_DARWIN" "$WORK/open-relative-time-bridge.o"
-clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-    -I "$STAGE/include/COpenRelativeTime" -shared \
-    "$W/full/relativetime/OpenRelativeTimeHost.c" \
-    -o "$RELATIVE_TIME_HOST" -licui18n -licuuc -lm
+bash "$W/full/relativetime/build_host_helper.sh" \
+    --repo "$W" \
+    --host-dir "$RUNTIME/host" \
+    --include-dir "$STAGE/include/COpenRelativeTime"
 clang-18 -std=c11 -O2 -Wall -Wextra -Werror \
     -I "$STAGE/include/COpenRelativeTime" \
     "$W/full/relativetime/OpenRelativeTimeHost.c" \

--- a/full/relativetime/build_host_helper.sh
+++ b/full/relativetime/build_host_helper.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build Linux libOpenRelativeTimeHost.so.
+# Clang flags stay byte-identical to the host -shared recipe in
+# full/frameworks/build_core_guest_package.sh and
+# full/xcodeplan/build_true_ios_platform_frameworks.sh. Darwin dylib,
+# host tests, and attestation stay in those lanes.
+
+set -euo pipefail
+
+W=''
+HOST_DIR=''
+INCLUDE_DIR=''
+
+usage() {
+    echo "usage: build_host_helper.sh --repo ROOT --host-dir DIR [--include-dir DIR]" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)
+            [ "$#" -ge 2 ] || usage
+            W=$2; shift 2 ;;
+        --host-dir)
+            [ "$#" -ge 2 ] || usage
+            HOST_DIR=$2; shift 2 ;;
+        --include-dir)
+            [ "$#" -ge 2 ] || usage
+            INCLUDE_DIR=$2; shift 2 ;;
+        -h|--help)
+            usage ;;
+        *)
+            echo "build_host_helper.sh: unknown option $1" >&2
+            usage ;;
+    esac
+done
+
+[ -n "$W" ] && [ -n "$HOST_DIR" ] || usage
+[ -n "$INCLUDE_DIR" ] || INCLUDE_DIR=$W/full/relativetime/include
+
+mkdir -p "$HOST_DIR"
+clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
+    -I "$INCLUDE_DIR" -shared \
+    "$W/full/relativetime/OpenRelativeTimeHost.c" \
+    -o "$HOST_DIR/libOpenRelativeTimeHost.so" -licui18n -licuuc -lm

--- a/full/urltransport/build_host_helper.sh
+++ b/full/urltransport/build_host_helper.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build Linux libOpenURLTransportHost.so.
+# Clang flags stay byte-identical to the host -shared recipe in
+# full/frameworks/build_core_guest_package.sh and
+# full/xcodeplan/build_true_ios_platform_frameworks.sh. Darwin dylib,
+# host tests, and attestation stay in those lanes.
+
+set -euo pipefail
+
+W=''
+HOST_DIR=''
+INCLUDE_DIR=''
+
+usage() {
+    echo "usage: build_host_helper.sh --repo ROOT --host-dir DIR [--include-dir DIR]" >&2
+    exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)
+            [ "$#" -ge 2 ] || usage
+            W=$2; shift 2 ;;
+        --host-dir)
+            [ "$#" -ge 2 ] || usage
+            HOST_DIR=$2; shift 2 ;;
+        --include-dir)
+            [ "$#" -ge 2 ] || usage
+            INCLUDE_DIR=$2; shift 2 ;;
+        -h|--help)
+            usage ;;
+        *)
+            echo "build_host_helper.sh: unknown option $1" >&2
+            usage ;;
+    esac
+done
+
+[ -n "$W" ] && [ -n "$HOST_DIR" ] || usage
+[ -n "$INCLUDE_DIR" ] || INCLUDE_DIR=$W/full/urltransport/include
+
+mkdir -p "$HOST_DIR"
+clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
+    -I "$INCLUDE_DIR" -shared \
+    "$W/full/urltransport/OpenURLTransportHost.c" \
+    -o "$HOST_DIR/libOpenURLTransportHost.so" -lcurl -pthread

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -215,16 +215,25 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    `bin/ud_guest.otool.txt` (`MH_MAGIC_64 X86_64` + expected loads). Overlay
    dylibs are not required at link time; rung a still needs them at load.
 10. `scratch/mrroot-x86_64/host/` is the Linux host runtime boundary
-    `build_full.sh` copies (`HOST_RUNTIME_FILES`: libdispatch.so,
-    libBlocksRuntime.so, and the four Open* helpers). phase2 resolves the
-    Swift linux lib dir the same way `full/dispatch/build_host_bridge.sh`
-    does (`SWIFT_TOOLCHAIN` → `/opt/swift624/usr` → `/opt/swift/usr` →
-    swiftc-on-PATH → `/usr`) via `full/dispatch/swift_linux_lib.inc`, copies
-    that closed set (dereference symlinks so they are regular files), records
-    sha256 in `host/SHA256SUMS`, and builds missing Open* helpers from the
-    committed C sources. An empty or partial `host/` is
+    `build_full.sh` copies (`HOST_RUNTIME_FILES`: libdispatch.so and
+    libBlocksRuntime.so from the Swift linux toolchain, **plus** four
+    project-built ELF helpers). phase2 resolves the Swift linux lib dir the
+    same way `full/dispatch/build_host_bridge.sh` does (`SWIFT_TOOLCHAIN` →
+    `/opt/swift624/usr` → `/opt/swift/usr` → swiftc-on-PATH → `/usr`) via
+    `full/dispatch/swift_linux_lib.inc`, copies **only** the two toolchain
+    names (dereference + require `ELF 64-bit LSB shared object, x86-64`;
+    arm64 ELF / Mach-O / text is dropped), then **builds** the four Open*
+    helpers for ELF x86_64 through the committed recipes — never copies
+    Open* from the linux dir or from an arm64 mrroot:
+    `full/dispatch/build_host_bridge.sh` → `libOpenDispatchHost.so`;
+    `full/foundationinternationalization/build_host_helper.sh` →
+    `libOpenFoundationInternationalizationHost.so`;
+    `full/urltransport/build_host_helper.sh` → `libOpenURLTransportHost.so`;
+    `full/relativetime/build_host_helper.sh` → `libOpenRelativeTimeHost.so`.
+    sha256 lands in `host/SHA256SUMS`. An empty or partial `host/` is
     `CANNOT_X86_HOST_RUNTIME missing=…` on item `mrroot-host-x86` **before**
-    rungs b/c invoke `build_full.sh`. Not a PR3 `CURSOR_ENV_CANNOT_*` marker.
+    rungs b/c invoke `build_full.sh`, and `missing=` names each file that
+    could not be copied or built. Not a PR3 `CURSOR_ENV_CANNOT_*` marker.
 
 ## Operator-staged Apple x86_64 overlays
 

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -692,13 +692,30 @@ phase2_stage_x86_base_mrroot() {
     if [ -f "$x86_core" ] && phase2_is_x86_macho "$x86_core"; then
         cp -f "$x86_core" "$dest/darwin/usr/lib/swift/libswiftCore.dylib"
     fi
-    # Host Linux boundary from the resolved Swift runtime dir (not a hardcoded
-    # /usr/lib/swift/linux). Incomplete host/ is CANNOT_X86_HOST_RUNTIME in
-    # phase2.sh, before build_full.sh runs.
-    phase2_stage_x86_host_runtime "$dest" >/dev/null || true
+    # Host Linux boundary: copy libdispatch.so / libBlocksRuntime.so from the
+    # resolved Swift runtime dir, then build the four Open* helpers as ELF
+    # x86_64. Incomplete host/ is CANNOT_X86_HOST_RUNTIME in phase2.sh.
+    phase2_stage_x86_host_runtime "$dest" "$PHASE2_REPO" >/dev/null || true
 }
 
-# Record sha256 of every regular file currently in dest/host/.
+# ELF 64-bit x86-64 shared object, regular file. Rejects arm64 ELF, Mach-O,
+# text fixtures, and symlinks (build_full.sh requires regular files).
+phase2_is_elf_x86_so() {
+    local f=$1
+    [ -f "$f" ] && [ ! -L "$f" ] || return 1
+    file -b "$f" | grep -q 'ELF 64-bit LSB shared object, x86-64'
+}
+
+phase2_drop_unless_elf_x86_so() {
+    local f=$1
+    if phase2_is_elf_x86_so "$f"; then
+        return 0
+    fi
+    rm -f "$f"
+    return 1
+}
+
+# Record sha256 of every staged ELF x86-64 host runtime file.
 phase2_record_host_runtime_sha256() {
     local dest=$1
     local host=$dest/host
@@ -708,17 +725,18 @@ phase2_record_host_runtime_sha256() {
         echo "# sha256 of staged host runtime files"
         while IFS= read -r name; do
             [ -n "$name" ] || continue
-            if [ -f "$host/$name" ] && [ ! -L "$host/$name" ]; then
+            if phase2_is_elf_x86_so "$host/$name"; then
                 sha256sum "$host/$name"
             fi
         done < <(openuikit_host_runtime_files)
     } > "$host/SHA256SUMS"
 }
 
-# Copy HOST_RUNTIME_FILES from the resolved Swift linux lib dir into dest/host.
-# Dereference symlinks so build_full.sh sees regular files. Prints OK or
-# MISSING=a,b,c. Optional $2 is the repo root: when set, missing Open* helpers
-# are built from the committed C sources (not invented).
+# Copy toolchain HOST_RUNTIME_FILES (libdispatch.so, libBlocksRuntime.so) from
+# the resolved Swift linux lib dir, then BUILD the four Open* helpers as ELF
+# x86_64 through the committed recipes. Never copies Open* (including arm64
+# ELF leftover in the linux dir). Optional $2 is the repo root. Prints OK or
+# MISSING=a,b,c naming each file that is not ELF x86-64.
 phase2_stage_x86_host_runtime() {
     local dest=$1 repo=${2:-}
     local host=$dest/host
@@ -731,8 +749,9 @@ phase2_stage_x86_host_runtime() {
         if [ -e "$src" ]; then
             cp -fL "$src" "$host/$name"
         fi
-    done < <(openuikit_host_runtime_files)
-    if [ -n "$repo" ] && [ -f "$repo/full/dispatch/build_host_bridge.sh" ]; then
+        phase2_drop_unless_elf_x86_so "$host/$name" || true
+    done < <(openuikit_host_runtime_toolchain_files)
+    if [ -n "$repo" ]; then
         phase2_build_x86_host_helpers "$dest" "$repo" || true
     fi
     phase2_record_host_runtime_sha256 "$dest"
@@ -745,14 +764,14 @@ phase2_stage_x86_host_runtime() {
     return 1
 }
 
-# Comma-separated HOST_RUNTIME_FILES absent from dest/host as regular files.
+# Comma-separated HOST_RUNTIME_FILES that are not ELF x86-64 regular files.
 phase2_host_runtime_missing() {
     local dest=$1
     local host=$dest/host
     local name missing=()
     while IFS= read -r name; do
         [ -n "$name" ] || continue
-        if [ ! -f "$host/$name" ] || [ -L "$host/$name" ]; then
+        if ! phase2_is_elf_x86_so "$host/$name"; then
             missing+=("$name")
         fi
     done < <(openuikit_host_runtime_files)
@@ -763,59 +782,73 @@ phase2_host_runtime_missing() {
     printf '%s\n' "${missing[*]}"
 }
 
-# Produce Open* helpers that are not in the Swift toolchain. libdispatch.so
-# and libBlocksRuntime.so must already be regular files in dest/host.
-# Uses committed clang argv / build_host_bridge.sh. Does not stub missing libs.
+# Build the four Open* helpers through committed scripts. Skip a helper that
+# is already ELF x86-64. Rebuild (do not keep) arm64 ELF / text / Mach-O.
+# libOpenDispatchHost.so uses full/dispatch/build_host_bridge.sh; the other
+# three use sibling build_host_helper.sh recipes. Does not stub missing libs.
 phase2_build_x86_host_helpers() {
     local dest=$1 repo=$2
     local host=$dest/host
     local work=$dest/host-work
     mkdir -p "$host" "$work"
-    if [ ! -f "$host/libdispatch.so" ] || [ -L "$host/libdispatch.so" ] \
-        || [ ! -f "$host/libBlocksRuntime.so" ] || [ -L "$host/libBlocksRuntime.so" ]; then
-        return 0
+
+    if ! phase2_is_elf_x86_so "$host/libOpenDispatchHost.so"; then
+        rm -f "$host/libOpenDispatchHost.so"
+        if phase2_is_elf_x86_so "$host/libdispatch.so" \
+            && phase2_is_elf_x86_so "$host/libBlocksRuntime.so" \
+            && [ -f "$repo/full/dispatch/build_host_bridge.sh" ]; then
+            set +e
+            bash "$repo/full/dispatch/build_host_bridge.sh" \
+                --repo "$repo" \
+                --host-dir "$host" \
+                --work-dir "$work" \
+                --skip-runtime-pin \
+                --host-abi "ELF64-$(uname -m)" \
+                --refuse-prefix 'phase2_host_runtime: ' \
+                >"$work/build_host_bridge.log" 2>&1
+            set -e
+        fi
+        phase2_drop_unless_elf_x86_so "$host/libOpenDispatchHost.so" || true
     fi
-    if [ ! -f "$host/libOpenDispatchHost.so" ] || [ -L "$host/libOpenDispatchHost.so" ]; then
-        set +e
-        bash "$repo/full/dispatch/build_host_bridge.sh" \
-            --repo "$repo" \
-            --host-dir "$host" \
-            --work-dir "$work" \
-            --skip-runtime-pin \
-            --host-abi "ELF64-$(uname -m)" \
-            --refuse-prefix 'phase2_host_runtime: ' \
-            >"$work/build_host_bridge.log" 2>&1
-        set -e
+
+    if ! phase2_is_elf_x86_so "$host/libOpenFoundationInternationalizationHost.so"; then
+        rm -f "$host/libOpenFoundationInternationalizationHost.so"
+        if [ -f "$repo/full/foundationinternationalization/build_host_helper.sh" ]; then
+            set +e
+            bash "$repo/full/foundationinternationalization/build_host_helper.sh" \
+                --repo "$repo" \
+                --host-dir "$host" \
+                >"$work/OpenFoundationInternationalizationHost.log" 2>&1
+            set -e
+        fi
+        phase2_drop_unless_elf_x86_so \
+            "$host/libOpenFoundationInternationalizationHost.so" || true
     fi
-    if [ ! -f "$host/libOpenFoundationInternationalizationHost.so" ] \
-        || [ -L "$host/libOpenFoundationInternationalizationHost.so" ]; then
-        set +e
-        clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-            -I "$repo/full/foundationinternationalization/include" -shared \
-            "$repo/full/foundationinternationalization/OpenFoundationInternationalizationHost.c" \
-            -o "$host/libOpenFoundationInternationalizationHost.so" \
-            >"$work/OpenFoundationInternationalizationHost.log" 2>&1
-        set -e
+
+    if ! phase2_is_elf_x86_so "$host/libOpenURLTransportHost.so"; then
+        rm -f "$host/libOpenURLTransportHost.so"
+        if [ -f "$repo/full/urltransport/build_host_helper.sh" ]; then
+            set +e
+            bash "$repo/full/urltransport/build_host_helper.sh" \
+                --repo "$repo" \
+                --host-dir "$host" \
+                >"$work/OpenURLTransportHost.log" 2>&1
+            set -e
+        fi
+        phase2_drop_unless_elf_x86_so "$host/libOpenURLTransportHost.so" || true
     fi
-    if [ ! -f "$host/libOpenURLTransportHost.so" ] \
-        || [ -L "$host/libOpenURLTransportHost.so" ]; then
-        set +e
-        clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-            -I "$repo/full/urltransport/include" -shared \
-            "$repo/full/urltransport/OpenURLTransportHost.c" \
-            -o "$host/libOpenURLTransportHost.so" -lcurl -pthread \
-            >"$work/OpenURLTransportHost.log" 2>&1
-        set -e
-    fi
-    if [ ! -f "$host/libOpenRelativeTimeHost.so" ] \
-        || [ -L "$host/libOpenRelativeTimeHost.so" ]; then
-        set +e
-        clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-            -I "$repo/full/relativetime/include" -shared \
-            "$repo/full/relativetime/OpenRelativeTimeHost.c" \
-            -o "$host/libOpenRelativeTimeHost.so" -licui18n -licuuc -lm \
-            >"$work/OpenRelativeTimeHost.log" 2>&1
-        set -e
+
+    if ! phase2_is_elf_x86_so "$host/libOpenRelativeTimeHost.so"; then
+        rm -f "$host/libOpenRelativeTimeHost.so"
+        if [ -f "$repo/full/relativetime/build_host_helper.sh" ]; then
+            set +e
+            bash "$repo/full/relativetime/build_host_helper.sh" \
+                --repo "$repo" \
+                --host-dir "$host" \
+                >"$work/OpenRelativeTimeHost.log" 2>&1
+            set -e
+        fi
+        phase2_drop_unless_elf_x86_so "$host/libOpenRelativeTimeHost.so" || true
     fi
 }
 

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -703,8 +703,10 @@ fi
 
 # Host Linux runtime boundary for build_full.sh. Always (re)stage, including
 # when mrroot-base-x86 is already satisfied: the operator tree had an empty
-# scratch/mrroot-x86_64/host/. Incomplete host/ is a named CANNOT before
-# rungs b/c invoke build_full.sh.
+# scratch/mrroot-x86_64/host/. Copies toolchain libdispatch.so /
+# libBlocksRuntime.so, then builds the four Open* helpers as ELF x86_64.
+# Incomplete host/ is a named CANNOT (each missing file) before rungs b/c
+# invoke build_full.sh.
 echo "==== mrroot-x86_64 host/ (Linux runtime boundary) ===="
 HOST_RUNTIME_OK=0
 if [ "$BASE_MRROOT" = "$ARM_BASE_MRROOT" ]; then

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -61,6 +61,9 @@ echo "== bash -n"
 for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
     "$ROOT/full/foundation/fe_sysroot_measurement.inc" \
     "$ROOT/full/dispatch/swift_linux_lib.inc" \
+    "$ROOT/full/urltransport/build_host_helper.sh" \
+    "$ROOT/full/relativetime/build_host_helper.sh" \
+    "$ROOT/full/foundationinternationalization/build_host_helper.sh" \
     "$ROOT/scripts/x86/ud_guest.inc"; do
     if bash -n "$s"; then
         ok "bash -n $(basename "$s")"
@@ -765,6 +768,39 @@ expect_not_grep 'src=/usr/lib/swift/linux/$name' "$COMMON" \
     "host stager no longer hardcodes /usr/lib/swift/linux"
 expect_not_grep 'X86_HOST_RUNTIME' "$ROOT/scripts/env/markers.py" \
     "CANNOT_X86_HOST_RUNTIME is not a PR3 CURSOR_ENV_CANNOT_* marker"
+expect_file "$ROOT/full/urltransport/build_host_helper.sh"
+expect_file "$ROOT/full/relativetime/build_host_helper.sh"
+expect_file "$ROOT/full/foundationinternationalization/build_host_helper.sh"
+expect_grep 'openuikit_host_runtime_toolchain_files' "$COMMON" \
+    "host stager copies only toolchain names"
+expect_grep 'openuikit_host_runtime_built_files' "$COMMON" \
+    "host stager distinguishes built Open* names"
+expect_grep 'urltransport/build_host_helper.sh' "$COMMON" \
+    "phase2 builds libOpenURLTransportHost.so via committed helper script"
+expect_grep 'relativetime/build_host_helper.sh' "$COMMON" \
+    "phase2 builds libOpenRelativeTimeHost.so via committed helper script"
+expect_grep 'foundationinternationalization/build_host_helper.sh' "$COMMON" \
+    "phase2 builds libOpenFoundationInternationalizationHost.so via committed helper script"
+expect_grep 'urltransport/build_host_helper.sh' \
+    "$ROOT/full/frameworks/build_core_guest_package.sh" \
+    "core-package host URL recipe is the shared helper script"
+expect_grep 'relativetime/build_host_helper.sh' \
+    "$ROOT/full/frameworks/build_core_guest_package.sh" \
+    "core-package host relative-time recipe is the shared helper script"
+expect_grep 'foundationinternationalization/build_host_helper.sh' \
+    "$ROOT/full/foundationinternationalization/build_foundation_internationalization.sh" \
+    "intl lane host recipe is the shared helper script"
+expect_grep -- '-lcurl -pthread' "$ROOT/full/urltransport/build_host_helper.sh" \
+    "URL host helper keeps committed -lcurl -pthread"
+expect_grep -- '-licui18n -licuuc -lm' \
+    "$ROOT/full/relativetime/build_host_helper.sh" \
+    "relative-time host helper keeps committed ICU libs"
+expect_not_grep 'OpenURLTransportHost.c' "$COMMON" \
+    "phase2 does not inline the URL host clang recipe"
+expect_not_grep 'OpenRelativeTimeHost.c' "$COMMON" \
+    "phase2 does not inline the relative-time host clang recipe"
+expect_not_grep 'OpenFoundationInternationalizationHost.c' "$COMMON" \
+    "phase2 does not inline the intl host clang recipe"
 # Host check must appear in phase2.sh before the widget/build_full invocation.
 awk '
     /cannot mrroot-host-x86 X86_HOST_RUNTIME/ { h=NR }
@@ -788,15 +824,27 @@ do
     expect_grep "$host_name" "$BUILD_FULL" "build_full.sh names $host_name"
 done
 
+OPEN_HOST_NAMES='libOpenDispatchHost.so,libOpenFoundationInternationalizationHost.so,libOpenURLTransportHost.so,libOpenRelativeTimeHost.so'
 saved_toolchain=${SWIFT_TOOLCHAIN:-}
+unset SWIFT_TOOLCHAIN
+real_linux=$(openuikit_resolve_swift_linux_lib)
+if [ ! -f "$real_linux/libdispatch.so" ] || [ ! -f "$real_linux/libBlocksRuntime.so" ]; then
+    die_test "no ELF toolchain libdispatch/libBlocksRuntime under $real_linux"
+fi
+
 HOST_FIX=$(mktemp -d /tmp/phase2-host-fix.XXXXXX)
 HOST_DEST=$(mktemp -d /tmp/phase2-host-dest.XXXXXX)
 mkdir -p "$HOST_FIX/opt/swift/usr/lib/swift/linux"
-for host_name in libdispatch.so libBlocksRuntime.so libOpenDispatchHost.so \
+cp -fL "$real_linux/libdispatch.so" "$HOST_FIX/opt/swift/usr/lib/swift/linux/libdispatch.so"
+cp -fL "$real_linux/libBlocksRuntime.so" \
+    "$HOST_FIX/opt/swift/usr/lib/swift/linux/libBlocksRuntime.so"
+# Dummy Open* in the linux dir must never be copied (including fake arm64 ELF).
+for host_name in libOpenDispatchHost.so \
     libOpenFoundationInternationalizationHost.so libOpenURLTransportHost.so \
     libOpenRelativeTimeHost.so
 do
-    printf 'fixture-%s\n' "$host_name" > "$HOST_FIX/opt/swift/usr/lib/swift/linux/$host_name"
+    printf 'not-x86-open-%s\n' "$host_name" \
+        > "$HOST_FIX/opt/swift/usr/lib/swift/linux/$host_name"
 done
 export SWIFT_TOOLCHAIN=$HOST_FIX/opt/swift/usr
 resolved=$(openuikit_resolve_swift_linux_lib)
@@ -805,32 +853,74 @@ if [ "$resolved" = "$HOST_FIX/opt/swift/usr/lib/swift/linux" ]; then
 else
     die_test "resolver got $resolved want $HOST_FIX/opt/swift/usr/lib/swift/linux"
 fi
-host_ok=$(phase2_stage_x86_host_runtime "$HOST_DEST" || true)
-if [ "$host_ok" = OK ]; then
+
+host_copy=$(phase2_stage_x86_host_runtime "$HOST_DEST" || true)
+expected_open_missing="MISSING=$OPEN_HOST_NAMES"
+if [ "$host_copy" = "$expected_open_missing" ] \
+    && phase2_is_elf_x86_so "$HOST_DEST/host/libdispatch.so" \
+    && phase2_is_elf_x86_so "$HOST_DEST/host/libBlocksRuntime.so"; then
+    open_copied=0
+    for host_name in libOpenDispatchHost.so \
+        libOpenFoundationInternationalizationHost.so libOpenURLTransportHost.so \
+        libOpenRelativeTimeHost.so
+    do
+        if [ -e "$HOST_DEST/host/$host_name" ]; then
+            open_copied=1
+        fi
+    done
+    if [ "$open_copied" -eq 0 ]; then
+        ok "without repo, toolchain copies are ELF x86-64 and each Open* is named missing"
+    else
+        die_test "Open* leaked into dest without a build: $(ls -l "$HOST_DEST/host")"
+    fi
+else
+    die_test "copy-only host stage expected $expected_open_missing got: $host_copy"
+fi
+
+# Build uses the real Swift linux dir for dispatch.h; the fixture has only .so files.
+if [ -z "${saved_toolchain}" ]; then
+    unset SWIFT_TOOLCHAIN
+else
+    export SWIFT_TOOLCHAIN=$saved_toolchain
+fi
+
+# Leftover non-x86 Open* in dest must be rebuilt, not kept.
+printf 'arm64-leftover\n' > "$HOST_DEST/host/libOpenURLTransportHost.so"
+host_built=$(phase2_stage_x86_host_runtime "$HOST_DEST" "$ROOT" || true)
+if [ "$host_built" = OK ]; then
     host_all=1
     for host_name in libdispatch.so libBlocksRuntime.so libOpenDispatchHost.so \
         libOpenFoundationInternationalizationHost.so libOpenURLTransportHost.so \
         libOpenRelativeTimeHost.so
     do
-        if [ ! -f "$HOST_DEST/host/$host_name" ] || [ -L "$HOST_DEST/host/$host_name" ]; then
+        if ! phase2_is_elf_x86_so "$HOST_DEST/host/$host_name"; then
             host_all=0
         fi
         if ! grep -q "$host_name" "$HOST_DEST/host/SHA256SUMS"; then
             host_all=0
         fi
         want=$(sha256sum "$HOST_DEST/host/$host_name" | awk '{print $1}')
-        got=$(awk -v n="$host_name" '$2 ~ n { print $1; exit }' "$HOST_DEST/host/SHA256SUMS")
+        got=$(grep -F "/$host_name" "$HOST_DEST/host/SHA256SUMS" | awk '{print $1}')
         if [ "$want" != "$got" ]; then
             host_all=0
         fi
     done
+    if grep -q arm64-leftover "$HOST_DEST/host/libOpenURLTransportHost.so"; then
+        host_all=0
+    fi
+    dummy_url=$(sha256sum "$HOST_FIX/opt/swift/usr/lib/swift/linux/libOpenURLTransportHost.so" \
+        | awk '{print $1}')
+    built_url=$(sha256sum "$HOST_DEST/host/libOpenURLTransportHost.so" | awk '{print $1}')
+    if [ "$dummy_url" = "$built_url" ]; then
+        host_all=0
+    fi
     if [ "$host_all" -eq 1 ]; then
-        ok "fixture /opt/swift/usr layout fills host/ with sha256 recorded"
+        ok "with repo, four Open* are built ELF x86-64 (not copied) and sha256 recorded"
     else
-        die_test "fixture host/ incomplete under $HOST_DEST/host: $(ls -l "$HOST_DEST/host")"
+        die_test "built host/ incomplete under $HOST_DEST/host: $(ls -l "$HOST_DEST/host"); $(file "$HOST_DEST/host"/*.so)"
     fi
 else
-    die_test "fixture host stage expected OK got: $host_ok"
+    die_test "repo host stage expected OK got: $host_built logs=$(ls "$HOST_DEST/host-work" 2>/dev/null); $(tail -n 20 "$HOST_DEST/host-work"/*.log 2>/dev/null)"
 fi
 
 EMPTY_FIX=$(mktemp -d /tmp/phase2-host-empty.XXXXXX)
@@ -840,16 +930,31 @@ export SWIFT_TOOLCHAIN=$EMPTY_FIX/opt/swift/usr
 host_miss=$(phase2_stage_x86_host_runtime "$EMPTY_DEST" || true)
 expected_host_missing="MISSING=$HOST_NAMES"
 if [ "$host_miss" = "$expected_host_missing" ]; then
-    ok "empty host/ is MISSING listing every HOST_RUNTIME_FILES name"
+    ok "empty toolchain without repo is MISSING listing every HOST_RUNTIME_FILES name"
 else
     die_test "empty host MISSING expected $expected_host_missing got: $host_miss"
 fi
+
+EMPTY_BUILD=$(mktemp -d /tmp/phase2-host-empty-build.XXXXXX)
+mkdir -p "$EMPTY_BUILD/host"
+host_empty_build=$(phase2_stage_x86_host_runtime "$EMPTY_BUILD" "$ROOT" || true)
+expected_dispatch_missing='MISSING=libdispatch.so,libBlocksRuntime.so,libOpenDispatchHost.so'
+if [ "$host_empty_build" = "$expected_dispatch_missing" ] \
+    && phase2_is_elf_x86_so \
+        "$EMPTY_BUILD/host/libOpenFoundationInternationalizationHost.so" \
+    && phase2_is_elf_x86_so "$EMPTY_BUILD/host/libOpenURLTransportHost.so" \
+    && phase2_is_elf_x86_so "$EMPTY_BUILD/host/libOpenRelativeTimeHost.so"; then
+    ok "empty toolchain with repo names each unbuilt helper (dispatch) and builds the other three"
+else
+    die_test "empty+repo expected $expected_dispatch_missing plus three ELF Open* got: $host_empty_build $(ls -l "$EMPTY_BUILD/host"); $(file "$EMPTY_BUILD/host"/* 2>/dev/null)"
+fi
+
 if [ -z "${saved_toolchain}" ]; then
     unset SWIFT_TOOLCHAIN
 else
     export SWIFT_TOOLCHAIN=$saved_toolchain
 fi
-rm -rf "$HOST_FIX" "$HOST_DEST" "$EMPTY_FIX" "$EMPTY_DEST"
+rm -rf "$HOST_FIX" "$HOST_DEST" "$EMPTY_FIX" "$EMPTY_DEST" "$EMPTY_BUILD"
 
 echo "== env-prepare with FULL_OUT_SUFFIX=-x86_64 never resolves unsuffixed arm64 trees"
 PREP_FIX=$(mktemp -d /tmp/phase2-prepare-suffix.XXXXXX)

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -773,8 +773,9 @@ expect_file "$ROOT/full/relativetime/build_host_helper.sh"
 expect_file "$ROOT/full/foundationinternationalization/build_host_helper.sh"
 expect_grep 'openuikit_host_runtime_toolchain_files' "$COMMON" \
     "host stager copies only toolchain names"
-expect_grep 'openuikit_host_runtime_built_files' "$COMMON" \
-    "host stager distinguishes built Open* names"
+expect_grep 'openuikit_host_runtime_built_files' \
+    "$ROOT/full/dispatch/swift_linux_lib.inc" \
+    "host runtime list splits built Open* names from toolchain copies"
 expect_grep 'urltransport/build_host_helper.sh' "$COMMON" \
     "phase2 builds libOpenURLTransportHost.so via committed helper script"
 expect_grep 'relativetime/build_host_helper.sh' "$COMMON" \
@@ -790,9 +791,9 @@ expect_grep 'relativetime/build_host_helper.sh' \
 expect_grep 'foundationinternationalization/build_host_helper.sh' \
     "$ROOT/full/foundationinternationalization/build_foundation_internationalization.sh" \
     "intl lane host recipe is the shared helper script"
-expect_grep -- '-lcurl -pthread' "$ROOT/full/urltransport/build_host_helper.sh" \
+expect_grep '-lcurl -pthread' "$ROOT/full/urltransport/build_host_helper.sh" \
     "URL host helper keeps committed -lcurl -pthread"
-expect_grep -- '-licui18n -licuuc -lm' \
+expect_grep '-licui18n -licuuc -lm' \
     "$ROOT/full/relativetime/build_host_helper.sh" \
     "relative-time host helper keeps committed ICU libs"
 expect_not_grep 'OpenURLTransportHost.c' "$COMMON" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #29 filled `scratch/mrroot-x86_64/host/`. Operator rerun at `86fb22ff` then stopped one step further on the **base** mrroot's Darwin content:

- rung c: `build_full: no regular staged Foundation loud-abort stub`
- rung b: `build_focus_widget_guest.sh` exit 2 right after `== staging Linux host runtime boundary` (same next file class)
- rung a: `UserDefaults.swift: missing required modules: 'OrderedCollections', '_RopeModule'`

`build_full.sh` reads a closed BASE set from `scratch/mrroot-x86_64`. Widget/reminder guests call `build_full` (they do not read the base root directly). That set must be filled through committed recipes **before** any rung runs `build_full`.

## What changed

Layout item `mrroot-layout-x86` (after host/ and FE overlays, before rungs b/c):

- Extensionless `Foundation` / `CoreFoundation` loud-abort stubs via `scripts/build_runtime_shims.sh STUBS_ONLY=1` for `x86_64-apple-macos` (never a copy of arm64 stubs).
- `libswiftcompat.dylib` via `swiftcore-macho/scripts/build_compat.sh`. Nine symbols that x86 `libSystem` already exports were deleted from `sdk/compat/swiftcompat.c` so the disjointness assertion can pass. Never copy arm64 `artifacts/libswiftcompat.dylib`.
- `libswift_Concurrency.dylib` / `libswiftObjectiveC.dylib` from the x86 overlay search. ObjectiveC is an Apple-SDK overlay; if the search finds no x86 Mach-O it is named in `missing=` rather than stubbed.
- Host ELF files and FE overlays are the same closed sets already gated by `mrroot-host-x86` / `mrroot-fe-overlays-x86`.

Incomplete inventory is `CANNOT_X86_MRROOT_LAYOUT missing=…` (leaf names). Not a PR3 `CURSOR_ENV_CANNOT_*` marker.

Rung a collections search path (same class as PR #28 FI `-I`):

- Stage `OrderedCollections` / `InternalCollectionsUtilities` / `_RopeModule` `.swiftmodule` next to the `.o` files.
- Put `-I $fe_out/collections` on the ud_guest port/runner argv in addition to the staged `$ud_w/fe/collections`.

Also includes the earlier host Open* work on this branch: the four Open* helpers are **built** as ELF x86-64 through committed recipes, not copied from the linux dir or an arm64 mrroot.

`machorun/` is not edited. Widget RUN-step / Dispatch `LD_PRELOAD` is untouched.

## Operator

```bash
bash x86_stage_inputs_phase2.sh
```

Expect `ENV_PREPARE mrroot-layout-x86 satisfied` (or `CANNOT_X86_MRROOT_LAYOUT missing=` listing each BASE/FE/host leaf still absent as x86 Mach-O / ELF) **before** `build_focus_widget_guest.sh` / `build_full.sh`. `libswiftObjectiveC.dylib` is an Apple-SDK overlay this Linux tree cannot build; if overlay search finds no x86 Mach-O it stays in `missing=`.

## Tests

- `bash scripts/x86/test_phase2.sh` — **312/312**
- Live: STUBS_ONLY Foundation/CoreFoundation are `MH_MAGIC_64 X86_64`; `build_compat.sh` emits 25-export x86 `libswiftcompat.dylib` disjoint from machorun userland (arm64 `artifacts/libswiftcompat.dylib` not copied); empty dest `MISSING=` includes `Foundation,CoreFoundation`; port argv has `-I $fe_out/collections`

[phase2 layout tests 312/312](https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_phase2_layout.txt)
[x86 loud-abort stubs, libswiftcompat, inventory, collections -I](https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmrroot_layout_x86.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

