### PR TITLE
Keep arm64 libswiftcompat in sync with source; unexport nine on x86

### DIFF
--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -241,7 +241,10 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
     reads: extensionless `Foundation` / `CoreFoundation` loud-abort stubs
     (`scripts/build_runtime_shims.sh STUBS_ONLY=1`, `x86_64-apple-macos`),
     `libswiftcompat.dylib` (`swiftcore-macho/scripts/build_compat.sh`; never
-    the arm64 `artifacts/libswiftcompat.dylib`), `libswiftCore.dylib` (already
+    the arm64 `artifacts/libswiftcompat.dylib` — x86 unexports the nine
+    symbols x86 `libSystem` already defines via
+    `sdk/compat/x86_unexported_symbols.txt`; the arm64 artifact stays
+    byte-identical because staged arm64 `libSystem` exports none of them), `libswiftCore.dylib` (already
     from `mrroot-base-x86`), `libswift_Concurrency.dylib` /
     `libswiftObjectiveC.dylib` from the x86 overlay search (Apple-SDK
     ObjectiveC is named in `missing=` rather than stubbed). Host ELF files

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -65,7 +65,8 @@ for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
     "$ROOT/full/relativetime/build_host_helper.sh" \
     "$ROOT/full/foundationinternationalization/build_host_helper.sh" \
     "$ROOT/scripts/x86/ud_guest.inc" \
-    "$ROOT/scripts/build_runtime_shims.sh"; do
+    "$ROOT/scripts/build_runtime_shims.sh" \
+    "$ROOT/swiftcore-macho/scripts/test_compat_source.sh"; do
     if bash -n "$s"; then
         ok "bash -n $(basename "$s")"
     else
@@ -1060,6 +1061,35 @@ if [ -d "$SYS/usr/lib" ]; then
 else
     die_test "x86 sysroot missing; cannot build loud-abort stubs"
 fi
+
+expect_grep 'x86_unexported_symbols.txt' \
+    "$ROOT/swiftcore-macho/scripts/build_compat.sh" \
+    "x86 compat omits overlap via the committed unexport list"
+expect_file "$ROOT/swiftcore-macho/sdk/compat/x86_unexported_symbols.txt"
+expect_file "$ROOT/swiftcore-macho/artifacts/libswiftcompat.source.json"
+expect_file "$ROOT/swiftcore-macho/scripts/test_compat_source.sh"
+if bash "$ROOT/swiftcore-macho/scripts/test_compat_source.sh"; then
+    ok "swiftcompat.c sha matches the pin beside artifacts/libswiftcompat.dylib"
+else
+    die_test "swiftcompat.c sha disagrees with artifacts/libswiftcompat.source.json"
+fi
+# The source-pin test must fail when the recorded sha is not the file's sha.
+PIN_FIX=$(mktemp -d /tmp/phase2-compat-pin.XXXXXX)
+python3 - "$ROOT/swiftcore-macho/artifacts/libswiftcompat.source.json" \
+    "$PIN_FIX/bad.json" <<'PY'
+import json, sys
+from pathlib import Path
+pin = json.loads(Path(sys.argv[1]).read_text())
+pin["swiftcompat.c"]["sha256"] = "0" * 64
+Path(sys.argv[2]).write_text(json.dumps(pin))
+PY
+if COMPAT_SOURCE_PIN=$PIN_FIX/bad.json \
+    bash "$ROOT/swiftcore-macho/scripts/test_compat_source.sh" >/dev/null 2>&1; then
+    die_test "test_compat_source.sh passed with a mismatched swiftcompat.c sha"
+else
+    ok "test_compat_source.sh fails when swiftcompat.c sha disagrees with the pin"
+fi
+rm -rf "$PIN_FIX"
 
 echo "== env-prepare with FULL_OUT_SUFFIX=-x86_64 never resolves unsuffixed arm64 trees"
 PREP_FIX=$(mktemp -d /tmp/phase2-prepare-suffix.XXXXXX)

