### PR TITLE
Overlay sysroot modulemap header closure and Darwin -soname rewrite

### DIFF
--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -171,10 +171,14 @@ ninja target depends on `libswiftCore.so`, so treating gold as allowed hid
 `CANNOT_LINKER_LLD` if missing) and passes `-DSWIFT_USE_LINKER=lld` plus
 `-B` at that directory. `binutils` provides `ld.gold` on Ubuntu 24.04;
 it is the wrong linker for this graph. Ninja's link *rule* is still Linux
-(`-shared`); `scripts/clangxx_darwin_link.py` is `CMAKE_CXX_COMPILER` and
-rewrites Darwin-target `-shared` to `-dynamiclib -nostdlib -lSystem
--Wl,-undefined,dynamic_lookup` so `libswiftCore.so` is a Mach-O dylib at
-the ninja path. `link_macho_dylib.sh` writes the same bytes to `.dylib`
+(`-shared` plus `$SONAME_FLAG$SONAME` → `-Wl,-soname,libswiftX.so`);
+`scripts/clangxx_darwin_link.py` is `CMAKE_CXX_COMPILER` and rewrites
+Darwin-target `-shared` to `-dynamiclib -nostdlib -lSystem
+-Wl,-undefined,dynamic_lookup`, translating `-soname` / `-Xlinker -soname`
+to `-Wl,-install_name,/usr/lib/swift/libswiftX.dylib` and dropping
+`--as-needed` / `-rpath-link` so `ld64.lld` never sees those ELF flags.
+The shim always prints `clangxx_darwin_link: ninja argv:` and
+`rewritten argv:`. `link_macho_dylib.sh` writes the same bytes to `.dylib`
 and copies `.so`. A remaining ninja miss is `CANNOT_ELF_SO_LINUX_SHARED`,
 not an allowed gold wall.
 
