### PR TITLE
Package the OpenFoundationInternationalization Darwin bridge into the onboarding guest

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -371,6 +371,9 @@ PACKAGE_CINC=(-Xcc -I"$PACKAGE/include/CPortableIO"
 HOST_BRIDGE_DIR=$OUT/host
 RELATIVE_TIME_DARWIN=$PACKAGE/libOpenRelativeTime.dylib
 RELATIVE_TIME_HOST=$HOST_BRIDGE_DIR/libOpenRelativeTimeHost.so
+FOUNDATION_INTL_DARWIN=$PACKAGE/libOpenFoundationInternationalization.dylib
+FOUNDATION_INTL_HOST=$HOST_BRIDGE_DIR/libOpenFoundationInternationalizationHost.so
+MACHO_DEPENDENCY_REWRITER=$W/full/xcodeplan/rewrite_macho_dependency.py
 FE_OUT=$FULL/foundation/essentials
 FE_COLLECTIONS=$FULL/foundation/collections
 FE_OS=$FULL/foundation/os
@@ -559,6 +562,84 @@ env SUPPORT_ROOT="$W" SWIFT_FOUNDATION="$SWIFT_FOUNDATION" \
 [ -f "$PACKAGE/libFoundationInternationalization.dylib" ] && \
     [ ! -L "$PACKAGE/libFoundationInternationalization.dylib" ] \
     || die 'libFoundationInternationalization.dylib is missing after build'
+[ -f "$PACKAGE/lib_FoundationICU.dylib" ] && \
+    [ ! -L "$PACKAGE/lib_FoundationICU.dylib" ] \
+    || die 'lib_FoundationICU.dylib is missing after build'
+
+echo '== build the OpenFoundationInternationalization Darwin bridge and Linux host helper'
+[ -f "$MACHO_DEPENDENCY_REWRITER" ] && [ ! -L "$MACHO_DEPENDENCY_REWRITER" ] \
+    || die "Mach-O dependency rewriter is missing: $MACHO_DEPENDENCY_REWRITER"
+clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
+    -fvisibility=hidden -Wall -Wextra -Werror \
+    -I "$W/full/foundationinternationalization/include" \
+    -c "$W/full/foundationinternationalization/OpenFoundationInternationalizationBridge.c" \
+    -o "$OUT/open-foundation-internationalization-bridge.o"
+run_link libOpenFoundationInternationalization "${LD[@]}" -dylib -dead_strip \
+    -undefined dynamic_lookup \
+    -install_name @rpath/libOpenFoundationInternationalization.dylib \
+    -rpath @loader_path \
+    -map "$AUDIT/libOpenFoundationInternationalization.link-map" \
+    -o "$FOUNDATION_INTL_DARWIN" \
+    "$OUT/open-foundation-internationalization-bridge.o"
+bash "$W/full/foundationinternationalization/build_host_helper.sh" \
+    --repo "$W" --host-dir "$HOST_BRIDGE_DIR" \
+    --include-dir "$W/full/foundationinternationalization/include"
+clang-18 -std=c11 -O2 -Wall -Wextra -Werror \
+    -I "$W/full/foundationinternationalization/include" \
+    "$W/full/foundationinternationalization/OpenFoundationInternationalizationHost.c" \
+    "$W/full/foundationinternationalization/OpenFoundationInternationalizationHostTests.c" \
+    -o "$OUT/open-foundation-internationalization-host-tests"
+"$OUT/open-foundation-internationalization-host-tests" \
+    > "$OUT/open-foundation-internationalization-host-test.log"
+grep -Fx \
+    'OPEN_FOUNDATION_INTERNATIONALIZATION_HOST_OK realpath=bounded,versioned' \
+    "$OUT/open-foundation-internationalization-host-test.log" >/dev/null \
+    || die 'FoundationInternationalization host marker is missing'
+[ -f "$FOUNDATION_INTL_DARWIN" ] && [ ! -L "$FOUNDATION_INTL_DARWIN" ] \
+    || die 'libOpenFoundationInternationalization.dylib is missing after build'
+[ -f "$FOUNDATION_INTL_HOST" ] && [ ! -L "$FOUNDATION_INTL_HOST" ] \
+    || die 'libOpenFoundationInternationalizationHost.so is missing after build'
+printf 'openui_foundation_intl_v1_realpath\n' \
+    > "$AUDIT/foundation-intl-expected-elf.txt"
+printf '_realpath\n' > "$AUDIT/foundation-intl-expected-mach-exports.txt"
+printf '_glibc_openui_foundation_intl_v1_realpath\n' \
+    > "$AUDIT/foundation-intl-expected-mach-imports.txt"
+readelf --wide --syms "$FOUNDATION_INTL_HOST" \
+    | awk '$5 == "GLOBAL" && $7 != "UND" && $8 ~ /^openui_foundation_intl_v1_/ { print $8 }' \
+    | LC_ALL=C sort -u > "$AUDIT/foundation-intl-elf-exports.txt"
+llvm-nm-18 --defined-only --extern-only --just-symbol-name \
+    "$FOUNDATION_INTL_DARWIN" | LC_ALL=C sort -u \
+    > "$AUDIT/foundation-intl-mach-exports.txt"
+llvm-nm-18 --undefined-only --extern-only --just-symbol-name \
+    "$FOUNDATION_INTL_DARWIN" | LC_ALL=C sort -u \
+    > "$AUDIT/foundation-intl-mach-imports.txt"
+cmp "$AUDIT/foundation-intl-expected-elf.txt" \
+    "$AUDIT/foundation-intl-elf-exports.txt" \
+    || die 'FoundationInternationalization Linux helper exports drifted'
+cmp "$AUDIT/foundation-intl-expected-mach-exports.txt" \
+    "$AUDIT/foundation-intl-mach-exports.txt" \
+    || die 'FoundationInternationalization Mach-O bridge exports drifted'
+cmp "$AUDIT/foundation-intl-expected-mach-imports.txt" \
+    "$AUDIT/foundation-intl-mach-imports.txt" \
+    || die 'FoundationInternationalization Mach-O bridge host import drifted'
+[ "$(llvm-otool-18 -D "$FOUNDATION_INTL_DARWIN" | tail -n 1)" = \
+    @rpath/libOpenFoundationInternationalization.dylib ] \
+    || die 'packaged FoundationInternationalization Mach-O bridge ID drifted'
+icu_bridge_old=$(llvm-otool-18 -L "$PACKAGE/lib_FoundationICU.dylib" \
+    | awk '$1 == "/usr/lib/libOpenFoundationInternationalization.dylib" { count++ } END { print count + 0 }')
+icu_bridge_new=$(llvm-otool-18 -L "$PACKAGE/lib_FoundationICU.dylib" \
+    | awk '$1 == "@rpath/libOpenFoundationInternationalization.dylib" { count++ } END { print count + 0 }')
+[ "$icu_bridge_old" -eq 1 ] && [ "$icu_bridge_new" -eq 0 ] \
+    || die "Foundation ICU runtime bridge load input drifted: old=$icu_bridge_old new=$icu_bridge_new"
+python3 -B "$MACHO_DEPENDENCY_REWRITER" "$PACKAGE/lib_FoundationICU.dylib" \
+    /usr/lib/libOpenFoundationInternationalization.dylib \
+    @rpath/libOpenFoundationInternationalization.dylib
+icu_bridge_old=$(llvm-otool-18 -L "$PACKAGE/lib_FoundationICU.dylib" \
+    | awk '$1 == "/usr/lib/libOpenFoundationInternationalization.dylib" { count++ } END { print count + 0 }')
+icu_bridge_new=$(llvm-otool-18 -L "$PACKAGE/lib_FoundationICU.dylib" \
+    | awk '$1 == "@rpath/libOpenFoundationInternationalization.dylib" { count++ } END { print count + 0 }')
+[ "$icu_bridge_old" -eq 0 ] && [ "$icu_bridge_new" -eq 1 ] \
+    || die "Foundation ICU runtime bridge load rewrite drifted: old=$icu_bridge_old new=$icu_bridge_new"
 PACKAGE_CINC+=(
     -Xcc -fmodule-map-file="$FINTL_STAGE/include/FoundationICU/_foundation_unicode/module.modulemap"
     -Xcc -I"$FINTL_STAGE/include/FoundationICU"
@@ -1016,7 +1097,8 @@ clang-18 -target "$TARGET" -isysroot "$SYS" -O2 \
     "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
 
 for dylib in FoundationEssentials OpenCoreGraphics OpenUIKit Foundation \
-    FoundationInternationalization Dispatch OpenRelativeTime OpenCombine Combine \
+    FoundationInternationalization _FoundationICU OpenFoundationInternationalization \
+    Dispatch OpenRelativeTime OpenCombine Combine \
     Symbols SwiftUI Widget Onboarding; do
     llvm-otool-18 -hv "$PACKAGE/lib$dylib.dylib" \
         | grep -Eq "MH_MAGIC_64[[:space:]]+${OTOOL_CPU}.*[[:space:]]DYLIB" \
@@ -1033,11 +1115,27 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 --executable "$OUT/focus_onboarding_guest" \
     --package "$PACKAGE" --guest-root "$MRROOT" \
     > "$AUDIT/runtime-closure.manifest"
+awk -F '\t' '
+    $1 == "file" && $2 == "package/libOpenFoundationInternationalization.dylib" {
+        files++
+    }
+    END { exit files == 1 ? 0 : 1 }
+' "$AUDIT/runtime-closure.manifest" \
+    || die 'runtime-closure inventory omitted package/libOpenFoundationInternationalization.dylib'
+awk -F '\t' '
+    $1 == "edge" && $2 == "package/lib_FoundationICU.dylib" \
+        && $4 == "@rpath/libOpenFoundationInternationalization.dylib" \
+        && $5 == "package/libOpenFoundationInternationalization.dylib" {
+        edges++
+    }
+    END { exit edges == 1 ? 0 : 1 }
+' "$AUDIT/runtime-closure.manifest" \
+    || die 'runtime-closure omitted the Foundation ICU @rpath OpenFoundationInternationalization edge'
 
 echo '== run exact Focus interaction path on Linux/machorun'
 echo '== build Linux Dispatch host bridge'
 DISPATCH_HOST=$HOST_BRIDGE_DIR/libOpenDispatchHost.so
-EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$RELATIVE_TIME_HOST
+EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST
 host_bridge_args=(
     --repo "$W"
     --host-dir "$HOST_BRIDGE_DIR"
@@ -1094,6 +1192,7 @@ validate_bundle "$RESOURCE_INPUT/Focus_Widget.bundle" "$EXPECTED_WIDGET_FILES" \
     printf 'widget-bundle-accessor\t%s\n' \
         "$(hash_file "$W/full/swiftui/FocusWidgetBundle.generated.swift")"
     for dylib in FoundationEssentials OpenCoreGraphics OpenUIKit Foundation \
+        FoundationInternationalization _FoundationICU OpenFoundationInternationalization \
         Dispatch OpenRelativeTime OpenCombine Combine Symbols SwiftUI Widget Onboarding; do
         printf 'lib%s\t%s\n' "$dylib" "$(hash_file "$PACKAGE/lib$dylib.dylib")"
     done

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -211,12 +211,72 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         )
         self.assertIn("_glibc_openui_relative_time_v1_format", text)
         self.assertIn(
-            "EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$RELATIVE_TIME_HOST",
+            "EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST",
             text,
         )
         self.assertIn("@rpath/libOpenRelativeTime.dylib", text)
         self.assertNotIn(
             "-install_name /usr/lib/libOpenRelativeTime.dylib",
+            text,
+        )
+
+    def test_foundation_intl_bridge_is_packaged_preloaded_and_in_closure(self) -> None:
+        text = BUILD.read_text()
+        self.assertIn(
+            "== build the OpenFoundationInternationalization Darwin bridge and Linux host helper",
+            text,
+        )
+        self.assertIn(
+            "full/foundationinternationalization/OpenFoundationInternationalizationBridge.c",
+            text,
+        )
+        self.assertIn(
+            "full/foundationinternationalization/OpenFoundationInternationalizationHost.c",
+            text,
+        )
+        self.assertIn(
+            "full/foundationinternationalization/build_host_helper.sh",
+            text,
+        )
+        self.assertIn("run_link libOpenFoundationInternationalization ", text)
+        self.assertIn(
+            "FOUNDATION_INTL_DARWIN=$PACKAGE/libOpenFoundationInternationalization.dylib",
+            text,
+        )
+        self.assertIn(
+            "FOUNDATION_INTL_HOST=$HOST_BRIDGE_DIR/libOpenFoundationInternationalizationHost.so",
+            text,
+        )
+        self.assertIn(
+            "-install_name @rpath/libOpenFoundationInternationalization.dylib",
+            text,
+        )
+        self.assertNotIn(
+            "-install_name /usr/lib/libOpenFoundationInternationalization.dylib",
+            text,
+        )
+        self.assertIn("full/xcodeplan/rewrite_macho_dependency.py", text)
+        self.assertIn(
+            'python3 -B "$MACHO_DEPENDENCY_REWRITER" "$PACKAGE/lib_FoundationICU.dylib"',
+            text,
+        )
+        self.assertIn("/usr/lib/libOpenFoundationInternationalization.dylib", text)
+        self.assertIn("@rpath/libOpenFoundationInternationalization.dylib", text)
+        self.assertNotIn("install_name_tool", text)
+        self.assertIn(
+            "OPEN_FOUNDATION_INTERNATIONALIZATION_HOST_OK realpath=bounded,versioned",
+            text,
+        )
+        self.assertIn(
+            "EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST",
+            text,
+        )
+        self.assertIn(
+            'package/libOpenFoundationInternationalization.dylib',
+            text,
+        )
+        self.assertIn(
+            "runtime-closure inventory omitted package/libOpenFoundationInternationalization.dylib",
             text,
         )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #34 and the authority inventory reconciliation (`c762ada3`), `== package ten reusable guest dylibs` passes. The gate then stops at:

```
== compile and link the project-owned guest harness
focus_widget_guest_attest: cannot resolve LC_LOAD_DYLIB /usr/lib/libOpenFoundationInternationalization.dylib required by package/lib_FoundationICU.dylib
```

The pinned FI builder links `lib_FoundationICU.dylib` against a Darwin-side `libOpenFoundationInternationalization.dylib` installed at `/usr/lib`. That image is not in the onboarding package or the read-only machorun root.

## Change

Same Darwin-bridge + Linux-host pair as OpenRelativeTime / OpenDispatch, using the frameworks lane's committed provider:

- Build `libOpenFoundationInternationalization.dylib` into `$PACKAGE` with `@rpath` (do not write it into MRROOT).
- Rewrite `lib_FoundationICU.dylib`'s `LC_LOAD_DYLIB` from `/usr/lib/libOpenFoundationInternationalization.dylib` to `@rpath/libOpenFoundationInternationalization.dylib` with `full/xcodeplan/rewrite_macho_dependency` (not `install_name_tool`). ICU already has `-rpath @loader_path`.
- Build `libOpenFoundationInternationalizationHost.so` via `full/foundationinternationalization/build_host_helper.sh` and preload it with Dispatch and relative-time.
- Fail closed if the attest runtime-closure inventory does not name `package/libOpenFoundationInternationalization.dylib`.

Unit tests cover: bridge dylib packaged at `@rpath`, host helper preloaded, closure inventory names it, rewriter used.

## Operator

Same gate on current main:

```
full/swiftui/build_focus_onboarding_guest.sh <normalized-bundles-directory>
```

Next expected `==` after the harness link: `== run exact Focus interaction path on Linux/machorun`. PASS marker unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