--- a/swiftcore-macho/artifacts/libswiftcompat.source.json
+++ b/swiftcore-macho/artifacts/libswiftcompat.source.json
@@ -1,0 +1,10 @@
+{
+  "artifact": "libswiftcompat.dylib",
+  "arch": "arm64",
+  "artifactSha256": "d038be7a050624241339a43f794005ea376a8e54609fc14d0a689d6ea5fb7593",
+  "artifactBytes": 52848,
+  "swiftcompat.c": {
+    "path": "sdk/compat/swiftcompat.c",
+    "sha256": "62e54cd90a17479b058936b1dee5f1a721c86559279c56548d8046c1054757c1"
+  }
+}

--- a/swiftcore-macho/scripts/build_compat.sh
+++ b/swiftcore-macho/scripts/build_compat.sh
@@ -96,6 +96,27 @@ mkdir -p "$(dirname "$OUT")"
   -fno-exceptions -fno-rtti \
   -c "$SRC/shim.cpp" -o "$tmp/shim.o"
 
+# x86-only: unexport the nine symbols x86 libSystem already defines. The
+# arm64 staged libSystem (scratch/mrroot_full, scratch/sysroot_fe4) exports
+# none of them, so the committed arm64 artifacts/libswiftcompat.dylib must
+# keep them. Do not delete them from swiftcompat.c. List:
+# sdk/compat/x86_unexported_symbols.txt
+unexport=()
+case "$SWIFTCORE_CLANG_TARGET" in
+  x86_64-*)
+    unexport_list=$SCRIPT_DIR/../sdk/compat/x86_unexported_symbols.txt
+    [ -f "$unexport_list" ] || {
+      echo "build_compat: missing $unexport_list" >&2
+      exit 2
+    }
+    while IFS= read -r s; do
+      [ -n "$s" ] || continue
+      case "$s" in \#*) continue ;; esac
+      unexport+=(-Wl,-unexported_symbol,"$s")
+    done < "$unexport_list"
+    ;;
+esac
+
 "$CXX" -target "$SWIFTCORE_CLANG_TARGET" -isysroot "$SDK" \
   -fuse-ld=lld -B "$LLD_BIN" \
   -dynamiclib -install_name /usr/lib/libswiftcompat.dylib \
@@ -104,6 +125,7 @@ mkdir -p "$(dirname "$OUT")"
   "$tmp/swiftcompat.o" "$tmp/shim.o" \
   -lSystem -lc++ \
   -Wl,-undefined,dynamic_lookup \
+  "${unexport[@]}" \
   -o "$tmp/libswiftcompat.dylib"
 
 "$NM" --defined-only --extern-only "$tmp/libswiftcompat.dylib" \