@@ -201,7 +205,7 @@ if asked to merge slices).
 | `_Concurrency` | **yes** — staged Mach-O x86_64 | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing. Missing CMake `dispatch` node was host-vs-target; patch 8 skips that LINK_LIBRARIES append when `SWIFT_PRIMARY_VARIANT_SDK` ∈ `SWIFT_DARWIN_PLATFORMS`. |
 | `_StringProcessing` / `Synchronization` / `_RegexParser` | **yes** — staged | `CANNOT_FETCH_STRING_PROCESSING_SOURCE`; `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
 | Observation | **yes** — staged | `CANNOT_OVERLAY_TARGET_ABSENT` if cmake did not create it |
-| `swiftDarwin` | sysroot has Apple POSIX overlay headers **and** a Clang `Darwin` module. Staging is **input-keyed** (`.overlay-sysroot-inputs`, recipe `overlay-darwin.2`): recipe + sha of overlay-darwin `math.h` / `MacTypes.h` / `ConditionalMacros.h` / modulemap recipe + machorun `sys/proc.h`. Required *staged* headers (`math.h`, `sys/proc.h`, `MacTypes.h`, `ConditionalMacros.h`, `Darwin.modulemap`) must be on disk — input-sha MATCH is not presence (`CANNOT_OVERLAY_SYSROOT_HEADER`). A pre-existing `$W/sdk/MacOSX.sdk` whose stamp mismatches is **displaced** (`MacOSX.sdk.stale-<utc>`), never `rm -rf`'d, and restaged into a fresh `MacOSX.sdk.overlay-<id>`. `.tbd` stubs are copied into that dest from the still-live tree / machorun `gen_tbd` **before** displacement; empty `usr/lib/*.tbd` is `CANNOT_OVERLAY_SYSROOT_TBDS tree=… realpath=… searched=…`. `configure.sh` prints each required header's sha **before ninja** and refuses `CANNOT_OVERLAY_SYSROOT_MATH_H` / `PROC_H` if `math.h` lacks `fmaxl` or `sys/proc.h` lacks `extern_proc`. Darwin.o `-sdk` / `-isysroot` comes from `ninja -t commands`. FE sysroot `math.h` without `fmaxl` or missing CarbonHeaders files are repaired from the pins. | ninja failure is `OVERLAY swiftDarwin-macosx-* FAILED first_error=…`. Synchronization **depends on** `libswiftDarwin.so` (`FAILED dep=swiftDarwin`). `_Concurrency` / `_StringProcessing` / `_Builtin_float` do **not**; a failure there prints their own `first_error`. |
+| `swiftDarwin` | sysroot has Apple POSIX overlay headers **and** a Clang `Darwin` module. Staging is **input-keyed** (`.overlay-sysroot-inputs`, recipe `overlay-darwin.3`): recipe + sha of overlay-darwin `math.h` / `MacTypes.h` / `ConditionalMacros.h` / modulemap recipe + machorun `sys/proc.h`. Required *staged* headers (`math.h`, `sys/proc.h`, `MacTypes.h`, `ConditionalMacros.h`, `Darwin.modulemap`) must be on disk — input-sha MATCH is not presence (`CANNOT_OVERLAY_SYSROOT_HEADER`). Every `header "…"` in every staged `*.modulemap` must resolve under `usr/include` **before cmake** (`phase2_darwin_modulemap_missing_headers`, same check as phase2's maps-only restage). Missing names are filled from the FE sysroot / `full/sdk-gaps` (complex.h) / machorun / overlay-darwin pins; leftovers are `CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER missing=…`. A pre-existing `$W/sdk/MacOSX.sdk` whose stamp mismatches is **displaced** (`MacOSX.sdk.stale-<utc>`), never `rm -rf`'d, and restaged into a fresh `MacOSX.sdk.overlay-<id>`. `.tbd` stubs are copied into that dest from the still-live tree / machorun `gen_tbd` **before** displacement; empty `usr/lib/*.tbd` is `CANNOT_OVERLAY_SYSROOT_TBDS tree=… realpath=… searched=…`. `configure.sh` prints each required header's sha **before ninja** and refuses `CANNOT_OVERLAY_SYSROOT_MATH_H` / `PROC_H` if `math.h` lacks `fmaxl` or `sys/proc.h` lacks `extern_proc`. Darwin.o `-sdk` / `-isysroot` comes from `ninja -t commands`. The Darwin dylib link is printed as `overlay_link: ninja` plus `overlay_link: rewritten` (no `-soname`). FE sysroot `math.h` without `fmaxl` or missing CarbonHeaders files are repaired from the pins. | ninja failure is `OVERLAY swiftDarwin-macosx-* FAILED first_error=…`. Synchronization **depends on** `libswiftDarwin.so` (`FAILED dep=swiftDarwin`). `_Concurrency` / `_StringProcessing` / `_Builtin_float` do **not**; a failure there prints their own `first_error`. |
 | `_DarwinFoundation1/2/3`, `_errno`, `swiftObjectiveC` | **no** — not CMake targets on Linux (Apple SDK overlays) | `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` (do not invoke `ninja` on the missing name) |
 
 Ninja rc tests: `scripts/test_ninja_rc.sh` (gold is `CANNOT_LINKER_GOLD_REJECTED`, not allowed), `scripts/test_overlay_targets.sh`,
@@ -211,8 +215,11 @@ attempts the other in-tree overlays), `scripts/test_clangxx_darwin_link.sh`,
 ninja graph), `scripts/test_overlay_posix.sh`, `scripts/test_overlay_darwin.sh`,
 `scripts/test_overlay_sysroot_stamp.sh` (stale MacOSX.sdk is displaced, not
 overwritten; `.tbd` stubs copied into the fresh dest; listed header ABSENT
-is `CANNOT_OVERLAY_SYSROOT_HEADER` not stamp MATCH; refuse-before-cmake;
-ninja `-sdk`/`-isysroot`; Darwin-dep vs `first_error`), `scripts/test_darwin_overlay_syntax.sh`, `scripts/test_probe_machorun.sh`.
+is `CANNOT_OVERLAY_SYSROOT_HEADER` not stamp MATCH; modulemap `header "…"`
+closure via `phase2_darwin_modulemap_missing_headers` /
+`CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER`; refuse-before-cmake;
+ninja `-sdk`/`-isysroot`; Darwin dylib `-soname` ninja line vs rewritten
+`-install_name`; Darwin-dep vs `first_error`), `scripts/test_darwin_overlay_syntax.sh`, `scripts/test_probe_machorun.sh`.
 
 ### Darwin-target `dispatch` (patch 8)
 
@@ -276,10 +283,11 @@ through `-sdk`. Their scoreboard line is `FAILED first_error=<first
 compiler/ninja error>` so a Darwin.o wall is not mistaken for their own.
 
 Before the overlay ninja loop, `build_stdlib.sh` prints each required
-sysroot header's sha and the Darwin.o `-sdk`/`-isysroot` from
-`ninja -t commands`. Cross-built overlays remain the redistributable path;
-do not gate on operator-staged Apple copies under
-`scratch/apple-x86-overlays`.
+sysroot header's sha, the Darwin.o `-sdk`/`-isysroot` from
+`ninja -t commands`, and the Darwin dylib link as `overlay_link: ninja`
+plus `overlay_link: rewritten` (Linux `-soname` must be gone). Cross-built
+overlays remain the redistributable path; do not gate on operator-staged
+Apple copies under `scratch/apple-x86-overlays`.
 
 **Operator 16 vCPU must confirm:** same overlay command; ninja overlay
 targets do **not** all die on `-fuse-ld=gold`; `_Concurrency` /

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -109,6 +109,7 @@ run_stdlib_ninja() {
     overlay_copy_so_as_dylib "$B" "$SWIFTCORE_DARWIN_ARCH"
     python3 "$SCRIPT_DIR/lipo_single_arch.py" --rewrite-ninja "$B" || true
     overlay_print_isysroot_from_ninja "$B" "$SWIFTCORE_DARWIN_ARCH"
+    overlay_print_darwin_link_from_ninja "$B" "$SWIFTCORE_DARWIN_ARCH"
     if [ "${SWIFTCORE_NINJA_HARNESS:-0}" != 1 ]; then
       overlay_sysroot_print_headers "$W/sdk/MacOSX.sdk"
     fi

--- a/swiftcore-macho/scripts/clangxx_darwin_link.py
+++ b/swiftcore-macho/scripts/clangxx_darwin_link.py
@@ -10,10 +10,16 @@ leaves Darwin symbols undefined because the recipe never passed -lSystem.
 This wrapper leaves compile / host-ELF links alone. Darwin-target -shared /
 -dynamiclib invocations are rewritten to the recipe in link_macho_dylib.sh:
 -dynamiclib -fuse-ld=lld -nostdlib -lSystem -lc++ -Wl,-undefined,dynamic_lookup.
+
+Linux CMake concatenates $SONAME_FLAG$SONAME (`-Wl,-soname,` + `libswiftX.so`)
+or emits `-Xlinker -soname`. ld64.lld does not accept `-soname`; rewrite to
+`-install_name` and drop `--as-needed` / `-rpath-link`. Always print the
+ninja argv and the rewritten argv so the operator log shows both.
 """
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -45,7 +51,7 @@ def _is_compile(argv: list[str]) -> bool:
 
 def _target(argv: list[str]) -> str | None:
     for i, a in enumerate(argv):
-        if a == "-target" and i + 1 < len(argv):
+        if a in ("-target", "--target") and i + 1 < len(argv):
             return argv[i + 1]
         if a.startswith("--target="):
             return a.split("=", 1)[1]
@@ -53,16 +59,62 @@ def _target(argv: list[str]) -> str | None:
 
 
 def _is_shared(argv: list[str]) -> bool:
-    return "-shared" in argv or "-dynamiclib" in argv
+    return (
+        "-shared" in argv
+        or "-dynamiclib" in argv
+        or any(a == "-Wl,-dylib" or a.startswith("-Wl,-dylib,") for a in argv)
+    )
+
+
+def _is_darwin_target(argv: list[str]) -> bool:
+    t = _target(argv)
+    if t and APPLE_MARKER in t:
+        return True
+    for a in argv:
+        if APPLE_MARKER in a:
+            return True
+        if "MacOSX.sdk" in a:
+            return True
+        if a.startswith("-mmacosx-version-min"):
+            return True
+    return False
+
+
+def _soname_payload(tok: str) -> str | None:
+    """GNU soname flag → payload. Empty string means the value is the next argv."""
+    if tok in ("-soname", "-Wl,-soname", "--soname"):
+        return ""
+    for prefix in (
+        "-Wl,-soname,",
+        "-Wl,-soname=",
+        "-soname,",
+        "-soname=",
+        "--soname=",
+        "--soname,",
+    ):
+        if tok.startswith(prefix):
+            return tok[len(prefix) :]
+    return None
+
+
+def _has_soname_flag(argv: list[str]) -> bool:
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if _soname_payload(a) is not None:
+            return True
+        if a == "-Xlinker" and i + 1 < len(argv) and _soname_payload(argv[i + 1]) is not None:
+            return True
+        i += 1
+    return False
 
 
 def is_darwin_shared_link(argv: list[str]) -> bool:
     if _is_compile(argv):
         return False
-    if not _is_shared(argv):
+    if not _is_darwin_target(argv):
         return False
-    t = _target(argv)
-    return bool(t and APPLE_MARKER in t)
+    return _is_shared(argv) or _has_soname_flag(argv)
 
 
 def _is_host_elf_input(arg: str) -> bool:
@@ -105,6 +157,25 @@ def _darwin_install_name(soname: str) -> str:
     return soname
 
 
+_ELF_DROP = {
+    "--as-needed",
+    "-as-needed",
+    "-Wl,--as-needed",
+    "-Wl,-as-needed",
+    "--no-as-needed",
+    "-Wl,--no-as-needed",
+}
+
+
+def _take_next_value(argv: list[str], i: int) -> tuple[str, int]:
+    """Consume the next argv as a linker value, unwrapping a leading -Xlinker."""
+    if i >= len(argv):
+        return "", i
+    if argv[i] == "-Xlinker" and i + 1 < len(argv):
+        return argv[i + 1], i + 2
+    return argv[i], i + 1
+
+
 def rewrite_darwin_shared(argv: list[str]) -> list[str]:
     """Return clang++ argv for a Mach-O dylib link (same intent as link_macho_dylib.sh)."""
     out: list[str] = []
@@ -143,27 +214,40 @@ def rewrite_darwin_shared(argv: list[str]) -> list[str]:
             have_B = True
             out.append(f"-B{_lld_bin()}")
             continue
-        if a == "-Wl,-soname" or a == "-soname":
-            # Convert GNU soname to Darwin install_name; consume the next arg.
-            if i < len(argv):
-                soname = argv[i]
-                i += 1
-                out.append(f"-Wl,-install_name,{_darwin_install_name(soname)}")
+        if a in _ELF_DROP:
             continue
-        if a.startswith("-Wl,-soname,"):
-            out.append(
-                "-Wl,-install_name," + _darwin_install_name(a[len("-Wl,-soname,"):])
-            )
+        if a.startswith("-Wl,-rpath-link") or a in ("-rpath-link", "-Wl,-rpath-link"):
+            if a in ("-rpath-link", "-Wl,-rpath-link") and not a.startswith("-Wl,-rpath-link,"):
+                skip_next = True
+            continue
+        if a == "-Xlinker" and i < len(argv):
+            nxt = argv[i]
+            sn = _soname_payload(nxt)
+            if sn is not None:
+                i += 1
+                if sn == "":
+                    sn, i = _take_next_value(argv, i)
+                if sn:
+                    out.append(f"-Wl,-install_name,{_darwin_install_name(sn)}")
+                continue
+            if nxt in _ELF_DROP or nxt.startswith("-rpath-link") or nxt.startswith("--rpath-link"):
+                i += 1
+                continue
+            out.append(a)
+            out.append(nxt)
+            i += 1
+            continue
+        sn = _soname_payload(a)
+        if sn is not None:
+            if sn == "":
+                sn, i = _take_next_value(argv, i)
+            if sn:
+                out.append(f"-Wl,-install_name,{_darwin_install_name(sn)}")
             continue
         if a.startswith("-Wl,-install_name,"):
             out.append(
                 "-Wl,-install_name," + _darwin_install_name(a[len("-Wl,-install_name,"):])
             )
-            continue
-        if a.startswith("-Wl,-rpath-link"):
-            continue
-        if a == "-Wl,-rpath-link":
-            skip_next = True
             continue
         if a in ("-lstdc++", "-lgcc_s", "-lgcc", "-lc", "-ldl", "-lpthread", "-lm"):
             continue
@@ -214,10 +298,46 @@ def rewrite_darwin_shared(argv: list[str]) -> list[str]:
     if not have_undef:
         extra.append("-Wl,-undefined,dynamic_lookup")
 
-    # Insert Darwin link extras after the compiler's own flags but before objects.
-    # Putting them at the end is what link_macho_dylib.sh does and is enough
-    # for ld64.lld to resolve -lSystem from the sysroot -L path already in argv.
-    return out + extra
+    rewritten = out + extra
+    return _drop_leftover_elf_link_flags(rewritten)
+
+
+def _drop_leftover_elf_link_flags(argv: list[str]) -> list[str]:
+    """Last pass: ld64.lld must never see -soname / --as-needed / -rpath-link."""
+    out: list[str] = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        i += 1
+        if a in _ELF_DROP:
+            continue
+        if a.startswith("-Wl,-rpath-link") or a in ("-rpath-link",):
+            continue
+        if _soname_payload(a) is not None:
+            if _soname_payload(a) == "":
+                if i < len(argv) and argv[i] == "-Xlinker":
+                    i += 1
+                if i < len(argv):
+                    i += 1
+            continue
+        if a == "-Xlinker" and i < len(argv):
+            nxt = argv[i]
+            if _soname_payload(nxt) is not None or nxt in _ELF_DROP or nxt.startswith("-rpath-link"):
+                i += 1
+                if _soname_payload(nxt) == "":
+                    if i < len(argv) and argv[i] == "-Xlinker":
+                        i += 1
+                    if i < len(argv):
+                        i += 1
+                continue
+        out.append(a)
+    return out
+
+
+def log_darwin_rewrite(original: list[str], rewritten: list[str]) -> None:
+    sys.stderr.write("clangxx_darwin_link: ninja argv: " + shlex.join(original) + "\n")
+    sys.stderr.write("clangxx_darwin_link: rewritten argv: " + shlex.join(rewritten) + "\n")
+    sys.stderr.flush()
 
 
 def _output_path(argv: list[str]) -> str | None:
@@ -247,16 +367,14 @@ def main(argv: list[str]) -> int:
     # argv[0] is this script; clang++ driver args follow.
     args = argv[1:]
     if is_darwin_shared_link(args):
-        args = rewrite_darwin_shared(args)
-        if os.environ.get("SWIFTCORE_CLANGXX_LOG"):
-            sys.stderr.write("clangxx_darwin_link: Darwin shared rewrite\n")
-            sys.stderr.write("  " + " ".join(args) + "\n")
+        rewritten = rewrite_darwin_shared(args)
+        log_darwin_rewrite(args, rewritten)
         if os.environ.get("SWIFTCORE_CLANGXX_PRINT_REWRITTEN"):
-            print(" ".join(args))
+            print(" ".join(rewritten))
             return 0
-        rc = subprocess.call([real] + args)
+        rc = subprocess.call([real] + rewritten)
         if rc == 0:
-            mirror_so_to_dylib(args)
+            mirror_so_to_dylib(rewritten)
         return rc
     if os.environ.get("SWIFTCORE_CLANGXX_PRINT_REWRITTEN"):
         print(" ".join(args))

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -117,7 +117,8 @@ if [ "$PRINT_FLAGS" != 1 ]; then
 fi
 
 # Overlay sysroot must carry Intel math.h (fmaxl) + machorun sys/proc.h
-# (extern_proc) *before* cmake bakes -DSWIFT_SDK_OSX_PATH. A stale
+# (extern_proc) *and* every header staged modulemaps name (complex.h from
+# full/sdk-gaps) *before* cmake bakes -DSWIFT_SDK_OSX_PATH. A stale
 # MacOSX.sdk from an earlier refuse-overwrite is CANNOT, not a ninja surprise.
 if [ "$PRINT_FLAGS" != 1 ] && [ "$SWIFTCORE_DARWIN_ARCH" = x86_64 ]; then
   overlay_sysroot_print_headers "$SDK"

--- a/swiftcore-macho/scripts/overlay_sysroot.inc
+++ b/swiftcore-macho/scripts/overlay_sysroot.inc
@@ -15,6 +15,11 @@
 # the dest tree: input-sha MATCH of the pin is not completeness. .tbd stubs
 # from machorun gen_tbd / the displaced tree are copied into the fresh dest
 # before the live MacOSX.sdk is moved aside.
+#
+# Staged Darwin*.modulemap files name headers (complex.h, …). Those files must
+# resolve under usr/include before cmake — the same closure phase2 already
+# checks (phase2_darwin_modulemap_missing_headers). Source them from the FE
+# sysroot / full/sdk-gaps / machorun / overlay-darwin pins.
 
 if [ -n "${SWIFTCORE_OVERLAY_SYSROOT_INC:-}" ]; then
     return 0 2>/dev/null || exit 0
@@ -25,9 +30,14 @@ _overlay_sysroot_inc_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SWIFTCORE_ROOT=${SWIFTCORE_ROOT:-$(cd "$_overlay_sysroot_inc_dir/.." && pwd)}
 OPENUIKIT_ROOT=${OPENUIKIT_ROOT:-$(cd "$SWIFTCORE_ROOT/.." && pwd)}
 
-# Bump when staging steps, the Darwin.modulemap header list, or the
-# required staged-header / tbd completeness gate change.
-OVERLAY_SYSROOT_RECIPE=overlay-darwin.2
+# Reuse phase2's modulemap quoted-header enumeration (scripts/x86/test_phase2.sh
+# maps-only restage). Do not reimplement the grep/sed.
+# shellcheck disable=SC1091
+. "$OPENUIKIT_ROOT/scripts/x86/common.inc"
+
+# Bump when staging steps, the Darwin.modulemap header list, modulemap
+# header closure, or the required staged-header / tbd completeness gate change.
+OVERLAY_SYSROOT_RECIPE=overlay-darwin.3
 OVERLAY_SYSROOT_STAMP=.overlay-sysroot-inputs
 
 # Same enumeration as stage_overlay_darwin.sh DARWIN_MODULE_HEADERS.
@@ -102,6 +112,7 @@ overlay_sysroot_input_lines() {
         "$(printf '%s\n' "${OVERLAY_DARWIN_MODULE_HEADERS[@]}" | sha256sum | awk '{print $1}')"
     printf 'required.headers=%s\n' \
         "$(printf '%s\n' "${OVERLAY_SYSROOT_REQUIRED_HEADERS[@]}" | sha256sum | awk '{print $1}')"
+    printf 'modulemap.closure=phase2_darwin_modulemap_missing_headers\n'
     printf 'machorun.sys/proc.h=%s\n' "$(overlay_sysroot_sha_or_absent "${proc:-}")"
 }
 
@@ -189,6 +200,7 @@ overlay_sysroot_print_headers() {
             echo "overlay_sysroot: header $rel ABSENT"
         fi
     done
+    overlay_sysroot_print_modulemap_closure "$sdk"
     overlay_sysroot_print_tbds "$sdk"
     if [ -f "$sdk/$OVERLAY_SYSROOT_STAMP" ]; then
         echo "overlay_sysroot: stamp=$sdk/$OVERLAY_SYSROOT_STAMP"
@@ -219,6 +231,96 @@ overlay_sysroot_headers_ok() {
         overlay_sysroot_has_fmaxl "$sdk/usr/include/math.h" || return 1
     fi
     overlay_sysroot_has_extern_proc "$sdk/usr/include/sys/proc.h" || return 1
+    phase2_darwin_modulemap_headers_ok "$sdk" || return 1
+}
+
+# usr/include search roots for headers named by staged modulemaps. Same
+# places the FE sysroot stages from (full/sdk-gaps for complex.h, then
+# FE / machorun / overlay-darwin pins).
+overlay_sysroot_header_search_roots() {
+    local dest=${1:-}
+    local dest_inc="" cand root seen=""
+    if [ -n "$dest" ]; then
+        dest_inc=$(realpath "$dest/usr/include" 2>/dev/null || true)
+    fi
+    for cand in \
+        ${SWIFTCORE_FE_SYSROOT:+$SWIFTCORE_FE_SYSROOT/usr/include} \
+        ${W:+$W/scratch/sysroot_fe4-${SWIFTCORE_DARWIN_ARCH:-x86_64}/usr/include} \
+        ${W:+$W/scratch/sysroot_fe4-x86_64/usr/include} \
+        "$OPENUIKIT_ROOT/scratch/sysroot_fe4-x86_64/usr/include" \
+        "$OPENUIKIT_ROOT/full/sdk-gaps/usr/include" \
+        ${W:+$W/machorun-sdk/usr/include} \
+        ${MACHORUN:+$MACHORUN/sdk/usr/include} \
+        ${W:+$W/machorun/sdk/usr/include} \
+        "$OPENUIKIT_ROOT/machorun/sdk/usr/include" \
+        "$SWIFTCORE_ROOT/sdk/overlay-darwin"
+    do
+        [ -n "$cand" ] || continue
+        [ -d "$cand" ] || continue
+        root=$(realpath "$cand" 2>/dev/null || printf '%s' "$cand")
+        [ -n "$dest_inc" ] && [ "$root" = "$dest_inc" ] && continue
+        case " $seen " in *" $root "*) continue ;; esac
+        seen="$seen $root"
+        printf '%s\n' "$root"
+    done
+}
+
+# Copy every `header "…"` named by staged *.modulemap that is not yet
+# under dest/usr/include. overlay_sysroot_fill_modulemap_headers <dest>
+overlay_sysroot_fill_modulemap_headers() {
+    local dest=${1:?overlay_sysroot_fill_modulemap_headers: dest}
+    local inc=$dest/usr/include
+    local miss_csv rel src_root src n=0
+    mkdir -p "$inc"
+    miss_csv=$(phase2_darwin_modulemap_missing_headers "$dest" || true)
+    if [ -z "$miss_csv" ]; then
+        echo "overlay_sysroot: modulemap headers complete tree=$dest"
+        return 0
+    fi
+    echo "overlay_sysroot: modulemap missing=$miss_csv tree=$dest"
+    while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        [ -f "$inc/$rel" ] && continue
+        src=
+        while IFS= read -r src_root; do
+            [ -n "$src_root" ] || continue
+            if [ -f "$src_root/$rel" ]; then
+                src=$src_root/$rel
+                break
+            fi
+        done < <(overlay_sysroot_header_search_roots "$dest")
+        if [ -n "$src" ]; then
+            mkdir -p "$(dirname "$inc/$rel")"
+            cp -a "$src" "$inc/$rel"
+            echo "overlay_sysroot: staged modulemap header $rel from $src"
+            n=$((n + 1))
+        fi
+    done < <(printf '%s\n' "$miss_csv" | tr ',' '\n')
+    echo "overlay_sysroot: filled $n modulemap headers into $inc"
+}
+
+overlay_sysroot_print_modulemap_closure() {
+    local sdk=${1:?overlay_sysroot_print_modulemap_closure: sdk}
+    local miss
+    miss=$(phase2_darwin_modulemap_missing_headers "$sdk" || true)
+    if [ -n "$miss" ]; then
+        echo "overlay_sysroot: modulemap missing=$miss"
+    else
+        echo "overlay_sysroot: modulemap headers complete"
+    fi
+}
+
+# Named CANNOT. Exit 2. overlay_sysroot_refuse_modulemap_headers <sdk>
+overlay_sysroot_refuse_modulemap_headers() {
+    local sdk=${1:?overlay_sysroot_refuse_modulemap_headers: sdk}
+    local miss resolved
+    miss=$(phase2_darwin_modulemap_missing_headers "$sdk" || true)
+    if [ -z "$miss" ]; then
+        return 0
+    fi
+    resolved=$(realpath "$sdk" 2>/dev/null || printf '%s' "$sdk")
+    echo "CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER tree=$sdk realpath=$resolved missing=$miss reason=staged modulemaps name these headers; overlay sysroot must stage the same header set the modulemaps reference (phase2_darwin_modulemap_missing_headers; complex.h comes from full/sdk-gaps)" >&2
+    return 2
 }
 
 overlay_sysroot_tbd_count() {
@@ -346,6 +448,9 @@ overlay_sysroot_refuse_incomplete() {
         echo "CANNOT_OVERLAY_SYSROOT_PROC_H path=$proc tree=$sdk realpath=$resolved reason=sys/proc.h lacks extern_proc (stale SDK; Darwin.swift.gyb:74)" >&2
         rc=2
     fi
+    if ! overlay_sysroot_refuse_modulemap_headers "$sdk"; then
+        rc=2
+    fi
     return "$rc"
 }
 
@@ -453,6 +558,7 @@ overlay_sysroot_finish() {
     local fresh=${2:?overlay_sysroot_finish: fresh}
     local live=$parent/MacOSX.sdk
     overlay_sysroot_copy_tbds "$fresh" "$live"
+    overlay_sysroot_fill_modulemap_headers "$fresh"
     overlay_sysroot_write_stamp "$fresh"
     overlay_sysroot_commit_live "$live" "$fresh"
     overlay_sysroot_print_headers "$live"

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -226,6 +226,85 @@ for f in flags:
 PY
 }
 
+# Print the exact Darwin overlay dylib link ninja will run, and the argv
+# clangxx_darwin_link.py rewrites it to (no -soname). Operator log must
+# show both: the Linux CMake line and the ld64.lld line.
+# overlay_print_darwin_link_from_ninja <build_dir> <arch>
+overlay_print_darwin_link_from_ninja() {
+    local build_dir=${1:?overlay_print_darwin_link_from_ninja: build dir}
+    local arch=${2:?overlay_print_darwin_link_from_ninja: arch}
+    local ninja_bin=${NINJA:-ninja}
+    local py
+    py=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/clangxx_darwin_link.py
+    local node="lib/swift/macosx/${arch}/libswiftDarwin.so"
+    local cmds=""
+    echo "overlay_link: ninja -t commands for Darwin dylib (arch=$arch node=$node)"
+    cmds=$("$ninja_bin" -C "$build_dir" -t commands "$node" 2>/dev/null) || cmds=""
+    if [ -z "$cmds" ]; then
+        cmds=$("$ninja_bin" -C "$build_dir" -t commands "swiftDarwin-macosx-${arch}" 2>/dev/null) || cmds=""
+    fi
+    if [ -z "$cmds" ]; then
+        echo "overlay_link: ninja Darwin dylib command ABSENT"
+        return 0
+    fi
+    python3 - "$py" "$cmds" <<'PY'
+import os, shlex, subprocess, sys
+
+def compiler_args(line):
+    argv = shlex.split(line)
+    if not argv:
+        return []
+    # CMake CXX_SHARED_LIBRARY rules wrap as: : && <compiler> ... && :
+    if argv[0] == ":" and len(argv) > 2 and argv[1] == "&&":
+        argv = argv[2:]
+    while len(argv) >= 2 and argv[-2] == "&&" and argv[-1] == ":":
+        argv = argv[:-2]
+    i = 0
+    for j, t in enumerate(argv):
+        base = os.path.basename(t.rstrip("\\"))
+        if base in ("clang++", "clang", "clangxx_darwin_link.py") or t.endswith("/clang++"):
+            i = j
+            break
+    return argv[i + 1 :]
+
+py, text = sys.argv[1], sys.argv[2]
+line = None
+for raw in text.splitlines():
+    if "libswiftDarwin.so" in raw and " -o " in raw and (
+        "clang++" in raw or "clang " in raw or raw.lstrip().startswith("clang")
+    ):
+        line = raw
+        break
+if line is None:
+    for raw in text.splitlines():
+        if "libswiftDarwin.so" in raw and ("-shared" in raw or "-dynamiclib" in raw or "soname" in raw):
+            line = raw
+            break
+if line is None:
+    print("overlay_link: ninja Darwin dylib command ABSENT (no clang++ link line)")
+    sys.exit(0)
+print("overlay_link: ninja", line)
+args = compiler_args(line)
+env = os.environ.copy()
+env["SWIFTCORE_CLANGXX_PRINT_REWRITTEN"] = "1"
+proc = subprocess.run(
+    [sys.executable, py, *args], env=env, text=True, capture_output=True
+)
+rewritten = (proc.stdout or "").strip()
+err = (proc.stderr or "").strip()
+if err:
+    for eline in err.splitlines():
+        print(eline)
+print("overlay_link: rewritten", rewritten if rewritten else "ABSENT")
+if "soname" in rewritten:
+    print("overlay_link: rewritten still has soname")
+    sys.exit(1)
+if rewritten and "-install_name" not in rewritten and "-Wl,-install_name" not in rewritten:
+    print("overlay_link: rewritten missing -install_name")
+    sys.exit(1)
+PY
+}
+
 # Resolve the phony overlay target to its libswift*.so and see whether that
 # node's ninja inputs include the Darwin overlay (libswiftDarwin / Darwin.swiftmodule).
 # overlay_ninja_depends_on_darwin <build_dir> <target> → 0 if yes.

--- a/swiftcore-macho/scripts/stage_overlay_darwin.sh
+++ b/swiftcore-macho/scripts/stage_overlay_darwin.sh
@@ -21,6 +21,8 @@ SWIFTCORE_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 OPENUIKIT_ROOT=$(cd "$SWIFTCORE_ROOT/.." && pwd)
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/guest_arch.inc"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/overlay_sysroot.inc"
 
 SDK=${1:-${SDK:-$HOME/work/sdk/MacOSX.sdk}}
 SRC=$SWIFTCORE_ROOT/sdk/overlay-darwin
@@ -257,6 +259,12 @@ else
   write_darwin_modulemap
 fi
 ensure_module_modulemap
+
+# FE copy writes DarwinFoundation*.modulemap which name headers (complex.h)
+# the error-enumerated FE header list does not copy. Fill every quoted
+# `header "…"` from the same places the FE sysroot does, then the
+# overlay_sysroot refuse-before-cmake gate can require closure.
+overlay_sysroot_fill_modulemap_headers "$SDK"
 
 echo "stage_overlay_darwin: done sysroot=$SDK"
 echo "  Darwin.modulemap: $([ -f "$SDK/usr/include/Darwin.modulemap" ] && echo present || echo ABSENT)"

--- a/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
+++ b/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
@@ -95,6 +95,57 @@ else
 fi
 
 echo
+echo "=== overlay Darwin -soname spellings rewrite to -install_name ==="
+assert_no_soname() {
+  local got=$1
+  if printf '%s\n' "$got" | grep -Eq -- '(^|[[:space:]])(-Wl,)?-?-soname'; then
+    echo "  FAIL leftover -soname in: $got"
+    fail=1
+    return 1
+  fi
+  echo "  OK  no -soname"
+}
+
+got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
+  -Wl,-soname,libswiftDarwin.so -o libswiftDarwin.so Darwin.o)
+printf '%s\n' "$got"
+assert_no_soname "$got"
+printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
+  && echo "  OK  -Wl,-soname,libswiftDarwin.so -> Darwin install_name" \
+  || { echo "  FAIL concatenated -Wl,-soname,"; fail=1; }
+
+got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
+  -soname,libswiftDarwin.so -o libswiftDarwin.so Darwin.o)
+printf '%s\n' "$got"
+assert_no_soname "$got"
+printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
+  && echo "  OK  -soname,libswiftDarwin.so -> Darwin install_name" \
+  || { echo "  FAIL bare -soname,"; fail=1; }
+
+got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
+  -Xlinker -soname -Xlinker libswiftDarwin.so -o libswiftDarwin.so Darwin.o)
+printf '%s\n' "$got"
+assert_no_soname "$got"
+printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
+  && echo "  OK  -Xlinker -soname -> Darwin install_name" \
+  || { echo "  FAIL -Xlinker -soname"; fail=1; }
+
+got=$(rewrite -isysroot /root/work/sdk/MacOSX.sdk -shared \
+  --as-needed -Wl,-rpath-link,/usr/lib -Wl,-soname,libswiftCore.so \
+  -o libswiftCore.so foo.o)
+printf '%s\n' "$got"
+assert_no_soname "$got"
+printf '%s\n' "$got" | grep -F -- '--as-needed' >/dev/null \
+  && { echo "  FAIL --as-needed survived"; fail=1; } \
+  || echo "  OK  --as-needed dropped"
+printf '%s\n' "$got" | grep -F -- '-rpath-link' >/dev/null \
+  && { echo "  FAIL -rpath-link survived"; fail=1; } \
+  || echo "  OK  -rpath-link dropped"
+printf '%s\n' "$got" | grep -F -- '-dynamiclib' >/dev/null \
+  && echo "  OK  MacOSX.sdk -shared rewritten without -target" \
+  || { echo "  FAIL MacOSX.sdk path not treated as Darwin"; fail=1; }
+
+echo
 if [ "$fail" -eq 0 ]; then
   echo "PASS -- Darwin shared link rewrite (lld, not gold; no host ELF libc++)"
   exit 0

--- a/swiftcore-macho/scripts/test_overlay_darwin.sh
+++ b/swiftcore-macho/scripts/test_overlay_darwin.sh
@@ -114,6 +114,38 @@ grep -q fmaxl "$tmp/sdk4/usr/include/math.h" \
   || { echo "  FAIL FE ConditionalMacros.h still absent"; fail=1; }
 
 echo
+echo "=== FE DarwinFoundation1.modulemap names complex.h; staged from sdk-gaps ==="
+mkdir -p "$tmp/fe3/usr/include" "$tmp/sdk6/usr/include" "$tmp/work3/scratch"
+echo 'module Darwin [system] { header "math.h" export * }' \
+  > "$tmp/fe3/usr/include/Darwin.modulemap"
+cat > "$tmp/fe3/usr/include/DarwinFoundation1.modulemap" <<'EOF'
+module _DarwinFoundation1 [system] {
+  header "complex.h"
+  export *
+}
+EOF
+echo 'extern module Darwin "Darwin.modulemap"' > "$tmp/fe3/usr/include/module.modulemap"
+echo 'extern float acosf(float);' > "$tmp/fe3/usr/include/math.h"
+echo 'extern long double fmaxl(long double, long double);' >> "$tmp/fe3/usr/include/math.h"
+ln -sfn "$tmp/fe3" "$tmp/work3/scratch/sysroot_fe4-x86_64"
+set +e
+out=$(W="$tmp/work3" SWIFTCORE_DARWIN_ARCH=x86_64 \
+  bash "$SCRIPT_DIR/stage_overlay_darwin.sh" "$tmp/sdk6" 2>&1)
+rc=$?
+set -e
+printf '%s\n' "$out" | tail -25
+[ "$rc" -eq 0 ] && echo "  OK  FE-complex rc=0" || { echo "  FAIL FE-complex rc=$rc"; fail=1; }
+grep -q 'header "complex.h"' "$tmp/sdk6/usr/include/DarwinFoundation1.modulemap" \
+  && echo "  OK  FE DarwinFoundation1.modulemap copied" \
+  || { echo "  FAIL Foundation1 map missing"; fail=1; }
+[ -f "$tmp/sdk6/usr/include/complex.h" ] \
+  && echo "  OK  complex.h staged" || { echo "  FAIL complex.h absent after FE maps"; fail=1; }
+cmp -s "$ROOT/../full/sdk-gaps/usr/include/complex.h" "$tmp/sdk6/usr/include/complex.h" \
+  && echo "  OK  complex.h is full/sdk-gaps stub" || { echo "  FAIL complex.h not sdk-gaps"; fail=1; }
+printf '%s\n' "$out" | grep -q 'staged modulemap header complex.h' \
+  && echo "  OK  fill named complex.h" || { echo "  FAIL no fill log for complex.h"; fail=1; }
+
+echo
 echo "=== FE math.h without fmaxl is repaired from overlay-darwin Intel pin ==="
 mkdir -p "$tmp/fe2/usr/include" "$tmp/sdk5/usr/include" "$tmp/work2/scratch"
 echo 'module Darwin [system] { header "math.h" export * }' \

--- a/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
+++ b/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Overlay sysroot staging is input-keyed. A pre-existing MacOSX.sdk with
 # clean-room math.h / no stamp is displaced, never rm'd; mismatch restages
-# into a fresh directory. Refuse-before-cmake if math.h lacks fmaxl or
-# sys/proc.h lacks extern_proc.
+# into a fresh directory. Refuse-before-cmake if math.h lacks fmaxl,
+# sys/proc.h lacks extern_proc, or a staged modulemap names a header that
+# is not on disk (phase2_darwin_modulemap_missing_headers).
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
@@ -203,6 +204,95 @@ printf '%s\n' "$tbd_ref" | grep -q "tree=$tmp/notbd" \
   && echo "  OK  TBDS refuse names the tree" || { echo "  FAIL TBDS tree path"; fail=1; }
 
 echo
+echo "=== modulemap header closure (phase2_darwin_modulemap_missing_headers) ==="
+mkdir -p "$tmp/mm/usr/include" "$tmp/mm/usr/lib"
+fill_required_headers "$tmp/mm"
+echo '--- !tapi-tbd-v3' > "$tmp/mm/usr/lib/libSystem.B.tbd"
+cat > "$tmp/mm/usr/include/DarwinFoundation1.modulemap" <<'EOF'
+module _DarwinFoundation1 [system] {
+  header "complex.h"
+  export *
+}
+EOF
+need '! phase2_darwin_modulemap_headers_ok "$tmp/mm"' \
+  "maps naming complex.h fail phase2 closure before fill"
+before=$(phase2_darwin_modulemap_missing_headers "$tmp/mm" || true)
+printf '%s\n' "$before" | grep -q 'complex.h' \
+  && echo "  OK  missing=complex.h ($before)" \
+  || { echo "  FAIL missing headers: $before"; fail=1; }
+set +e
+refuse_mm=$(overlay_sysroot_refuse_modulemap_headers "$tmp/mm" 2>&1)
+st=$?
+set -e
+printf '%s\n' "$refuse_mm"
+[ "$st" -eq 2 ] && echo "  OK  modulemap refuse rc=2" || { echo "  FAIL modulemap refuse rc=$st"; fail=1; }
+printf '%s\n' "$refuse_mm" | grep -q 'CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER' \
+  && echo "  OK  CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER" \
+  || { echo "  FAIL missing MODULEMAP_HEADER marker"; fail=1; }
+printf '%s\n' "$refuse_mm" | grep -q 'complex.h' \
+  && echo "  OK  refuse names complex.h" || { echo "  FAIL refuse path"; fail=1; }
+if overlay_sysroot_tree_complete "$tmp/mm"; then
+  echo "  FAIL tree_complete true with modulemap header missing"
+  fail=1
+else
+  echo "  OK  tree_complete false while complex.h absent"
+fi
+overlay_sysroot_fill_modulemap_headers "$tmp/mm" | tee "$tmp/mm.fill"
+grep -q 'staged modulemap header complex.h' "$tmp/mm.fill" \
+  && echo "  OK  fill staged complex.h from sdk-gaps" \
+  || { echo "  FAIL fill did not stage complex.h"; cat "$tmp/mm.fill"; fail=1; }
+[ -f "$tmp/mm/usr/include/complex.h" ] \
+  && echo "  OK  complex.h now on disk" || { echo "  FAIL complex.h still absent"; fail=1; }
+cmp -s "$OPENUIKIT_ROOT/full/sdk-gaps/usr/include/complex.h" \
+       "$tmp/mm/usr/include/complex.h" \
+  && echo "  OK  complex.h is the sdk-gaps stub" || { echo "  FAIL complex.h contents"; fail=1; }
+if phase2_darwin_modulemap_headers_ok "$tmp/mm"; then
+  echo "  OK  phase2 closure after fill"
+else
+  echo "  FAIL still missing $(phase2_darwin_modulemap_missing_headers "$tmp/mm" || true)"
+  fail=1
+fi
+set +e
+overlay_sysroot_refuse_modulemap_headers "$tmp/mm"
+st=$?
+set -e
+[ "$st" -eq 0 ] && echo "  OK  refuse rc=0 after fill" || { echo "  FAIL refuse after fill rc=$st"; fail=1; }
+if overlay_sysroot_tree_complete "$tmp/mm"; then
+  echo "  OK  tree_complete after fill"
+else
+  echo "  FAIL tree_complete still false"
+  fail=1
+fi
+
+echo
+echo "=== configure.sh refuses before cmake when modulemap header is missing ==="
+mkdir -p "$W/swift-experimental-string-processing/Sources/_StringProcessing"
+mkdir -p "$W/libdispatch"
+touch "$W/libdispatch/CMakeLists.txt"
+mkdir -p "$W/sdk/MacOSX.sdk/usr/include/sys" "$W/sdk/MacOSX.sdk/usr/lib"
+fill_required_headers "$W/sdk/MacOSX.sdk"
+echo '--- !tapi-tbd-v3' > "$W/sdk/MacOSX.sdk/usr/lib/libSystem.B.tbd"
+cat > "$W/sdk/MacOSX.sdk/usr/include/DarwinFoundation1.modulemap" <<'EOF'
+module _DarwinFoundation1 [system] { header "complex.h" export * }
+EOF
+set +e
+out=$(
+  SWIFTCORE_OVERLAYS=1 SWIFTCORE_DARWIN_ARCH=x86_64 \
+    W="$W" B="$W/build-mm" \
+    bash "$SCRIPT_DIR/configure.sh" 2>&1
+)
+rc=$?
+set -e
+printf '%s\n' "$out" | tail -20
+[ "$rc" -eq 2 ] && echo "  OK  configure modulemap rc=2" || { echo "  FAIL configure modulemap rc=$rc"; fail=1; }
+printf '%s\n' "$out" | grep -q 'CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER' \
+  && echo "  OK  configure named MODULEMAP_HEADER" \
+  || { echo "  FAIL configure MODULEMAP_HEADER"; fail=1; }
+[ -f "$W/configure.log" ] && grep -q cmake "$W/configure.log" 2>/dev/null \
+  && { echo "  FAIL cmake ran after modulemap refuse"; fail=1; } \
+  || echo "  OK  cmake not invoked after modulemap refuse"
+
+echo
 echo "=== stage_sdk.sh does not rm -rf \$W/sdk ==="
 if grep -n 'rm -rf "$W/sdk"' "$SCRIPT_DIR/stage_sdk.sh"; then
   echo "  FAIL stage_sdk.sh still rm -rf \$W/sdk"
@@ -278,6 +368,84 @@ printf '%s\n' "$out" | grep -q -- '-sdk=/root/work/sdk/MacOSX.sdk' \
   && echo "  OK  printed -sdk from ninja commands" || { echo "  FAIL missing -sdk"; fail=1; }
 printf '%s\n' "$out" | grep -q -- '-isysroot=/root/work/sdk/MacOSX.sdk' \
   && echo "  OK  printed -isysroot from ninja commands" || { echo "  FAIL missing -isysroot"; fail=1; }
+
+echo
+echo "=== ninja Darwin dylib link is printed and -soname rewritten ==="
+cat > "$fake/ninja" <<'EOF'
+#!/bin/bash
+args=("$@")
+i=0
+tool=""
+node=""
+while [ $i -lt ${#args[@]} ]; do
+  a=${args[$i]}
+  case "$a" in
+    -C) i=$((i+2)); continue ;;
+    -t)
+      i=$((i+1)); tool=${args[$i]:-}; i=$((i+1)); continue ;;
+    *) node=$a; i=$((i+1)); continue ;;
+  esac
+done
+if [ "$tool" = commands ]; then
+  echo "clang++ -target x86_64-apple-macosx13.0 -shared -Wl,-soname,libswiftDarwin.so -o lib/swift/macosx/x86_64/libswiftDarwin.so Darwin.o"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$fake/ninja"
+set +e
+out=$(NINJA="$fake/ninja" overlay_print_darwin_link_from_ninja "$tmp/ninjabuild" x86_64)
+st=$?
+set -e
+printf '%s\n' "$out"
+[ "$st" -eq 0 ] && echo "  OK  print_darwin_link rc=0" || { echo "  FAIL print_darwin_link rc=$st"; fail=1; }
+printf '%s\n' "$out" | grep -q 'overlay_link: ninja' \
+  && echo "  OK  printed ninja Darwin link" || { echo "  FAIL missing ninja link"; fail=1; }
+printf '%s\n' "$out" | grep -q -- '-Wl,-soname,libswiftDarwin.so' \
+  && echo "  OK  ninja line has -soname" || { echo "  FAIL ninja line missing -soname"; fail=1; }
+printf '%s\n' "$out" | grep -q 'overlay_link: rewritten' \
+  && echo "  OK  printed rewritten link" || { echo "  FAIL missing rewritten"; fail=1; }
+printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -Eq -- '(^|[[:space:]])(-Wl,)?-?-soname' \
+  && { echo "  FAIL rewritten still has -soname"; fail=1; } \
+  || echo "  OK  rewritten has no -soname"
+printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-install_name' \
+  && echo "  OK  rewritten has -install_name" || { echo "  FAIL rewritten missing install_name"; fail=1; }
+
+echo
+echo "=== cmake : && clang++ && : wrapper is stripped before rewrite ==="
+cat > "$fake/ninja" <<'EOF'
+#!/bin/bash
+args=("$@")
+i=0
+tool=""
+while [ $i -lt ${#args[@]} ]; do
+  a=${args[$i]}
+  case "$a" in
+    -C) i=$((i+2)); continue ;;
+    -t)
+      i=$((i+1)); tool=${args[$i]:-}; i=$((i+1)); continue ;;
+    *) i=$((i+1)); continue ;;
+  esac
+done
+if [ "$tool" = commands ]; then
+  echo ": && /root/work/shims/clang++ -target x86_64-apple-macosx13.0 -shared -Wl,-soname,libswiftDarwin.so -o lib/swift/macosx/x86_64/libswiftDarwin.so Darwin.o && :"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$fake/ninja"
+set +e
+out=$(NINJA="$fake/ninja" overlay_print_darwin_link_from_ninja "$tmp/ninjabuild" x86_64)
+st=$?
+set -e
+printf '%s\n' "$out"
+[ "$st" -eq 0 ] && echo "  OK  cmake-wrapper print rc=0" || { echo "  FAIL cmake-wrapper rc=$st"; fail=1; }
+printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q '&&' \
+  && { echo "  FAIL rewritten kept cmake && wrapper"; fail=1; } \
+  || echo "  OK  rewritten dropped cmake && wrapper"
+printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-install_name' \
+  && echo "  OK  wrapper line still rewrites install_name" \
+  || { echo "  FAIL wrapper rewrite"; fail=1; }
 
 echo
 echo "=== overlay FAILED dep=swiftDarwin vs first_error from the graph ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #30 merged; operator rerun of the same overlay command passed stamp/tbd/headers and compiled Darwin far enough to hit two new walls. This PR is on current `main`.

**WALL A — clang module graph.** Staged `DarwinFoundation1.modulemap` names `complex.h`; the overlay sysroot copied the maps without the files. Staging now enumerates every `header "…"` in every staged modulemap (`phase2_darwin_modulemap_missing_headers`, same check as phase2) and fills from the FE sysroot / `full/sdk-gaps` (complex.h) / machorun / overlay-darwin pins **before cmake**. Leftovers are `CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER`. Recipe `overlay-darwin.3`.

**WALL B — overlay dylib link.** Linux CMake emits `-Wl,-soname` / `-Xlinker -soname` / `--as-needed` for Darwin-target shared links; `ld64.lld` rejects `-soname`. `clangxx_darwin_link.py` rewrites those to `-install_name`, drops ELF flags, and always logs `ninja argv` vs `rewritten argv`. `build_stdlib.sh` prints `overlay_link: ninja` and `overlay_link: rewritten` before the overlay ninja loop.

Operator command (unchanged):

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

Tests: `test_overlay_sysroot_stamp.sh` (modulemap closure + `-soname` ninja line rewritten), `test_clangxx_darwin_link.sh` (`-Wl,-soname,`, `-soname,`, `-Xlinker -soname`), `test_overlay_darwin.sh` (FE maps naming complex.h staged from sdk-gaps).

`_DarwinFoundation1/2/3`, `_errno`, `ObjectiveC`: still `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35369cc-b509-457d-83ef-c090127c9afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

