### PR TITLE
Compose the onboarding machorun preload after Dispatch with every built host helper

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -780,10 +780,9 @@ run_link libOpenRelativeTime "${LD[@]}" -dylib -dead_strip -undefined dynamic_lo
     -install_name @rpath/libOpenRelativeTime.dylib -rpath @loader_path \
     -map "$AUDIT/libOpenRelativeTime.link-map" \
     -o "$RELATIVE_TIME_DARWIN" "$OUT/open-relative-time-bridge.o"
-clang-18 -std=c11 -O2 -fPIC -fvisibility=hidden -Wall -Wextra -Werror \
-    -I "$PACKAGE/include/COpenRelativeTime" -shared \
-    "$W/full/relativetime/OpenRelativeTimeHost.c" \
-    -o "$RELATIVE_TIME_HOST" -licui18n -licuuc -lm
+bash "$W/full/relativetime/build_host_helper.sh" \
+    --repo "$W" --host-dir "$HOST_BRIDGE_DIR" \
+    --include-dir "$PACKAGE/include/COpenRelativeTime"
 clang-18 -std=c11 -O2 -Wall -Wextra -Werror \
     -I "$PACKAGE/include/COpenRelativeTime" \
     "$W/full/relativetime/OpenRelativeTimeHost.c" \
@@ -1135,7 +1134,6 @@ awk -F '\t' '
 echo '== run exact Focus interaction path on Linux/machorun'
 echo '== build Linux Dispatch host bridge'
 DISPATCH_HOST=$HOST_BRIDGE_DIR/libOpenDispatchHost.so
-EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST
 host_bridge_args=(
     --repo "$W"
     --host-dir "$HOST_BRIDGE_DIR"
@@ -1152,6 +1150,18 @@ fi
 bash "$W/full/dispatch/build_host_bridge.sh" "${host_bridge_args[@]}"
 [ -f "$DISPATCH_HOST" ] && [ ! -L "$DISPATCH_HOST" ] \
     || die "Linux Dispatch host helper is missing: $DISPATCH_HOST"
+
+echo '== compose Linux host preload'
+# Frameworks PLATFORM_HOST_PRELOAD order is dispatch, FI, URL transport,
+# relative-time. This harness excludes URLSession.swift, so it does not
+# bind OpenURLTransport and omits that helper.
+for helper in "$DISPATCH_HOST" "$FOUNDATION_INTL_HOST" "$RELATIVE_TIME_HOST"; do
+    [ -f "$helper" ] && [ ! -L "$helper" ] \
+        || die "Linux host helper is missing from the run preload: $helper"
+done
+EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST
+printf 'LD_PRELOAD=%s\n' \
+    "$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}"
 if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
     echo "focus_onboarding_guest: compile/link may proceed on this VM; execution of arm64 guests cannot" >&2
     bash "${W:-$(git rev-parse --show-toplevel)}/.cursor/refuse-arm64-execution.sh" \

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -200,6 +200,7 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("full/relativetime/OpenRelativeTimeHost.c", text)
         self.assertIn("full/relativetime/OpenRelativeTimeHostTests.c", text)
         self.assertIn("run_link libOpenRelativeTime ", text)
+        self.assertIn("full/relativetime/build_host_helper.sh", text)
         self.assertIn("RELATIVE_TIME_DARWIN=$PACKAGE/libOpenRelativeTime.dylib", text)
         self.assertIn(
             "RELATIVE_TIME_HOST=$HOST_BRIDGE_DIR/libOpenRelativeTimeHost.so",
@@ -278,6 +279,54 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn(
             "runtime-closure inventory omitted package/libOpenFoundationInternationalization.dylib",
             text,
+        )
+
+    def test_run_step_preloads_every_built_host_helper(self) -> None:
+        text = BUILD.read_text()
+        run = text.split(
+            "== run exact Focus interaction path on Linux/machorun", 1
+        )[1]
+        helpers = sorted(set(re.findall(r"libOpen[A-Za-z]+Host\.so", text)))
+        self.assertEqual(
+            helpers,
+            [
+                "libOpenDispatchHost.so",
+                "libOpenFoundationInternationalizationHost.so",
+                "libOpenRelativeTimeHost.so",
+            ],
+        )
+        self.assertNotIn("libOpenURLTransportHost.so", text)
+        assignments = dict(
+            re.findall(
+                r"^([A-Z0-9_]+)=\$HOST_BRIDGE_DIR/(libOpen[A-Za-z]+Host\.so)$",
+                text,
+                re.MULTILINE,
+            )
+        )
+        inverse = {name: var for var, name in assignments.items()}
+        preload_lines = [
+            line
+            for line in run.splitlines()
+            if line.startswith("EARLY_PLATFORM_HOST_PRELOAD=")
+        ]
+        self.assertEqual(len(preload_lines), 1, preload_lines)
+        preload_line = preload_lines[0]
+        self.assertEqual(
+            preload_line,
+            "EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST",
+        )
+        for helper in helpers:
+            self.assertIn(helper, inverse)
+            self.assertIn(f"${inverse[helper]}", preload_line)
+        self.assertIn("== compose Linux host preload", run)
+        self.assertIn("printf 'LD_PRELOAD=%s\\n'", run)
+        self.assertLess(
+            run.index('bash "$W/full/dispatch/build_host_bridge.sh"'),
+            run.index("EARLY_PLATFORM_HOST_PRELOAD="),
+        )
+        self.assertLess(
+            run.index("EARLY_PLATFORM_HOST_PRELOAD="),
+            run.index('LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD'),
         )
 
     def test_foundation_runtime_closure_is_exact_and_mutation_sensitive(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #37 (`main` `845be23e`) compiles and links the onboarding guest harness and reaches `== run exact Focus interaction path on Linux/machorun`. The guest then dies:

```
== build Linux Dispatch host bridge
machorun: undefined symbol '_glibc_openui_relative_time_v1_format'  (rc=73)
```

The run step rebuilt Dispatch and invoked machorun without a verified, logged preload. Relative-time and FI host helpers were already built, but the Dispatch-only banner made the composition easy to drop.

## Change

- Compose `EARLY_PLATFORM_HOST_PRELOAD` **after** the Dispatch host bridge, in the frameworks `PLATFORM_HOST_PRELOAD` order: dispatch, FI, relative-time.
- URL transport is omitted because this harness still excludes `URLSession.swift`.
- Fail closed if any of those three `.so` files is missing, and print the final `LD_PRELOAD=` line.
- Build the relative-time host helper through `full/relativetime/build_host_helper.sh`.
- Unit test: every `libOpen*Host.so` the gate builds appears in the run-step preload.

## Operator

Same gate on current main:

```
full/swiftui/build_focus_onboarding_guest.sh <normalized-bundles-directory>
```

Log should show `== compose Linux host preload` and `LD_PRELOAD=` naming all three helpers before machorun. Expected next: `FOCUS_ONBOARDING_MACHO_GUEST_OK …` or the next undefined symbol.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