--- a/swiftcore-macho/scripts/test_compat_source.sh
+++ b/swiftcore-macho/scripts/test_compat_source.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Grade the committed arm64 libswiftcompat.dylib against the source that is
+# supposed to have built it. A swiftcompat.c edit that does not rebuild the
+# staged artifact is the stale-artefact class (084a028c).
+#
+# Also records the arch split that forbids deleting the nine x86-overlap
+# symbols from the shared source: x86 libSystem exports them, the staged
+# arm64 libSystem does not.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+fail=0
+ok() { echo "  OK  $*"; }
+bad() { echo "  FAIL $*"; fail=1; }
+
+SRC=$ROOT/sdk/compat/swiftcompat.c
+ART=$ROOT/artifacts/libswiftcompat.dylib
+PIN=${COMPAT_SOURCE_PIN:-$ROOT/artifacts/libswiftcompat.source.json}
+UNEXPORT=$ROOT/sdk/compat/x86_unexported_symbols.txt
+MAN=$ROOT/artifacts/arm64.manifest.json
+NM=${NM:-llvm-nm-18}
+command -v "$NM" >/dev/null 2>&1 || NM=llvm-nm
+
+[ -f "$SRC" ] || { echo "REFUSING: no $SRC" >&2; exit 2; }
+[ -f "$ART" ] || { echo "REFUSING: no $ART" >&2; exit 2; }
+[ -f "$PIN" ] || { echo "REFUSING: no $PIN (source sha must sit beside the artifact)" >&2; exit 2; }
+
+src_sha=$(sha256sum "$SRC" | awk '{print $1}')
+art_sha=$(sha256sum "$ART" | awk '{print $1}')
+art_bytes=$(wc -c < "$ART" | tr -d ' ')
+
+python3 - "$PIN" "$src_sha" "$art_sha" "$art_bytes" "$MAN" <<'PY' || fail=1
+import json, sys
+from pathlib import Path
+pin_path, src_sha, art_sha, art_bytes, man_path = sys.argv[1:]
+pin = json.loads(Path(pin_path).read_text())
+bad = 0
+want_src = pin["swiftcompat.c"]["sha256"]
+if src_sha != want_src:
+    print(f"  FAIL swiftcompat.c sha {src_sha} != recorded {want_src}")
+    print("       rebuild artifacts/libswiftcompat.dylib from this source")
+    print("       (or restore the source that built the staged artifact)")
+    bad = 1
+else:
+    print(f"  OK  swiftcompat.c sha matches {want_src}")
+want_art = pin["artifactSha256"]
+if art_sha != want_art:
+    print(f"  FAIL {pin['artifact']} sha {art_sha} != recorded {want_art}")
+    bad = 1
+else:
+    print(f"  OK  {pin['artifact']} sha matches {want_art}")
+if int(art_bytes) != int(pin["artifactBytes"]):
+    print(f"  FAIL {pin['artifact']} bytes {art_bytes} != recorded {pin['artifactBytes']}")
+    bad = 1
+man = json.loads(Path(man_path).read_text())
+man_ent = man["files"].get("libswiftcompat.dylib")
+if not man_ent:
+    print("  FAIL arm64.manifest.json has no libswiftcompat.dylib")
+    bad = 1
+elif man_ent["sha256"] != art_sha or int(man_ent["bytes"]) != int(art_bytes):
+    print("  FAIL arm64.manifest.json disagrees with the staged artifact")
+    bad = 1
+else:
+    print("  OK  arm64.manifest.json matches the staged artifact")
+sys.exit(1 if bad else 0)
+PY
+
+echo
+echo "=== arm64 artifact still exports the nine x86-overlap names ==="
+[ -f "$UNEXPORT" ] || { bad "missing $UNEXPORT"; UNEXPORT=/dev/null; }
+art_syms=$("$NM" --defined-only --extern-only "$ART" 2>/dev/null | awk '{print $NF}' | sort -u)
+nine=0
+while IFS= read -r s; do
+  [ -n "$s" ] || continue
+  case "$s" in \#*) continue ;; esac
+  nine=$((nine + 1))
+  echo "$art_syms" | grep -qx "$s" && ok "artifact exports $s" || bad "artifact missing $s"
+done < "$UNEXPORT"
+[ "$nine" -eq 9 ] && ok "unexport list has 9 names" || bad "unexport list has $nine names, expected 9"
+
+echo
+echo "=== nm both libSystem builds (skip a side that is absent) ==="
+X86_SYS=${X86_LIBSYSTEM:-$ROOT/../machorun/darwin/usr/lib/libSystem.B.dylib}
+ARM_SYS=${ARM_LIBSYSTEM:-}
+for cand in \
+    "$ROOT/../scratch/mrroot_full/darwin/usr/lib/libSystem.B.dylib" \
+    "$ROOT/../scratch/sysroot_fe4/usr/lib/libSystem.B.dylib"; do
+  [ -f "$cand" ] || continue
+  if llvm-otool-18 -hv "$cand" 2>/dev/null | grep -Eq 'MH_MAGIC_64[[:space:]]+ARM64'; then
+    ARM_SYS=$cand
+    break
+  fi
+done
+nm_has() {
+  local f=$1 s=$2
+  "$NM" --defined-only --extern-only "$f" 2>/dev/null | awk '{print $NF}' | grep -qx "$s"
+}
+
+if [ -f "$X86_SYS" ] && llvm-otool-18 -hv "$X86_SYS" 2>/dev/null | grep -Eq 'MH_MAGIC_64[[:space:]]+X86_64'; then
+  x_hit=0
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    case "$s" in \#*) continue ;; esac
+    if nm_has "$X86_SYS" "$s"; then x_hit=$((x_hit + 1)); else bad "x86 libSystem missing $s"; fi
+  done < "$UNEXPORT"
+  [ "$x_hit" -eq 9 ] && ok "x86 libSystem exports all 9 ($X86_SYS)" \
+    || bad "x86 libSystem hit $x_hit/9"
+else
+  echo "  skip x86 libSystem (not an X86_64 Mach-O at $X86_SYS)"
+fi
+
+if [ -n "${ARM_SYS:-}" ] && [ -f "$ARM_SYS" ] \
+    && llvm-otool-18 -hv "$ARM_SYS" 2>/dev/null | grep -Eq 'MH_MAGIC_64[[:space:]]+ARM64'; then
+  a_hit=0
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    case "$s" in \#*) continue ;; esac
+    nm_has "$ARM_SYS" "$s" && a_hit=$((a_hit + 1)) && bad "arm64 libSystem unexpectedly exports $s"
+  done < "$UNEXPORT"
+  [ "$a_hit" -eq 0 ] && ok "arm64 libSystem exports none of the 9 ($ARM_SYS)" \
+    || bad "arm64 libSystem hit $a_hit/9 (drop would be right only if this is 9)"
+else
+  echo "  skip arm64 libSystem (no ARM64 Mach-O libSystem.B.dylib in scratch/)"
+fi
+
+hdr=$(llvm-otool-18 -hv "$ART" 2>/dev/null || true)
+echo "$hdr" | grep -Eq 'MH_MAGIC_64[[:space:]]+ARM64' && ok "staged artifact is MH_MAGIC_64 ARM64" \
+  || bad "staged artifact is not ARM64"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- swiftcompat.c sha matches the pin beside artifacts/libswiftcompat.dylib"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_staged_slice.sh
+++ b/swiftcore-macho/scripts/test_staged_slice.sh
@@ -107,6 +107,15 @@ sys.exit(1 if bad else 0)
 PY
 
 echo
