### PR TITLE
Stage onboarding _glibc_ bridges in a run-local Darwin overlay

### DIFF
--- a/full/relativetime/OpenRelativeTimeHost.c
+++ b/full/relativetime/OpenRelativeTimeHost.c
@@ -38,7 +38,7 @@ static URelativeDateTimeUnit relative_unit(int32_t unit, bool *valid)
     }
 }
 
-int32_t openui_relative_time_v1_format(
+OPENUI_RELATIVE_TIME_API int32_t openui_relative_time_v1_format(
     uint32_t abi_version,
     const uint8_t *locale_bytes,
     uint64_t locale_count,

--- a/full/relativetime/include/OpenRelativeTimeABI.h
+++ b/full/relativetime/include/OpenRelativeTimeABI.h
@@ -57,6 +57,4 @@ OPENUI_RELATIVE_TIME_API int32_t openui_relative_time_v1_format(
 }
 #endif
 
-#undef OPENUI_RELATIVE_TIME_API
-
 #endif

--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -117,6 +117,27 @@ run_link() {
     "$@"
 }
 
+assert_no_glibc_host_imports() {
+    local image=$1 label=$2
+    if llvm-nm-18 --undefined-only --extern-only --just-symbol-name "$image" \
+        | grep -q '^_glibc_'; then
+        die "$label imports _glibc_*; keep those in the run-local Darwin-root bridge"
+    fi
+}
+
+# Every machorun invocation must print a site banner and use the same
+# composed host preload plus the run-local Darwin overlay. Site names are
+# how the log identifies which invocation printed rc=73.
+run_machorun_site() {
+    local site=$1
+    shift
+    echo "== machorun site: $site"
+    LD_LIBRARY_PATH="$HOST_BRIDGE_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}" \
+    MACHORUN_ROOT="$RUNROOT" \
+    "$MRROOT/machorun" "$@"
+}
+
 assert_clean_commit() {
     local repo=$1 expected=$2 label=$3 expected_tree=${4:-} actual status actual_tree
     [ -d "$repo/.git" ] || die "$label is not a Git checkout: $repo"
@@ -235,6 +256,16 @@ mkdir -p "$PACKAGE/include/CPortableIO" "$PACKAGE/include/CSTBTrueType" \
     "$PACKAGE/include/COpenDispatch" "$PACKAGE/include/COpenRelativeTime" \
     "$PACKAGE/include/CQuartz" "$PACKAGE/include/CoreFoundation" \
     "$MODULE_CACHE" "$AUDIT" "$OUT/fonts" "$OUT/host"
+echo '== clone shared machorun root into a writable run-local overlay'
+# machorun's host_lookup/_glibc_ path only runs for images served from the
+# darwin-root prefix map (is_runtime). The shared MRROOT is read-only, so
+# stage those bridges in a per-run copy rather than $PACKAGE @rpath images.
+[ "$RUNROOT" != "$MRROOT" ] \
+    || die 'run-local overlay path collided with the shared machorun root'
+mkdir -p "$RUNROOT"
+cp -a "$MRROOT/." "$RUNROOT/"
+chmod -R u+w "$RUNROOT"
+mkdir -p "$RUNROOT/darwin/usr/lib"
 
 git -C "$FOCUS_ROOT" ls-tree -r -z "$EXPECTED_FOCUS_COMMIT" -- focus-ios \
     | while IFS= read -r -d '' record; do
@@ -369,10 +400,15 @@ PACKAGE_CINC=(-Xcc -I"$PACKAGE/include/CPortableIO"
     -Xcc -fmodule-map-file="$PACKAGE/include/CoreFoundation/module.modulemap"
     -Xcc -I"$PACKAGE/include/CoreFoundation")
 HOST_BRIDGE_DIR=$OUT/host
+RUNROOT=$OUT/runroot
+RELATIVE_TIME_RUNTIME=$RUNROOT/darwin/usr/lib/libOpenRelativeTime.dylib
 RELATIVE_TIME_DARWIN=$PACKAGE/libOpenRelativeTime.dylib
 RELATIVE_TIME_HOST=$HOST_BRIDGE_DIR/libOpenRelativeTimeHost.so
+DISPATCH_DARWIN=$RUNROOT/darwin/usr/lib/libOpenDispatch.dylib
+FOUNDATION_INTL_RUNTIME=$RUNROOT/darwin/usr/lib/libOpenFoundationInternationalization.dylib
 FOUNDATION_INTL_DARWIN=$PACKAGE/libOpenFoundationInternationalization.dylib
 FOUNDATION_INTL_HOST=$HOST_BRIDGE_DIR/libOpenFoundationInternationalizationHost.so
+HOST_PRELOAD_DLSYM_PROBE=$W/full/swiftui/host_preload_dlsym_probe.c
 MACHO_DEPENDENCY_REWRITER=$W/full/xcodeplan/rewrite_macho_dependency.py
 FE_OUT=$FULL/foundation/essentials
 FE_COLLECTIONS=$FULL/foundation/collections
@@ -516,7 +552,8 @@ done
 # the umbrella cannot be bounded without that module. Build it from the
 # committed FI script against the same Darwin sysroot / FE module the
 # gate already uses. Do not write the Darwin bridge into the shared
-# machorun root: this harness keeps that tree read-only.
+# machorun root: this harness keeps that tree read-only and stages the
+# `_glibc_*` image in the run-local overlay so machorun will host-lookup.
 echo '== build pinned FoundationInternationalization against the same sysroot'
 for fe_artifact in FoundationEssentials.swiftmodule FoundationEssentials.swiftdoc; do
     [ -f "$FE_OUT/$fe_artifact" ] && [ ! -L "$FE_OUT/$fe_artifact" ] \
@@ -574,13 +611,20 @@ clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
     -I "$W/full/foundationinternationalization/include" \
     -c "$W/full/foundationinternationalization/OpenFoundationInternationalizationBridge.c" \
     -o "$OUT/open-foundation-internationalization-bridge.o"
+run_link libOpenFoundationInternationalizationRuntime "${LD[@]}" -dylib \
+    -dead_strip -undefined dynamic_lookup \
+    -install_name /usr/lib/libOpenFoundationInternationalization.dylib \
+    -map "$AUDIT/libOpenFoundationInternationalizationRuntime.link-map" \
+    -o "$FOUNDATION_INTL_RUNTIME" \
+    "$OUT/open-foundation-internationalization-bridge.o"
 run_link libOpenFoundationInternationalization "${LD[@]}" -dylib -dead_strip \
-    -undefined dynamic_lookup \
+    -ignore_auto_link \
     -install_name @rpath/libOpenFoundationInternationalization.dylib \
     -rpath @loader_path \
     -map "$AUDIT/libOpenFoundationInternationalization.link-map" \
     -o "$FOUNDATION_INTL_DARWIN" \
-    "$OUT/open-foundation-internationalization-bridge.o"
+    -reexport_library "$FOUNDATION_INTL_RUNTIME" \
+    "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
 bash "$W/full/foundationinternationalization/build_host_helper.sh" \
     --repo "$W" --host-dir "$HOST_BRIDGE_DIR" \
     --include-dir "$W/full/foundationinternationalization/include"
@@ -597,6 +641,8 @@ grep -Fx \
     || die 'FoundationInternationalization host marker is missing'
 [ -f "$FOUNDATION_INTL_DARWIN" ] && [ ! -L "$FOUNDATION_INTL_DARWIN" ] \
     || die 'libOpenFoundationInternationalization.dylib is missing after build'
+[ -f "$FOUNDATION_INTL_RUNTIME" ] && [ ! -L "$FOUNDATION_INTL_RUNTIME" ] \
+    || die 'run-local OpenFoundationInternationalization Darwin bridge is missing'
 [ -f "$FOUNDATION_INTL_HOST" ] && [ ! -L "$FOUNDATION_INTL_HOST" ] \
     || die 'libOpenFoundationInternationalizationHost.so is missing after build'
 printf 'openui_foundation_intl_v1_realpath\n' \
@@ -608,10 +654,10 @@ readelf --wide --syms "$FOUNDATION_INTL_HOST" \
     | awk '$5 == "GLOBAL" && $7 != "UND" && $8 ~ /^openui_foundation_intl_v1_/ { print $8 }' \
     | LC_ALL=C sort -u > "$AUDIT/foundation-intl-elf-exports.txt"
 llvm-nm-18 --defined-only --extern-only --just-symbol-name \
-    "$FOUNDATION_INTL_DARWIN" | LC_ALL=C sort -u \
+    "$FOUNDATION_INTL_RUNTIME" | LC_ALL=C sort -u \
     > "$AUDIT/foundation-intl-mach-exports.txt"
 llvm-nm-18 --undefined-only --extern-only --just-symbol-name \
-    "$FOUNDATION_INTL_DARWIN" | LC_ALL=C sort -u \
+    "$FOUNDATION_INTL_RUNTIME" | LC_ALL=C sort -u \
     > "$AUDIT/foundation-intl-mach-imports.txt"
 cmp "$AUDIT/foundation-intl-expected-elf.txt" \
     "$AUDIT/foundation-intl-elf-exports.txt" \
@@ -622,9 +668,21 @@ cmp "$AUDIT/foundation-intl-expected-mach-exports.txt" \
 cmp "$AUDIT/foundation-intl-expected-mach-imports.txt" \
     "$AUDIT/foundation-intl-mach-imports.txt" \
     || die 'FoundationInternationalization Mach-O bridge host import drifted'
+[ "$(llvm-otool-18 -D "$FOUNDATION_INTL_RUNTIME" | tail -n 1)" = \
+    /usr/lib/libOpenFoundationInternationalization.dylib ] \
+    || die 'run-local FoundationInternationalization Mach-O bridge ID drifted'
 [ "$(llvm-otool-18 -D "$FOUNDATION_INTL_DARWIN" | tail -n 1)" = \
     @rpath/libOpenFoundationInternationalization.dylib ] \
     || die 'packaged FoundationInternationalization Mach-O bridge ID drifted'
+assert_no_glibc_host_imports "$FOUNDATION_INTL_DARWIN" \
+    'packaged OpenFoundationInternationalization facade'
+fi_runtime_reexport_count=$(llvm-otool-18 -l "$FOUNDATION_INTL_DARWIN" \
+    | awk '$1 == "cmd" { command = $2 }
+        $1 == "name" && $2 == "/usr/lib/libOpenFoundationInternationalization.dylib" \
+            && command == "LC_REEXPORT_DYLIB" { count++ }
+        END { print count + 0 }')
+[ "$fi_runtime_reexport_count" -eq 1 ] \
+    || die "packaged FI facade Darwin-root reexport count $fi_runtime_reexport_count, expected 1"
 icu_bridge_old=$(llvm-otool-18 -L "$PACKAGE/lib_FoundationICU.dylib" \
     | awk '$1 == "/usr/lib/libOpenFoundationInternationalization.dylib" { count++ } END { print count + 0 }')
 icu_bridge_new=$(llvm-otool-18 -L "$PACKAGE/lib_FoundationICU.dylib" \
@@ -667,6 +725,17 @@ clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
     -I "$PACKAGE/include/COpenDispatch" \
     -c "$W/full/dispatch/OpenDispatchBridge.c" \
     -o "$OUT/open-dispatch-bridge.o"
+run_link libOpenDispatch "${LD[@]}" -dylib -dead_strip -undefined dynamic_lookup \
+    -install_name /usr/lib/libOpenDispatch.dylib \
+    -map "$AUDIT/libOpenDispatch.link-map" \
+    -o "$DISPATCH_DARWIN" "$OUT/open-dispatch-bridge.o"
+[ "$(llvm-otool-18 -D "$DISPATCH_DARWIN" | tail -n 1)" = \
+    /usr/lib/libOpenDispatch.dylib ] \
+    || die 'run-local OpenDispatch Mach-O bridge ID drifted'
+dispatch_glibc=$(llvm-nm-18 --undefined-only --extern-only --just-symbol-name \
+    "$DISPATCH_DARWIN" | grep -c '^_glibc_openui_dispatch_host_v1_' || true)
+[ "$dispatch_glibc" -eq 12 ] \
+    || die "run-local OpenDispatch host import count $dispatch_glibc, expected 12"
 "${SWIFTC[@]}" -parse-as-library "${PACKAGE_CINC[@]}" \
     -I "$PACKAGE" \
     -module-name Dispatch -module-link-name Dispatch -emit-module \
@@ -676,7 +745,7 @@ run_link libDispatch "${LD[@]}" -dylib -dead_strip -ignore_auto_link -undefined 
     -install_name @rpath/libDispatch.dylib -rpath @loader_path \
     -map "$AUDIT/libDispatch.link-map" \
     -o "$PACKAGE/libDispatch.dylib" \
-    "$OUT/dispatch.o" "$OUT/open-dispatch-bridge.o" \
+    "$OUT/dispatch.o" "$DISPATCH_DARWIN" \
     -L"$PACKAGE" -lOpenCombine \
     -L"$MRROOT/darwin/usr/lib" -L/usr/lib/swift \
     -lswiftCore \
@@ -688,6 +757,11 @@ run_link libDispatch "${LD[@]}" -dylib -dead_strip -ignore_auto_link -undefined 
     || die 'project Dispatch swiftmodule is missing after build'
 [ -f "$PACKAGE/libDispatch.dylib" ] && [ ! -L "$PACKAGE/libDispatch.dylib" ] \
     || die 'libDispatch.dylib is missing after build'
+assert_no_glibc_host_imports "$PACKAGE/libDispatch.dylib" 'packaged libDispatch'
+dispatch_open_load_count=$(llvm-otool-18 -L "$PACKAGE/libDispatch.dylib" \
+    | awk '$1 == "/usr/lib/libOpenDispatch.dylib" { count++ } END { print count + 0 }')
+[ "$dispatch_open_load_count" -eq 1 ] \
+    || die "packaged libDispatch OpenDispatch load count $dispatch_open_load_count, expected 1"
 
 echo '== compile the bounded Foundation umbrella after SwiftUI'
 [ -f "$PACKAGE/include/COpenCombineHelpers/module.modulemap" ] && \
@@ -776,10 +850,17 @@ clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
     -I "$PACKAGE/include/COpenRelativeTime" \
     -c "$W/full/relativetime/OpenRelativeTimeBridge.c" \
     -o "$OUT/open-relative-time-bridge.o"
-run_link libOpenRelativeTime "${LD[@]}" -dylib -dead_strip -undefined dynamic_lookup \
+run_link libOpenRelativeTimeRuntime "${LD[@]}" -dylib -dead_strip \
+    -undefined dynamic_lookup \
+    -install_name /usr/lib/libOpenRelativeTime.dylib \
+    -map "$AUDIT/libOpenRelativeTimeRuntime.link-map" \
+    -o "$RELATIVE_TIME_RUNTIME" "$OUT/open-relative-time-bridge.o"
+run_link libOpenRelativeTime "${LD[@]}" -dylib -dead_strip -ignore_auto_link \
     -install_name @rpath/libOpenRelativeTime.dylib -rpath @loader_path \
     -map "$AUDIT/libOpenRelativeTime.link-map" \
-    -o "$RELATIVE_TIME_DARWIN" "$OUT/open-relative-time-bridge.o"
+    -o "$RELATIVE_TIME_DARWIN" \
+    -reexport_library "$RELATIVE_TIME_RUNTIME" \
+    "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
 bash "$W/full/relativetime/build_host_helper.sh" \
     --repo "$W" --host-dir "$HOST_BRIDGE_DIR" \
     --include-dir "$PACKAGE/include/COpenRelativeTime"
@@ -796,6 +877,8 @@ grep -Fx \
     || die 'native relative-time semantic marker is missing'
 [ -f "$RELATIVE_TIME_DARWIN" ] && [ ! -L "$RELATIVE_TIME_DARWIN" ] \
     || die 'libOpenRelativeTime.dylib is missing after build'
+[ -f "$RELATIVE_TIME_RUNTIME" ] && [ ! -L "$RELATIVE_TIME_RUNTIME" ] \
+    || die 'run-local OpenRelativeTime Darwin bridge is missing'
 [ -f "$RELATIVE_TIME_HOST" ] && [ ! -L "$RELATIVE_TIME_HOST" ] \
     || die 'libOpenRelativeTimeHost.so is missing after build'
 printf 'openui_relative_time_v1_format\n' \
@@ -808,10 +891,10 @@ readelf --wide --syms "$RELATIVE_TIME_HOST" \
     | awk '$5 == "GLOBAL" && $7 != "UND" && $8 ~ /^openui_relative_time_v1_/ { print $8 }' \
     | LC_ALL=C sort -u > "$AUDIT/relative-time-elf-exports.txt"
 llvm-nm-18 --defined-only --extern-only --just-symbol-name \
-    "$RELATIVE_TIME_DARWIN" | LC_ALL=C sort -u \
+    "$RELATIVE_TIME_RUNTIME" | LC_ALL=C sort -u \
     > "$AUDIT/relative-time-mach-exports.txt"
 llvm-nm-18 --undefined-only --extern-only --just-symbol-name \
-    "$RELATIVE_TIME_DARWIN" | LC_ALL=C sort -u \
+    "$RELATIVE_TIME_RUNTIME" | LC_ALL=C sort -u \
     > "$AUDIT/relative-time-mach-imports.txt"
 cmp "$AUDIT/relative-time-expected-elf.txt" \
     "$AUDIT/relative-time-elf-exports.txt" \
@@ -822,6 +905,21 @@ cmp "$AUDIT/relative-time-expected-mach-exports.txt" \
 cmp "$AUDIT/relative-time-expected-mach-imports.txt" \
     "$AUDIT/relative-time-mach-imports.txt" \
     || die 'Mach-O relative-time host imports drifted'
+[ "$(llvm-otool-18 -D "$RELATIVE_TIME_RUNTIME" | tail -n 1)" = \
+    /usr/lib/libOpenRelativeTime.dylib ] \
+    || die 'run-local relative-time Mach-O bridge ID drifted'
+[ "$(llvm-otool-18 -D "$RELATIVE_TIME_DARWIN" | tail -n 1)" = \
+    @rpath/libOpenRelativeTime.dylib ] \
+    || die 'packaged relative-time Mach-O facade ID drifted'
+assert_no_glibc_host_imports "$RELATIVE_TIME_DARWIN" \
+    'packaged OpenRelativeTime facade'
+relative_time_runtime_reexport_count=$(llvm-otool-18 -l "$RELATIVE_TIME_DARWIN" \
+    | awk '$1 == "cmd" { command = $2 }
+        $1 == "name" && $2 == "/usr/lib/libOpenRelativeTime.dylib" \
+            && command == "LC_REEXPORT_DYLIB" { count++ }
+        END { print count + 0 }')
+[ "$relative_time_runtime_reexport_count" -eq 1 ] \
+    || die "packaged relative-time facade Darwin-root reexport count $relative_time_runtime_reexport_count, expected 1"
 
 echo '== package ten reusable guest dylibs'
 run_link libFoundationEssentials "${LD[@]}" -dylib -dead_strip \
@@ -998,8 +1096,9 @@ expected_symbols_inputs=$(printf '%s\n' \
     "$SYS/usr/lib/libSystem.tbd")
 # Umbrella objects plus the four input classes the failed link named:
 # libswift_Concurrency.tbd, libswiftDarwin.tbd, libOpenCoreGraphics.dylib,
-# and the packaged OpenRelativeTime Darwin dylib. -ignore_auto_link means
-# Darwin/Concurrency cannot ride in through autolink the way they do on FE.
+# and the packaged OpenRelativeTime facade (which reexports the run-local
+# /usr/lib Darwin-root bridge). -ignore_auto_link means Darwin/Concurrency
+# cannot ride in through autolink the way they do on FE.
 expected_foundation_inputs=$(printf '%s\n' \
     'linker synthesized' \
     "$OUT/foundation.o" \
@@ -1112,7 +1211,7 @@ llvm-otool-18 -hv "$OUT/focus_onboarding_guest" \
 
 perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 --executable "$OUT/focus_onboarding_guest" \
-    --package "$PACKAGE" --guest-root "$MRROOT" \
+    --package "$PACKAGE" --guest-root "$RUNROOT" \
     > "$AUDIT/runtime-closure.manifest"
 awk -F '\t' '
     $1 == "file" && $2 == "package/libOpenFoundationInternationalization.dylib" {
@@ -1121,6 +1220,27 @@ awk -F '\t' '
     END { exit files == 1 ? 0 : 1 }
 ' "$AUDIT/runtime-closure.manifest" \
     || die 'runtime-closure inventory omitted package/libOpenFoundationInternationalization.dylib'
+awk -F '\t' '
+    $1 == "file" && $2 == "guest-root/darwin/usr/lib/libOpenFoundationInternationalization.dylib" {
+        files++
+    }
+    END { exit files == 1 ? 0 : 1 }
+' "$AUDIT/runtime-closure.manifest" \
+    || die 'runtime-closure inventory omitted the run-local OpenFoundationInternationalization Darwin bridge'
+awk -F '\t' '
+    $1 == "file" && $2 == "guest-root/darwin/usr/lib/libOpenRelativeTime.dylib" {
+        files++
+    }
+    END { exit files == 1 ? 0 : 1 }
+' "$AUDIT/runtime-closure.manifest" \
+    || die 'runtime-closure inventory omitted the run-local OpenRelativeTime Darwin bridge'
+awk -F '\t' '
+    $1 == "file" && $2 == "guest-root/darwin/usr/lib/libOpenDispatch.dylib" {
+        files++
+    }
+    END { exit files == 1 ? 0 : 1 }
+' "$AUDIT/runtime-closure.manifest" \
+    || die 'runtime-closure inventory omitted the run-local OpenDispatch Darwin bridge'
 awk -F '\t' '
     $1 == "edge" && $2 == "package/lib_FoundationICU.dylib" \
         && $4 == "@rpath/libOpenFoundationInternationalization.dylib" \
@@ -1162,6 +1282,26 @@ done
 EARLY_PLATFORM_HOST_PRELOAD=$DISPATCH_HOST:$FOUNDATION_INTL_HOST:$RELATIVE_TIME_HOST
 printf 'LD_PRELOAD=%s\n' \
     "$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}"
+
+echo '== host dlsym probe of composed LD_PRELOAD (loader-process RTLD_DEFAULT)'
+[ -f "$HOST_PRELOAD_DLSYM_PROBE" ] && [ ! -L "$HOST_PRELOAD_DLSYM_PROBE" ] \
+    || die "host dlsym probe source is missing: $HOST_PRELOAD_DLSYM_PROBE"
+clang-18 -std=c11 -O2 -Wall -Wextra -Werror \
+    -o "$OUT/host_preload_dlsym_probe" "$HOST_PRELOAD_DLSYM_PROBE"
+LD_LIBRARY_PATH="$HOST_BRIDGE_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}" \
+    "$OUT/host_preload_dlsym_probe" \
+        openui_relative_time_v1_format \
+        openui_dispatch_host_v1_get_global_queue \
+        openui_foundation_intl_v1_realpath \
+    | tee "$OUT/host-preload-dlsym.log"
+for probe_symbol in openui_relative_time_v1_format \
+    openui_dispatch_host_v1_get_global_queue \
+    openui_foundation_intl_v1_realpath; do
+    grep -Fx "dlsym hit: $probe_symbol" "$OUT/host-preload-dlsym.log" >/dev/null \
+        || die "composed LD_PRELOAD did not export $probe_symbol to RTLD_DEFAULT"
+done
+
 if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm64 ]; then
     echo "focus_onboarding_guest: compile/link may proceed on this VM; execution of arm64 guests cannot" >&2
     bash "${W:-$(git rev-parse --show-toplevel)}/.cursor/refuse-arm64-execution.sh" \
@@ -1169,9 +1309,7 @@ if [ "$ARCH" = arm64 ] && [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != arm
 fi
 (
     cd "$OUT"
-    LD_LIBRARY_PATH="$HOST_BRIDGE_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-    LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}" \
-    MACHORUN_ROOT="$MRROOT" "$MRROOT/machorun" ./focus_onboarding_guest \
+    run_machorun_site interaction-path ./focus_onboarding_guest \
         "$OUT/Focus_Onboarding.bundle" \
         "$OUT/Focus_Widget.bundle" \
         "$UIKIT/Sources/OpenUIKit/Resources" "$OUT/fonts"

--- a/full/swiftui/host_preload_dlsym_probe.c
+++ b/full/swiftui/host_preload_dlsym_probe.c
@@ -1,0 +1,30 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Loader-process probe for the same RTLD_DEFAULT dlsym path machorun uses
+ * for `_glibc_*` (name + 7). Run it under the composed LD_PRELOAD so a
+ * miss is the ELF helper / visibility story and a hit isolates the
+ * remaining failure to machorun's from->is_runtime gate.
+ */
+int main(int argc, char **argv)
+{
+    int failed = 0;
+
+    if (argc < 2) {
+        fprintf(stderr, "usage: host_preload_dlsym_probe SYMBOL...\n");
+        return 2;
+    }
+    for (int i = 1; i < argc; i++) {
+        void *symbol = dlsym(RTLD_DEFAULT, argv[i]);
+        if (symbol == NULL) {
+            fprintf(stderr, "dlsym miss: %s (%s)\n", argv[i], dlerror());
+            failed = 1;
+            continue;
+        }
+        printf("dlsym hit: %s\n", argv[i]);
+    }
+    return failed;
+}

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -117,7 +117,8 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("MH_MAGIC_64[[:space:]]+${OTOOL_CPU}", text)
         self.assertIn('actual_id=$(llvm-otool-18 -D', text)
         self.assertIn('focus_widget_guest_attest.pl" closure', text)
-        self.assertIn('"$MRROOT/machorun" ./focus_onboarding_guest', text)
+        self.assertIn('"$MRROOT/machorun"', text)
+        self.assertIn("run_machorun_site interaction-path ./focus_onboarding_guest", text)
         self.assertIn("compile the first-party Symbols value model while Foundation is hidden", text)
         self.assertIn("libSymbols Apple Symbols load count", text)
         self.assertIn("-lOpenUIKit -lOpenCoreGraphics -lCombine -lOpenCombine -lSymbols", text)
@@ -200,7 +201,9 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("full/relativetime/OpenRelativeTimeHost.c", text)
         self.assertIn("full/relativetime/OpenRelativeTimeHostTests.c", text)
         self.assertIn("run_link libOpenRelativeTime ", text)
+        self.assertIn("run_link libOpenRelativeTimeRuntime ", text)
         self.assertIn("full/relativetime/build_host_helper.sh", text)
+        self.assertIn("RELATIVE_TIME_RUNTIME=$RUNROOT/darwin/usr/lib/libOpenRelativeTime.dylib", text)
         self.assertIn("RELATIVE_TIME_DARWIN=$PACKAGE/libOpenRelativeTime.dylib", text)
         self.assertIn(
             "RELATIVE_TIME_HOST=$HOST_BRIDGE_DIR/libOpenRelativeTimeHost.so",
@@ -216,8 +219,15 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             text,
         )
         self.assertIn("@rpath/libOpenRelativeTime.dylib", text)
-        self.assertNotIn(
+        self.assertIn(
             "-install_name /usr/lib/libOpenRelativeTime.dylib",
+            text,
+        )
+        self.assertIn("-reexport_library \"$RELATIVE_TIME_RUNTIME\"", text)
+        self.assertIn("LC_REEXPORT_DYLIB", text)
+        self.assertIn("assert_no_glibc_host_imports \"$RELATIVE_TIME_DARWIN\"", text)
+        self.assertIn(
+            "== clone shared machorun root into a writable run-local overlay",
             text,
         )
 
@@ -241,6 +251,10 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         )
         self.assertIn("run_link libOpenFoundationInternationalization ", text)
         self.assertIn(
+            "FOUNDATION_INTL_RUNTIME=$RUNROOT/darwin/usr/lib/libOpenFoundationInternationalization.dylib",
+            text,
+        )
+        self.assertIn(
             "FOUNDATION_INTL_DARWIN=$PACKAGE/libOpenFoundationInternationalization.dylib",
             text,
         )
@@ -252,8 +266,13 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             "-install_name @rpath/libOpenFoundationInternationalization.dylib",
             text,
         )
-        self.assertNotIn(
+        self.assertIn(
             "-install_name /usr/lib/libOpenFoundationInternationalization.dylib",
+            text,
+        )
+        self.assertIn("-reexport_library \"$FOUNDATION_INTL_RUNTIME\"", text)
+        self.assertIn(
+            "assert_no_glibc_host_imports \"$FOUNDATION_INTL_DARWIN\"",
             text,
         )
         self.assertIn("full/xcodeplan/rewrite_macho_dependency.py", text)
@@ -280,6 +299,12 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             "runtime-closure inventory omitted package/libOpenFoundationInternationalization.dylib",
             text,
         )
+        self.assertIn(
+            "runtime-closure inventory omitted the run-local OpenFoundationInternationalization Darwin bridge",
+            text,
+        )
+        self.assertIn('--guest-root "$RUNROOT"', text)
+        self.assertNotIn('--guest-root "$MRROOT"', text)
 
     def test_run_step_preloads_every_built_host_helper(self) -> None:
         text = BUILD.read_text()
@@ -320,6 +345,8 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             self.assertIn(f"${inverse[helper]}", preload_line)
         self.assertIn("== compose Linux host preload", run)
         self.assertIn("printf 'LD_PRELOAD=%s\\n'", run)
+        self.assertIn("== host dlsym probe of composed LD_PRELOAD", run)
+        self.assertIn("run_machorun_site interaction-path ./focus_onboarding_guest", run)
         self.assertLess(
             run.index('bash "$W/full/dispatch/build_host_bridge.sh"'),
             run.index("EARLY_PLATFORM_HOST_PRELOAD="),
@@ -328,6 +355,20 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             run.index("EARLY_PLATFORM_HOST_PRELOAD="),
             run.index('LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD'),
         )
+        self.assertLess(
+            run.index("== compose Linux host preload"),
+            run.index("== host dlsym probe of composed LD_PRELOAD"),
+        )
+        self.assertLess(
+            run.index("== host dlsym probe of composed LD_PRELOAD"),
+            run.index("run_machorun_site interaction-path"),
+        )
+        self.assertIn('MACHORUN_ROOT="$RUNROOT"', text)
+        self.assertNotIn('MACHORUN_ROOT="$MRROOT"', text)
+        self.assertIn("full/swiftui/host_preload_dlsym_probe.c", text)
+        self.assertEqual(text.count('"$MRROOT/machorun" "$@"'), 1)
+        self.assertEqual(text.count("echo \"== machorun site: $site\""), 1)
+        self.assertEqual(len(re.findall(r"\brun_machorun_site \S+", text)), 1)
 
     def test_foundation_runtime_closure_is_exact_and_mutation_sensitive(self) -> None:
         source = BUILD.read_text()
@@ -555,6 +596,14 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         )[1].split("== FoundationGuest/UIKit notification identity compile proof", 1)[0]
         self.assertIn('"$W/full/dispatch/Dispatch.swift"', dispatch)
         self.assertIn('"$W/full/dispatch/OpenDispatchBridge.c"', dispatch)
+        self.assertIn("DISPATCH_DARWIN=$RUNROOT/darwin/usr/lib/libOpenDispatch.dylib", text)
+        self.assertIn("-install_name /usr/lib/libOpenDispatch.dylib", dispatch)
+        self.assertIn('"$DISPATCH_DARWIN"', dispatch)
+        self.assertIn(
+            'assert_no_glibc_host_imports "$PACKAGE/libDispatch.dylib"',
+            dispatch,
+        )
+        self.assertNotIn('"$OUT/open-dispatch-bridge.o" \\', dispatch.split("run_link libDispatch", 1)[1])
         self.assertIn('-module-name Dispatch', dispatch)
         self.assertIn('-emit-module-path "$PACKAGE/Dispatch.swiftmodule"', dispatch)
         self.assertIn('-I "$PACKAGE"', dispatch)
@@ -600,6 +649,28 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             self.assertNotIn("/usr/lib/swift/CoreFoundation", blob)
             self.assertNotIn("arm64e-apple-macos", blob)
         self.assertIn("arm64-apple-macos", (ROOT / "full/scripts/guest_arch.inc").read_text())
+
+    def test_machorun_sites_share_composed_preload_and_runtime_overlay(self) -> None:
+        text = BUILD.read_text()
+        helper = (ROOT / "full/swiftui/host_preload_dlsym_probe.c").read_text()
+        resolve = (ROOT / "machorun/src/resolve.c").read_text()
+        image = (ROOT / "machorun/src/image.c").read_text()
+        deny = (ROOT / "machorun/src/host_deny.c").read_text()
+        self.assertIn("run_machorun_site()", text)
+        self.assertIn('echo "== machorun site: $site"', text)
+        self.assertIn('LD_PRELOAD="$EARLY_PLATFORM_HOST_PRELOAD${LD_PRELOAD:+:$LD_PRELOAD}"', text)
+        self.assertIn('MACHORUN_ROOT="$RUNROOT"', text)
+        self.assertIn("cp -a \"$MRROOT/.\" \"$RUNROOT/\"", text)
+        self.assertIn("dlsym(RTLD_DEFAULT", helper)
+        self.assertIn("from->is_runtime", resolve)
+        self.assertIn("host_lookup(name)", resolve)
+        self.assertIn("*is_runtime = 1;", image)
+        self.assertIn("A Darwin absolute path.", image)
+        self.assertIn("`_glibc_*` IS NOT AND MUST NOT BE DENIED", deny)
+        self.assertIn(
+            "if (!*found && from->is_runtime)",
+            resolve,
+        )
 
     def test_success_marker_is_exact_and_fail_closed(self) -> None:
         build = BUILD.read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why rc=73 survived the composed preload

PR #39 composed `LD_PRELOAD` with all three host helpers after Dispatch. On the arm64 authority at `8cfeebe8` that composition is present (log 487–488) and `libOpenRelativeTimeHost.so` exports `openui_relative_time_v1_format`, but `machorun` still dies with:

```
machorun: undefined symbol '_glibc_openui_relative_time_v1_format'   (rc=73)
```

### Hypothesis 1 — wrong machorun site

`build_focus_onboarding_guest.sh` has **one** `machorun` invocation (the interaction path). Widget has several; onboarding does not. This PR still wraps that call as `== machorun site: interaction-path` through `run_machorun_site()`, which applies the same composed `LD_PRELOAD` / `LD_LIBRARY_PATH` and the run-local overlay.

### Hypothesis 2 — ELF visibility vs machorun `is_runtime`

A loader-process `dlsym(RTLD_DEFAULT)` probe with the same preload **hits** on this x86_64 VM (no arm64 guest required):

```
dlsym hit: openui_relative_time_v1_format
dlsym hit: openui_dispatch_host_v1_get_global_queue
dlsym hit: openui_foundation_intl_v1_realpath
```

`readelf` shows `FUNC GLOBAL DEFAULT` for the relative-time export (the ABI header no longer `#undef`s the default-visibility macro). `_glibc_*` is not in `host_deny.c`.

`machorun/src/resolve.c` only calls `host_lookup()` when `from->is_runtime`. That bit is set only for Darwin absolute paths served from the darwin-root prefix map (`image.c`). Package `@rpath` images never take that path, so a perfect preload cannot bind `_glibc_openui_relative_time_v1_format` from `$PACKAGE/libOpenRelativeTime.dylib`.

## Fix

Do not write the shared `scratch/mrroot_full`. Copy it to `$OUT/runroot` and stage the `_glibc_*` Mach-O bridges there with `/usr/lib/` install names (frameworks Compression/Dispatch pattern):

- `guest-root/darwin/usr/lib/libOpenRelativeTime.dylib`
- `guest-root/darwin/usr/lib/libOpenDispatch.dylib`
- `guest-root/darwin/usr/lib/libOpenFoundationInternationalization.dylib`

Package `@rpath` facades reexport those runtime images and must not themselves import `_glibc_*`. Foundation still loads `@rpath/libOpenRelativeTime.dylib`; ICU still loads the packaged FI facade. `MACHORUN_ROOT` and the attest `--guest-root` point at the overlay.

## Operator rerun

Same gate: `full/swiftui/build_focus_onboarding_guest.sh <normalized-bundles-directory>`

Expect `== machorun site: interaction-path` immediately before the guest, `== host dlsym probe of composed LD_PRELOAD` with three `dlsym hit:` lines, and the existing `FOCUS_ONBOARDING_MACHO_GUEST_OK` marker.

This x86_64 cloud VM cannot execute arm64 Mach-O (`CURSOR_ENV_CANNOT_EXECUTE_ARM64 host=x86_64 machorun=arm64-linux-native split=compile-link-static-in-vm/execution-arm64-ec2/macos-oracle-local-only`). 22 onboarding unit tests pass; the dlsym probe ran here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