+echo "=== libswiftcompat source pin matches the staged arm64 artifact ==="
+if bash "$ROOT/scripts/test_compat_source.sh"; then
+  echo "  OK  swiftcompat.c sha matches artifacts/libswiftcompat.source.json"
+else
+  echo "  FAIL swiftcompat.c / staged artifact pin"
+  fail=1
+fi
+
+echo
 if [ "$fail" -eq 0 ]; then
   echo "PASS -- arm64 pin intact, x86_64 is MH_MAGIC_64 X86_64 beside it"
   exit 0

--- a/swiftcore-macho/sdk/compat/swiftcompat.c
+++ b/swiftcore-macho/sdk/compat/swiftcompat.c
@@ -1,18 +1,18 @@
 /* libswiftcompat.dylib — the exact gap between what our cross-built
  * libswiftCore.dylib imports and what machorun's self-hosted libSystem /
- * libc++ / libobjc export. The live export count is whatever
- * scripts/build_compat.sh prints after the disjointness assertion.
+ * libc++ / libobjc export. 29 symbols, enumerated by scripts/verify.sh, not
+ * guessed.
  *
  * This is deliberately a SEPARATE dylib in this repository rather than an edit
  * to machorun: it keeps the measurement honest (the gap stays visible and
  * countable) and leaves ~/machorun read-only.
  *
  * Symbols are grouped by how real the implementation is:
- *   REAL     — a correct implementation (the arithmetic builtins,
- *              dispatch_once_f).
+ *   REAL     — a correct implementation (the arithmetic builtins, getline,
+ *              getsectiondata, dispatch_once_f, the locale strtod family).
  *   BENIGN   — correct for our purposes, where the Darwin behaviour is either
  *              trivially reproducible or genuinely unused off Apple hardware
- *              (availability checks, flockfile).
+ *              (availability checks, malloc zones, flockfile).
  *
  * There is no longer a BIND-ONLY class, and that is the point of this file's
  * one hard rule:
@@ -34,8 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-#include <sched.h>
-#include <time.h>
+#include <pthread.h>
 
 #define SHIM(name) __asm__(name) __attribute__((visibility("default")))
 
@@ -86,21 +85,88 @@ s128 __modti3(s128 a, s128 b) {
     return neg ? -(s128)r : (s128)r;
 }
 
-/* DELETED 2026-09-03: getline, getsectiondata, strtod_l / strtof_l / strtold_l,
- * os_system_version_get_current_version, malloc_zone_from_ptr,
- * pthread_get_stackaddr_np, pthread_get_stacksize_np.
- *
- * machorun's libSystem (darwin/src/libsystem.c) now exports all nine. The
- * x86_64 in-tree dylib grades them as overlap, and build_compat.sh refuses to
- * emit a colliding shim. Same rule as the 2026-08-27 libc++abi cut: delete
- * from this file, do not keep a second copy.
+/* ---------------------------------------------------------------- REAL ----
+ * getline(3). POSIX; machorun's libSystem carries getdelim's siblings but not
+ * this one.
  */
+ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+    if (!lineptr || !n || !stream) return -1;
+    size_t cap = *n, len = 0;
+    char *buf = *lineptr;
+    if (!buf || cap == 0) { cap = 128; buf = (char *)malloc(cap); if (!buf) return -1; }
+    for (;;) {
+        int c = fgetc(stream);
+        if (c == EOF) { if (len == 0) { *lineptr = buf; *n = cap; return -1; } break; }
+        if (len + 2 > cap) {
+            size_t ncap = cap * 2;
+            char *nb = (char *)realloc(buf, ncap);
+            if (!nb) { *lineptr = buf; *n = cap; return -1; }
+            buf = nb; cap = ncap;
+        }
+        buf[len++] = (char)c;
+        if (c == '\n') break;
+    }
+    buf[len] = '\0';
+    *lineptr = buf; *n = cap;
+    return (ssize_t)len;
+}
 
 /* ---------------------------------------------------------------- REAL ----
- * Mach-O header type for _NSGetMachExecuteHeader. Layout constants are from
- * the Mach-O format, not from an Apple header.
+ * getsectiondata(3): walk the Mach-O load commands of an already-loaded image.
+ * Layout constants are from the Mach-O format, not from an Apple header.
  */
 struct mh { uint32_t magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags, reserved; };
+struct lc { uint32_t cmd, cmdsize; };
+struct seg64 {
+    uint32_t cmd, cmdsize; char segname[16];
+    uint64_t vmaddr, vmsize, fileoff, filesize;
+    uint32_t maxprot, initprot, nsects, flags;
+};
+struct sect64 {
+    char sectname[16], segname[16];
+    uint64_t addr, size;
+    uint32_t offset, align, reloff, nreloc, flags, reserved1, reserved2, reserved3;
+};
+#define LC_SEGMENT_64 0x19
+
+uint8_t *getsectiondata(const struct mh *header, const char *segname,
+                        const char *sectname, unsigned long *size) {
+    if (!header) return NULL;
+    const uint8_t *p = (const uint8_t *)header + sizeof(struct mh);
+    /* Slide: vmaddr in the file vs where the image actually landed. */
+    intptr_t slide = 0;
+    int have_slide = 0;
+    for (uint32_t i = 0; i < header->ncmds; i++) {
+        const struct lc *c = (const struct lc *)p;
+        if (c->cmd == LC_SEGMENT_64) {
+            const struct seg64 *s = (const struct seg64 *)c;
+            if (!have_slide && strncmp(s->segname, "__TEXT", 16) == 0) {
+                slide = (intptr_t)header - (intptr_t)s->vmaddr;
+                have_slide = 1;
+            }
+        }
+        p += c->cmdsize;
+    }
+    p = (const uint8_t *)header + sizeof(struct mh);
+    for (uint32_t i = 0; i < header->ncmds; i++) {
+        const struct lc *c = (const struct lc *)p;
+        if (c->cmd == LC_SEGMENT_64) {
+            const struct seg64 *s = (const struct seg64 *)c;
+            if (strncmp(s->segname, segname, 16) == 0) {
+                const struct sect64 *sec = (const struct sect64 *)(s + 1);
+                for (uint32_t j = 0; j < s->nsects; j++, sec++) {
+                    if (strncmp(sec->sectname, sectname, 16) == 0) {
+                        if (size) *size = (unsigned long)sec->size;
+                        return (uint8_t *)(sec->addr + slide);
+                    }
+                }
+            }
+        }
+        p += c->cmdsize;
+    }
+    if (size) *size = 0;
+    return NULL;
+}
 
 /* _NSGetMachExecuteHeader: the main executable's header. machorun's libSystem
  * exports no dyld image APIs at all (it has only the _NSGetArgc/Argv family),
@@ -134,6 +200,14 @@ void dispatch_once_f(dispatch_once_t *pred, void *ctx, void (*fn)(void *)) {
     while (__atomic_load_n(pred, __ATOMIC_ACQUIRE) != 2) sched_yield();
 }
 
+/* ---------------------------------------------------------------- REAL ----
+ * The locale-aware strtod family. The stdlib calls these with the C locale
+ * only (_swift_stdlib_strtod_clocale and friends), which is what strtod does.
+ */
+double      strtod_l (const char *s, char **e, void *loc) { (void)loc; return strtod(s, e); }
+float       strtof_l (const char *s, char **e, void *loc) { (void)loc; return strtof(s, e); }
+long double strtold_l(const char *s, char **e, void *loc) { (void)loc; return strtold(s, e); }
+
 /* -------------------------------------------------------------- BENIGN ----
  * Availability. Every check is against the deployment target of a system we
  * are emulating in full, so "yes" is the honest answer here.
@@ -146,11 +220,38 @@ int32_t __isPlatformOrVariantPlatformVersionAtLeast(uint32_t p, uint32_t ma, uin
                                                     uint32_t mi2, uint32_t su2) {
     (void)p; (void)ma; (void)mi; (void)su; (void)p2; (void)ma2; (void)mi2; (void)su2; return 1;
 }
+typedef struct { uint32_t major, minor, patch; } os_sysver_t;
+/* Mach-O adds the leading underscore; the C name carries none. */
+os_sysver_t os_system_version_get_current_version(void) {
+    os_sysver_t v = { 15, 0, 0 };
+    return v;
+}
 int _dyld_is_objc_constant(const void *p) { (void)p; return 0; }
+
+/* -------------------------------------------------------------- BENIGN ----
+ * Malloc zones. machorun's allocator is a single flat heap with no zone
+ * concept; NULL is what Darwin returns for a pointer it does not own, and it
+ * is the answer the one caller (-[_TtCs12_SwiftObject zone]) handles.
+ */
+void *malloc_zone_from_ptr(const void *p) { (void)p; return NULL; }
 
 /* stdio locking: machorun is not multiplexing FILE* across threads. */
 void flockfile(FILE *f)   { (void)f; }
 void funlockfile(FILE *f) { (void)f; }
+
+/* pthread stack introspection. Darwin's pthread.h has no pthread_getattr_np
+ * (that is a glibc extension), and we are compiling against Darwin headers, so
+ * this is derived from the caller's own frame: Darwin's _np accessors return
+ * the stack *base* (highest address) and its size. The stdlib uses these only
+ * to decide whether a pointer looks stack-allocated, so a conservative window
+ * around the current frame is the right shape of answer. */
+#define SHIM_DEFAULT_STACK (8u * 1024u * 1024u)
+void *pthread_get_stackaddr_np(pthread_t t) {
+    (void)t;
+    uintptr_t here = (uintptr_t)__builtin_frame_address(0);
+    return (void *)((here + SHIM_DEFAULT_STACK) & ~(uintptr_t)(SHIM_DEFAULT_STACK - 1));
+}
+size_t pthread_get_stacksize_np(pthread_t t) { (void)t; return SHIM_DEFAULT_STACK; }
 
 /* ----------------------------------------------------------------- C++ ----
  * libc++ / libc++abi pieces machorun's 60 KB libc++.1.dylib does not carry.

--- a/swiftcore-macho/sdk/compat/x86_unexported_symbols.txt
+++ b/swiftcore-macho/sdk/compat/x86_unexported_symbols.txt
@@ -1,0 +1,17 @@
+# Mach-O names (leading underscore). build_compat.sh passes
+# -Wl,-unexported_symbol for each when SWIFTCORE_CLANG_TARGET is x86_64-*.
+# nm --defined-only --extern-only on this tree (2026-09-03):
+#   x86_64  machorun/darwin/usr/lib/libSystem.B.dylib          all nine present
+#   arm64   scratch/mrroot_full/darwin/usr/lib/libSystem.B.dylib  none present
+#   arm64   scratch/sysroot_fe4/usr/lib/libSystem.B.dylib         none present
+# The committed arm64 artifacts/libswiftcompat.dylib must keep exporting
+# these; dropping them from swiftcompat.c would starve the arm64 guest.
+_getline
+_getsectiondata
+_malloc_zone_from_ptr
+_os_system_version_get_current_version
+_pthread_get_stackaddr_np
+_pthread_get_stacksize_np
+_strtod_l
+_strtof_l
+_strtold_l


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`084a028c` dropped nine symbols from `swiftcore-macho/sdk/compat/swiftcompat.c` without rebuilding `artifacts/libswiftcompat.dylib` (52848 bytes, staged by `machorun/scripts/stage_swiftcore.sh` on both arches). Source and staged binary disagreed — the repo's stale-artefact class.

## nm on both libSystem builds (2026-09-03)

The nine names: `_getline`, `_getsectiondata`, `_malloc_zone_from_ptr`, `_os_system_version_get_current_version`, `_pthread_get_stackaddr_np`, `_pthread_get_stacksize_np`, `_strtod_l`, `_strtof_l`, `_strtold_l`.

| image | arch | of the nine |
|---|---|---|
| `machorun/darwin/usr/lib/libSystem.B.dylib` | x86_64 | **all 9 present** |
| `scratch/mrroot_full/darwin/usr/lib/libSystem.B.dylib` | arm64 | **none** |
| `scratch/sysroot_fe4/usr/lib/libSystem.B.dylib` | arm64 | **none** |
| `artifacts/libswiftcompat.dylib` (staged) | arm64 | all 9 exported |

Dropping them from the shared source would starve the arm64 guest. The operator's 2026-09-03 arm64 duplicate list of six of these names does not match the staged arm64 `libSystem` in this tree, so this PR takes option **(b)**.

## What changed

- Restored `swiftcompat.c` to the source that built `artifacts/libswiftcompat.dylib` (`d038be7a…`, 52848 bytes, 34 exports). Arm64 artifact is **byte-identical**; manifests unchanged.
- `build_compat.sh` passes `-Wl,-unexported_symbol` for those nine when `SWIFTCORE_CLANG_TARGET` is `x86_64-*` (`sdk/compat/x86_unexported_symbols.txt`). x86 live build: 25 exports, disjoint from machorun userland.
- `artifacts/libswiftcompat.source.json` records `swiftcompat.c`'s sha beside the staged artifact.
- `scripts/test_compat_source.sh` fails when that sha disagrees. Wired into `test_staged_slice.sh` and `scripts/x86/test_phase2.sh`.

`machorun/` is not edited.

## Tests

- `bash swiftcore-macho/scripts/test_compat_source.sh` — PASS (source pin, artifact pin, nm both libSystems)
- `bash scripts/x86/test_phase2.sh` — **319/319** (includes a negative: mismatched pin fails)

[compat source pin, nm both libSystems, arm64 artifact unchanged](https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompat_source_pin.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f830f51-28a1-4151-8e56-3dd0cf5e8680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

