### PR TITLE
Classify libswiftCore.so as ELF by -o, not macosx/; --ld-path=; explain rc=126

### DIFF
--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -175,16 +175,13 @@ it is the wrong linker for this graph. Ninja's link *rule* is still Linux
 `scripts/clangxx_darwin_link.py` is `CMAKE_C_COMPILER` / `CMAKE_CXX_COMPILER`
 and `SWIFT_NATIVE_CLANG_TOOLS_PATH` (Swift `stdlib/CMakeLists.txt` otherwise
 overwrites CXX to `${TC}/bin/clang++` — the operator `/opt/swift/usr/bin/clang++`
-line). It decides the linker **per link** from `-target` / the output
-`.so` vs `.dylib`, not from a global PATH or `-B` that contains both
-`ld.lld` and `ld64.lld`. An ELF host line (`-target …-linux-…`, `-soname`,
-`.so`) keeps `-soname` and prints `clangxx_darwin_link: linker=ld.lld`.
-A Darwin-target line (`-target …-apple-…`, overlay `.dylib`) is rewritten
-to `-dynamiclib -nostdlib -lSystem -Wl,-undefined,dynamic_lookup`,
-translating `-soname` / `-Xlinker -soname` to
-`-Wl,-install_name,/usr/lib/swift/libswiftX.dylib`, dropping
-`--as-needed` / `-rpath-link`, forcing `-fuse-ld=`**ld64.lld**, and printing
-`linker=ld64.lld`. `link_macho_dylib.sh` writes the same bytes to `.dylib`
+line). It classifies **from `-o`**, never from directory names (`macosx/` is
+the Darwin-target stdlib's host-side ELF helper): `*.so` keeps `-soname` and
+prints `clangxx_darwin_link: -o …/libswiftCore.so decision=elf linker=ld.lld`
+with `--ld-path=`**ld.lld**; `*.dylib` / `-install_name` / an apple triple
+prints `decision=darwin linker=ld64.lld`, rewriting `-soname` to
+`-Wl,-install_name,/usr/lib/swift/libswiftX.dylib` and dropping
+`--as-needed` / `-rpath-link`. `link_macho_dylib.sh` writes the same bytes to `.dylib`
 and copies `.so`. A remaining ninja miss is `CANNOT_ELF_SO_LINUX_SHARED`,
 not an allowed gold wall.
 

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -70,6 +70,12 @@ run_stdlib_ninja() {
   step "ninja $SWIFTCORE_NINJA_CORE -j$NINJA_JOBS"
   ninja_checked "$W/build.log" -C "$B" -j "$NINJA_JOBS" \
     "$SWIFTCORE_NINJA_CORE" || core_st=$?
+  echo "build_stdlib: ninja-core rc=$core_st"
+  if [ "$core_st" -eq 126 ]; then
+    echo "CANNOT_NOT_EXECUTABLE step=ninja-core rc=126 means a command was found but not executable (EACCES/ENOEXEC), not a link error." >&2
+    ls -l "$W/shims/clang++" "$W/shims/clang" "$(command -v python3)" \
+      "${LD_LLD:-}" "${LD64_LLD:-}" "${TC}/bin/clang++" 2>&1 | sed 's/^/  /' >&2
+  fi
   obj_n=$(find "$B" -name '*.o' 2>/dev/null | wc -l)
   echo "objects=$obj_n"
   so=$B/lib/swift/macosx/${SWIFTCORE_DARWIN_ARCH}/libswiftCore.so
@@ -128,6 +134,10 @@ run_stdlib_ninja() {
         tlog=$W/overlay.${t}.log
         : > "$tlog"
         ninja_checked "$tlog" -C "$B" -j "$NINJA_JOBS" "$t" || ninja_st=$?
+        echo "build_stdlib: ninja-overlay $t rc=$ninja_st"
+        if [ "$ninja_st" -eq 126 ]; then
+          echo "CANNOT_NOT_EXECUTABLE step=ninja-overlay target=$t rc=126" >&2
+        fi
         if [ -f "$tlog" ]; then
           cat "$tlog" >> "$W/build.log" 2>/dev/null || true
         fi
@@ -147,11 +157,13 @@ run_stdlib_ninja() {
     overlay_list_products "$B/lib/swift/macosx"
     if [ "$overlay_rc" -ne 0 ]; then
       echo "overlay: FAILED rc=$overlay_rc" >&2
+      echo "build_stdlib: returning overlay_rc=$overlay_rc"
       return "$overlay_rc"
     fi
   fi
   if [ "$core_st" -ne 0 ]; then
     echo "core: FAILED rc=$core_st" >&2
+    echo "build_stdlib: returning core_st=$core_st"
     return "$core_st"
   fi
 }

--- a/swiftcore-macho/scripts/clangxx_darwin_link.py
+++ b/swiftcore-macho/scripts/clangxx_darwin_link.py
@@ -1,23 +1,15 @@
 #!/usr/bin/env python3
-"""clang++ / clang driver shim: pick the linker per link, not globally.
+"""clang++ / clang driver shim: pick the linker per OUTPUT FILE, not globally.
 
-Ninja's CXX_SHARED_LIBRARY rule is generated from Modules/Platform/Linux.cmake,
-so it always injects `-shared` and `$SONAME_FLAG$SONAME` (`-Wl,-soname`).
-A Darwin-target line (`-target …-apple-…`, or a `.dylib` output) must still
-become the Mach-O recipe in link_macho_dylib.sh and use **ld64.lld**. An ELF
-host line (`-target …-linux-…`, or a `.so` output without an Apple triple)
-must keep `-soname` and use **ld.lld**. Putting ld64.lld on PATH / `-B` for
-every job is what made the operator core link die:
+Classify from `-o`:
+  `*.so`  → ELF / ld.lld, keep `-soname`
+  `*.dylib` (or `-install_name` / apple triple) → Darwin / ld64.lld
 
-    ld64.lld: error: unknown argument '-soname'
+Never from directory names (`macosx` in the path is the Darwin-target
+stdlib's host-side ELF helper). Clang 18+ wants `--ld-path=` rather than
+`-fuse-ld=<absolute path>`. Every shared link prints one line:
 
-stdlib/CMakeLists.txt overwrites CMAKE_CXX_COMPILER to
-`${SWIFT_NATIVE_CLANG_TOOLS_PATH}/clang++` unless
-SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER is ON. configure.sh points that path
-at this shim so `/opt/swift/usr/bin/clang++` cannot skip the rewrite.
-
-Every shared link prints `clangxx_darwin_link: linker=ld.lld` or
-`linker=ld64.lld`.
+    clangxx_darwin_link: -o <path> decision=elf|darwin linker=ld.lld|ld64.lld
 """
 from __future__ import annotations
 
@@ -94,17 +86,22 @@ def linker_label(path: str) -> str:
     return base or path
 
 
-def _fuse_ld_flag(linker_path: str) -> str:
-    return f"-fuse-ld={linker_path}"
+def _ld_path_flag(linker_path: str) -> str:
+    """Clang 18+: `--ld-path=` is the non-deprecated way to pass an absolute linker."""
+    return f"--ld-path={linker_path}"
 
 
-def _set_fuse_ld(argv: list[str], linker_path: str) -> list[str]:
-    """Replace every -fuse-ld=* with an absolute linker; append if missing."""
+def _is_linker_select_flag(tok: str) -> bool:
+    return tok.startswith("-fuse-ld=") or tok.startswith("--ld-path=")
+
+
+def _set_ld_path(argv: list[str], linker_path: str) -> list[str]:
+    """Drop -fuse-ld=* / --ld-path=* and set `--ld-path=<absolute linker>` once."""
     out: list[str] = []
     replaced = False
-    flag = _fuse_ld_flag(linker_path)
+    flag = _ld_path_flag(linker_path)
     for a in argv:
-        if a.startswith("-fuse-ld="):
+        if _is_linker_select_flag(a):
             if not replaced:
                 out.append(flag)
                 replaced = True
@@ -145,43 +142,55 @@ def _output_path(argv: list[str]) -> str | None:
     return None
 
 
+def _output_is_elf_so(path: str) -> bool:
+    """True for a shared-object output. Basename only — never the directory."""
+    base = os.path.basename(path)
+    return base.endswith(".so") or ".so." in base
+
+
+def _output_is_dylib(path: str) -> bool:
+    return os.path.basename(path).endswith(".dylib")
+
+
+def _has_install_name(argv: list[str]) -> bool:
+    for i, a in enumerate(argv):
+        if a.startswith("-Wl,-install_name") or a.startswith("-install_name"):
+            return True
+        if a in ("-install_name", "-Wl,-install_name") and i + 1 < len(argv):
+            return True
+        if a == "-Xlinker" and i + 1 < len(argv) and "install_name" in argv[i + 1]:
+            return True
+    return False
+
+
 def link_flavor(argv: list[str]) -> str | None:
     """Classify a driver invocation: 'darwin', 'elf', or None (not a shared link).
 
-    Decision is per argv, from the target triple and/or the output's .so/.dylib
-    — never from a global PATH / CMAKE_LINKER / -B that contains both ld.lld
-    and ld64.lld.
+    Output file first: `-o …*.so` is always ELF (the Darwin-target stdlib's
+    host-side helper is still named libswiftCore.so and lives under macosx/).
+    `.dylib`, `-install_name`, or an apple triple selects ld64.lld.
     """
     if _is_compile(argv):
         return None
     if not (_is_shared(argv) or _has_soname_flag(argv)):
         return None
-    t = _target(argv)
     out = _output_path(argv) or ""
-    if t and APPLE_MARKER in t:
+    if _output_is_elf_so(out):
+        return "elf"
+    if _output_is_dylib(out):
         return "darwin"
-    if out.endswith(".dylib"):
+    if _has_install_name(argv):
+        return "darwin"
+    t = _target(argv)
+    if t and APPLE_MARKER in t:
         return "darwin"
     if "-dynamiclib" in argv:
         return "darwin"
-    if t and ("linux" in t.lower() or "unknown-linux" in t.lower()):
-        return "elf"
-    if out.endswith(".so") or ".so." in os.path.basename(out):
-        return "elf"
     return "elf"
 
 
 def _is_darwin_target(argv: list[str]) -> bool:
-    """True when this argv is a Darwin-target link (triple or .dylib)."""
-    t = _target(argv)
-    if t and APPLE_MARKER in t:
-        return True
-    out = _output_path(argv) or ""
-    if out.endswith(".dylib"):
-        return True
-    if "-dynamiclib" in argv:
-        return True
-    return False
+    return link_flavor(argv) == "darwin"
 
 
 def _soname_payload(tok: str) -> str | None:
@@ -219,7 +228,7 @@ def is_darwin_shared_link(argv: list[str]) -> bool:
 
 def rewrite_elf_shared(argv: list[str]) -> list[str]:
     """ELF shared link: keep -soname / -shared; force ld.lld (never ld64.lld)."""
-    return _set_fuse_ld(argv, _ld_lld())
+    return _set_ld_path(argv, _ld_lld())
 
 
 def _is_host_elf_input(arg: str) -> bool:
@@ -306,10 +315,10 @@ def rewrite_darwin_shared(argv: list[str]) -> list[str]:
             have_dynamiclib = True
             out.append(a)
             continue
-        if a.startswith("-fuse-ld="):
-            # Darwin-target: absolute ld64.lld, never gold / host ld.lld.
+        if _is_linker_select_flag(a):
+            # Darwin-target: --ld-path=ld64.lld, never gold / host ld.lld.
             have_fuse = True
-            out.append(_fuse_ld_flag(_ld64_lld()))
+            out.append(_ld_path_flag(_ld64_lld()))
             continue
         if a.startswith("-B"):
             have_B = True
@@ -385,7 +394,7 @@ def rewrite_darwin_shared(argv: list[str]) -> list[str]:
     if not have_dynamiclib:
         extra.append("-dynamiclib")
     if not have_fuse:
-        extra.append(_fuse_ld_flag(_ld64_lld()))
+        extra.append(_ld_path_flag(_ld64_lld()))
     if not have_B:
         extra.append(f"-B{_lld_bin()}")
     if not have_nostdlib:
@@ -441,15 +450,38 @@ def log_link(
     original: list[str],
     rewritten: list[str] | None = None,
 ) -> None:
-    sys.stderr.write(f"clangxx_darwin_link: linker={linker} kind={kind}\n")
+    out = _output_path(original) or "ABSENT"
+    # One line the operator can grep: -o and the decision together.
+    sys.stderr.write(f"clangxx_darwin_link: -o {out} decision={kind} linker={linker}\n")
     sys.stderr.write("clangxx_darwin_link: ninja argv: " + shlex.join(original) + "\n")
     if rewritten is not None:
         sys.stderr.write("clangxx_darwin_link: rewritten argv: " + shlex.join(rewritten) + "\n")
     sys.stderr.flush()
 
 
-def log_darwin_rewrite(original: list[str], rewritten: list[str]) -> None:
-    log_link("darwin", "ld64.lld", original, rewritten)
+def _run_compiler(real: str, compiler_argv: list[str]) -> int:
+    """Invoke the real clang/clang++. Map exec failures so ninja does not see a bare 126."""
+    if not os.path.isfile(real):
+        sys.stderr.write(f"CANNOT_COMPILER_NOT_EXECUTABLE path={real} reason=missing\n")
+        return 2
+    if not os.access(real, os.X_OK):
+        sys.stderr.write(
+            f"CANNOT_COMPILER_NOT_EXECUTABLE path={real} reason=not-executable "
+            "(bash/ninja would report rc=126)\n"
+        )
+        return 2
+    try:
+        rc = subprocess.call([real] + compiler_argv)
+    except OSError as e:
+        sys.stderr.write(
+            f"CANNOT_COMPILER_NOT_EXECUTABLE path={real} errno={e.errno} {e}\n"
+        )
+        return 2
+    if rc == 126:
+        sys.stderr.write(
+            f"clangxx_darwin_link: compiler rc=126 (not executable / ENOEXEC) path={real}\n"
+        )
+    return rc
 
 
 def mirror_so_to_dylib(argv: list[str]) -> None:
@@ -477,7 +509,7 @@ def main(argv: list[str]) -> int:
         if print_rewritten:
             print(" ".join(rewritten))
             return 0
-        rc = subprocess.call([real] + rewritten)
+        rc = _run_compiler(real, rewritten)
         if rc == 0:
             mirror_so_to_dylib(rewritten)
         return rc
@@ -487,13 +519,11 @@ def main(argv: list[str]) -> int:
         if print_rewritten:
             print(" ".join(rewritten))
             return 0
-        os.execv(real, [real] + rewritten)
-        return 127
+        return _run_compiler(real, rewritten)
     if print_rewritten:
         print(" ".join(args))
         return 0
-    os.execv(real, [real] + args)
-    return 127
+    return _run_compiler(real, args)
 
 
 if __name__ == "__main__":

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -172,6 +172,15 @@ SHIM_LIPO=$W/shims/lipo
 mkdir -p "$SHIM_DIR"
 write_clang_shim() {
   local dest=$1 driver=$2
+  local pyexe
+  pyexe=$(command -v python3 || true)
+  if [ -z "$pyexe" ]; then
+    pyexe=python3
+  elif [ ! -x "$pyexe" ]; then
+    echo "CANNOT_PYTHON3_NOT_EXECUTABLE path=$pyexe (bash would report rc=126)" >&2
+    [ "$PRINT_FLAGS" = 1 ] || exit 2
+  fi
+  chmod +x "$SCRIPT_DIR/clangxx_darwin_link.py" 2>/dev/null || true
   {
     printf '#!/bin/bash\n'
     printf 'export SWIFTCORE_CLANG_DRIVER=%q\n' "$driver"
@@ -181,7 +190,7 @@ write_clang_shim() {
     printf 'export LD_LLD=%q\n' "${LD_LLD:-}"
     printf 'export LD64_LLD=%q\n' "${LD64_LLD:-}"
     printf 'export TC=%q\n' "${TC}"
-    printf 'exec python3 %q "$@"\n' "$SCRIPT_DIR/clangxx_darwin_link.py"
+    printf 'exec %q %q "$@"\n' "$pyexe" "$SCRIPT_DIR/clangxx_darwin_link.py"
   } > "$dest"
   chmod +x "$dest"
 }

--- a/swiftcore-macho/scripts/ninja_checked.inc
+++ b/swiftcore-macho/scripts/ninja_checked.inc
@@ -38,6 +38,9 @@ ninja_checked() {
     local st=${PIPESTATUS[0]}
     if [ "$errexit_was_on" = 1 ]; then set -e; fi
     echo "ninja $* exit=$st"
+    if [ "$st" -eq 126 ]; then
+        echo "ninja_checked: rc=126 means ninja could not execute a command (not a compile/link diagnostic). Check that CMAKE_CXX_COMPILER / the clang++ shim / python3 / ld.lld are +x ELF binaries." >&2
+    fi
     if [ "$st" -eq 0 ]; then
         rm -f "$chunk"
         return 0

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -271,10 +271,8 @@ overlay_print_overlay_module_evidence() {
     done
 }
 
-# Print the exact Darwin overlay dylib link ninja will run, and the argv
-# clangxx_darwin_link.py rewrites it to (no -soname, linker=ld64.lld).
-# Operator log must show both: the Linux CMake line and the ld64.lld line.
-# ELF core .so links print linker=ld.lld and keep -soname.
+# Print the ninja link for libswiftDarwin.so and the argv the shim would
+# run. `-o …*.so` is ELF (keep -soname, linker=ld.lld) even under macosx/.
 # overlay_print_darwin_link_from_ninja <build_dir> <arch>
 overlay_print_darwin_link_from_ninja() {
     local build_dir=${1:?overlay_print_darwin_link_from_ninja: build dir}
@@ -342,12 +340,33 @@ if err:
     for eline in err.splitlines():
         print(eline)
 print("overlay_link: rewritten", rewritten if rewritten else "ABSENT")
-if "soname" in rewritten:
-    print("overlay_link: rewritten still has soname")
+outp = ""
+for i, a in enumerate(args):
+    if a == "-o" and i + 1 < len(args):
+        outp = args[i + 1]
+        break
+base = os.path.basename(outp)
+decision = next((l for l in err.splitlines() if l.startswith("clangxx_darwin_link: -o ")), "")
+if not decision:
+    print("overlay_link: missing -o decision line")
     sys.exit(1)
-if rewritten and "-install_name" not in rewritten and "-Wl,-install_name" not in rewritten:
-    print("overlay_link: rewritten missing -install_name")
-    sys.exit(1)
+if base.endswith(".so") or ".so." in base:
+    if "decision=elf" not in decision or "linker=ld.lld" not in decision:
+        print("overlay_link: .so output must be decision=elf linker=ld.lld")
+        sys.exit(1)
+    if "soname" not in rewritten:
+        print("overlay_link: ELF rewritten dropped soname")
+        sys.exit(1)
+    if "ld64.lld" in rewritten:
+        print("overlay_link: ELF .so routed to ld64.lld")
+        sys.exit(1)
+else:
+    if "soname" in rewritten:
+        print("overlay_link: rewritten still has soname")
+        sys.exit(1)
+    if rewritten and "-install_name" not in rewritten and "-Wl,-install_name" not in rewritten:
+        print("overlay_link: rewritten missing -install_name")
+        sys.exit(1)
 PY
 }
 

--- a/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
+++ b/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Per-link linker: ELF -soname stays for ld.lld; Darwin -shared is rewritten
-# for ld64.lld. Decision is the target triple / output .so vs .dylib, not a
-# global PATH or -B that contains both linkers.
+# Per-link linker: `-o …*.so` → ELF / ld.lld (keep -soname);
+# `-o …*.dylib` (or -install_name / apple triple) → ld64.lld.
+# Never by directory names (macosx in the path is not Darwin).
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 py=$SCRIPT_DIR/clangxx_darwin_link.py
@@ -17,23 +17,23 @@ rewrite() {
   SWIFTCORE_CLANGXX_PRINT_REWRITTEN=1 python3 "$py" "$@" 2>"$tmp/link.err"
 }
 
-assert_linker() {
-  local want=$1
-  if grep -q "^clangxx_darwin_link: linker=${want} " "$tmp/link.err" \
-     || grep -q "^clangxx_darwin_link: linker=${want}$" "$tmp/link.err"; then
-    echo "  OK  printed linker=${want}"
-    grep '^clangxx_darwin_link: linker=' "$tmp/link.err"
+assert_decision() {
+  local out=$1 kind=$2 linker=$3
+  local line="clangxx_darwin_link: -o ${out} decision=${kind} linker=${linker}"
+  if grep -Fqx "$line" "$tmp/link.err"; then
+    echo "  OK  $line"
   else
-    echo "  FAIL expected linker=${want} in:"
-    cat "$tmp/link.err"
+    echo "  FAIL expected: $line"
+    echo "  got:"
+    grep '^clangxx_darwin_link:' "$tmp/link.err" || cat "$tmp/link.err"
     fail=1
   fi
 }
 
-echo "=== Darwin -shared is rewritten ==="
+echo "=== Darwin -shared .dylib is rewritten for ld64.lld ==="
 got=$(rewrite -target x86_64-apple-macosx13.0 -isysroot /sdk \
-  -fuse-ld=gold -B/usr/bin -shared -Wl,-soname,libswiftCore.so \
-  -o libswiftCore.so foo.o /usr/lib/llvm-18/lib/libc++.so \
+  -fuse-ld=gold -B/usr/bin -shared -Wl,-soname,libswiftDarwin.dylib \
+  -o libswiftDarwin.dylib foo.o /usr/lib/llvm-18/lib/libc++.so \
   -L/usr/lib/llvm-18/lib -L/home/ubuntu/work/build/lib/swift/macosx/x86_64)
 printf '%s\n' "$got"
 printf '%s\n' "$got" | grep -F -- '-dynamiclib' >/dev/null \
@@ -41,16 +41,19 @@ printf '%s\n' "$got" | grep -F -- '-dynamiclib' >/dev/null \
 printf '%s\n' "$got" | grep -F -- '-shared' >/dev/null \
   && { echo "  FAIL still has -shared"; fail=1; } \
   || echo "  OK  no -shared"
-printf '%s\n' "$got" | grep -F -- "-fuse-ld=${LD64_LLD}" >/dev/null \
-  && echo "  OK  -fuse-ld=ld64.lld" || { echo "  FAIL missing ld64.lld fuse-ld"; fail=1; }
+printf '%s\n' "$got" | grep -F -- "--ld-path=${LD64_LLD}" >/dev/null \
+  && echo "  OK  --ld-path=ld64.lld" || { echo "  FAIL missing --ld-path=ld64.lld"; fail=1; }
+printf '%s\n' "$got" | grep -E -- '-fuse-ld=/' >/dev/null \
+  && { echo "  FAIL deprecated -fuse-ld=<path> survived"; fail=1; } \
+  || echo "  OK  no -fuse-ld=<path>"
 printf '%s\n' "$got" | grep -F -- '-fuse-ld=gold' >/dev/null \
   && { echo "  FAIL gold survived"; fail=1; } \
   || echo "  OK  gold dropped"
-assert_linker ld64.lld
+assert_decision libswiftDarwin.dylib darwin ld64.lld
 printf '%s\n' "$got" | grep -F -- '-Wl,-soname' >/dev/null \
   && { echo "  FAIL -soname survived"; fail=1; } \
   || echo "  OK  no -soname"
-printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftCore.dylib' >/dev/null \
+printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
   && echo "  OK  soname -> Darwin install_name" || { echo "  FAIL missing Darwin install_name"; fail=1; }
 printf '%s\n' "$got" | grep -F -- '/usr/lib/llvm-18/lib/libc++.so' >/dev/null \
   && { echo "  FAIL host libc++.so survived"; fail=1; } \
@@ -79,6 +82,52 @@ printf '%s\n' "$got" | grep -F -- '-c' >/dev/null \
   && echo "  OK  still -c" || { echo "  FAIL lost -c"; fail=1; }
 
 echo
+echo "=== operator libswiftCore.so (macosx dir, ELF flags, no apple triple) is ELF ==="
+# Exact flag head from the operator / CMake Linux CXX_SHARED_LIBRARY log
+# (PR #40 classified this as darwin because of the macosx directory / apple
+# heuristic). Output is .so → ld.lld, keep -soname.
+got=$(rewrite \
+  -fPIC -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden \
+  -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra \
+  -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers \
+  -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type \
+  -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override \
+  -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported \
+  -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG \
+  -B/usr/lib/llvm-18/bin \
+  -isysroot /root/work/sdk/MacOSX.sdk \
+  -F/root/work/sdk/MacOSX.sdk/../../../Developer/Library/Frameworks \
+  -fuse-ld=lld \
+  -Wl,-sectcreate,__TEXT,__info_plist,/root/work/build/stdlib/public/core/Info.plist \
+  -Wl,-application_extension -Xlinker -compatibility_version -Xlinker 1 \
+  -shared -Wl,-soname,libswiftCore.so \
+  -o lib/swift/macosx/x86_64/libswiftCore.so \
+  foo.o)
+printf '%s\n' "$got"
+printf '%s\n' "$got" | grep -F -- '-Wl,-soname,libswiftCore.so' >/dev/null \
+  && echo "  OK  ELF -soname kept" || { echo "  FAIL operator .so lost -soname"; fail=1; }
+printf '%s\n' "$got" | grep -F -- '-shared' >/dev/null \
+  && echo "  OK  -shared kept" || { echo "  FAIL operator .so dropped -shared"; fail=1; }
+printf '%s\n' "$got" | grep -F -- '-dynamiclib' >/dev/null \
+  && { echo "  FAIL operator .so grew -dynamiclib"; fail=1; } \
+  || echo "  OK  not Darwin-rewritten"
+printf '%s\n' "$got" | grep -F -- "--ld-path=${LD_LLD}" >/dev/null \
+  && echo "  OK  --ld-path=ld.lld" || { echo "  FAIL missing --ld-path=ld.lld"; fail=1; }
+printf '%s\n' "$got" | grep -F -- 'ld64.lld' >/dev/null \
+  && { echo "  FAIL operator .so selected ld64.lld"; fail=1; } \
+  || echo "  OK  did not select ld64.lld"
+assert_decision lib/swift/macosx/x86_64/libswiftCore.so elf ld.lld
+
+echo
+echo "=== .so still ELF even with an apple triple (directory names do not win) ==="
+got=$(rewrite -fPIC -fno-semantic-interposition \
+  -target x86_64-apple-macosx13.0 -shared -Wl,-soname,libswiftCore.so \
+  -o lib/swift/macosx/x86_64/libswiftCore.so foo.o)
+printf '%s\n' "$got" | grep -F -- '-Wl,-soname,libswiftCore.so' >/dev/null \
+  && echo "  OK  apple-triple .so keeps -soname" || { echo "  FAIL apple-triple .so rewritten"; fail=1; }
+assert_decision lib/swift/macosx/x86_64/libswiftCore.so elf ld.lld
+
+echo
 echo "=== host ELF -shared with -soname is left for ld.lld ==="
 got=$(rewrite -target x86_64-unknown-linux-gnu -shared \
   -Wl,-soname,libswiftCore.so -o libswiftCore.so foo.o)
@@ -87,24 +136,18 @@ printf '%s\n' "$got" | grep -F -- '-shared' >/dev/null \
   && echo "  OK  host -shared kept" || { echo "  FAIL host -shared dropped"; fail=1; }
 printf '%s\n' "$got" | grep -F -- '-Wl,-soname,libswiftCore.so' >/dev/null \
   && echo "  OK  ELF -soname kept" || { echo "  FAIL ELF -soname rewritten"; fail=1; }
-printf '%s\n' "$got" | grep -F -- '-dynamiclib' >/dev/null \
-  && { echo "  FAIL host link grew -dynamiclib"; fail=1; } \
-  || echo "  OK  host not Darwin-rewritten"
-printf '%s\n' "$got" | grep -F -- "-fuse-ld=${LD_LLD}" >/dev/null \
-  && echo "  OK  -fuse-ld=ld.lld" || { echo "  FAIL missing ld.lld fuse-ld"; fail=1; }
-printf '%s\n' "$got" | grep -F -- 'ld64.lld' >/dev/null \
-  && { echo "  FAIL ELF link selected ld64.lld"; fail=1; } \
-  || echo "  OK  ELF link did not select ld64.lld"
-assert_linker ld.lld
+printf '%s\n' "$got" | grep -F -- "--ld-path=${LD_LLD}" >/dev/null \
+  && echo "  OK  --ld-path=ld.lld" || { echo "  FAIL missing --ld-path=ld.lld"; fail=1; }
+assert_decision libswiftCore.so elf ld.lld
 
 echo
-echo "=== linux triple wins over MacOSX.sdk on an ELF .so ==="
+echo "=== linux triple + MacOSX.sdk + .so is still ELF ==="
 got=$(rewrite -target x86_64-unknown-linux-gnu \
   -isysroot /root/work/sdk/MacOSX.sdk -shared \
   -Wl,-soname,libswiftCore.so -o libswiftCore.so foo.o)
 printf '%s\n' "$got" | grep -F -- '-Wl,-soname,libswiftCore.so' >/dev/null \
   && echo "  OK  linux triple keeps -soname" || { echo "  FAIL SDK heuristic stole ELF link"; fail=1; }
-assert_linker ld.lld
+assert_decision libswiftCore.so elf ld.lld
 
 echo
 echo "=== overlay link keeps Darwin-named .so input ==="
@@ -113,9 +156,10 @@ got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
   /home/ubuntu/work/build/lib/swift/macosx/x86_64/libswiftCore.so)
 printf '%s\n' "$got" | grep -F -- 'libswiftCore.so' >/dev/null \
   && echo "  OK  Darwin .so input kept" || { echo "  FAIL dropped overlay dep .so"; fail=1; }
+assert_decision libswiftDarwin.so elf ld.lld
 
 echo
-echo "=== Darwin .so output is mirrored to .dylib ==="
+echo "=== Darwin .so output is mirrored to .dylib (helper) ==="
 mkdir -p "$tmp/lib/swift/macosx/x86_64"
 echo so > "$tmp/lib/swift/macosx/x86_64/libswiftDarwin.so"
 python3 -c "
@@ -133,7 +177,7 @@ else
 fi
 
 echo
-echo "=== overlay Darwin -soname spellings rewrite to -install_name ==="
+echo "=== overlay Darwin .dylib -soname spellings rewrite to -install_name ==="
 assert_no_soname() {
   local got=$1
   if printf '%s\n' "$got" | grep -Eq -- '(^|[[:space:]])(-Wl,)?-?-soname'; then
@@ -145,23 +189,24 @@ assert_no_soname() {
 }
 
 got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
-  -Wl,-soname,libswiftDarwin.so -o libswiftDarwin.so Darwin.o)
+  -Wl,-soname,libswiftDarwin.dylib -o libswiftDarwin.dylib Darwin.o)
 printf '%s\n' "$got"
 assert_no_soname "$got"
 printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
-  && echo "  OK  -Wl,-soname,libswiftDarwin.so -> Darwin install_name" \
+  && echo "  OK  -Wl,-soname,libswiftDarwin.dylib -> Darwin install_name" \
   || { echo "  FAIL concatenated -Wl,-soname,"; fail=1; }
+assert_decision libswiftDarwin.dylib darwin ld64.lld
 
 got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
-  -soname,libswiftDarwin.so -o libswiftDarwin.so Darwin.o)
+  -soname,libswiftDarwin.dylib -o libswiftDarwin.dylib Darwin.o)
 printf '%s\n' "$got"
 assert_no_soname "$got"
 printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
-  && echo "  OK  -soname,libswiftDarwin.so -> Darwin install_name" \
+  && echo "  OK  -soname,libswiftDarwin.dylib -> Darwin install_name" \
   || { echo "  FAIL bare -soname,"; fail=1; }
 
 got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
-  -Xlinker -soname -Xlinker libswiftDarwin.so -o libswiftDarwin.so Darwin.o)
+  -Xlinker -soname -Xlinker libswiftDarwin.dylib -o libswiftDarwin.dylib Darwin.o)
 printf '%s\n' "$got"
 assert_no_soname "$got"
 printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' >/dev/null \
@@ -169,8 +214,8 @@ printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarw
   || { echo "  FAIL -Xlinker -soname"; fail=1; }
 
 got=$(rewrite -target x86_64-apple-macosx13.0 -shared \
-  --as-needed -Wl,-rpath-link,/usr/lib -Wl,-soname,libswiftCore.so \
-  -o libswiftCore.so foo.o)
+  --as-needed -Wl,-rpath-link,/usr/lib -Wl,-soname,libswiftCore.dylib \
+  -o libswiftCore.dylib foo.o)
 printf '%s\n' "$got"
 assert_no_soname "$got"
 printf '%s\n' "$got" | grep -F -- '--as-needed' >/dev/null \
@@ -179,19 +224,7 @@ printf '%s\n' "$got" | grep -F -- '--as-needed' >/dev/null \
 printf '%s\n' "$got" | grep -F -- '-rpath-link' >/dev/null \
   && { echo "  FAIL -rpath-link survived"; fail=1; } \
   || echo "  OK  -rpath-link dropped"
-assert_linker ld64.lld
-
-echo
-echo "=== apple-triple core .so (Linux CMake ELF flags) is still Darwin/ld64 ==="
-got=$(rewrite -fPIC -fno-semantic-interposition \
-  -target x86_64-apple-macosx13.0 -shared -Wl,-soname,libswiftCore.so \
-  -o lib/swift/macosx/x86_64/libswiftCore.so foo.o)
-printf '%s\n' "$got"
-assert_no_soname "$got"
-printf '%s\n' "$got" | grep -F -- "-fuse-ld=${LD64_LLD}" >/dev/null \
-  && echo "  OK  apple-triple core uses ld64.lld" \
-  || { echo "  FAIL apple-triple core not ld64.lld"; fail=1; }
-assert_linker ld64.lld
+assert_decision libswiftCore.dylib darwin ld64.lld
 
 echo
 echo "=== .dylib output without -target is Darwin/ld64 ==="
@@ -199,11 +232,11 @@ got=$(rewrite -shared -Wl,-soname,libswiftDarwin.dylib \
   -o libswiftDarwin.dylib Darwin.o)
 printf '%s\n' "$got"
 assert_no_soname "$got"
-assert_linker ld64.lld
+assert_decision libswiftDarwin.dylib darwin ld64.lld
 
 echo
 if [ "$fail" -eq 0 ]; then
-  echo "PASS -- ELF -soname → ld.lld; Darwin -shared → ld64.lld; linker printed"
+  echo "PASS -- -o *.so → ld.lld; -o *.dylib → ld64.lld; --ld-path=; decision printed"
   exit 0
 fi
 echo "FAIL"

--- a/swiftcore-macho/scripts/test_ninja_rc.sh
+++ b/swiftcore-macho/scripts/test_ninja_rc.sh
@@ -86,6 +86,11 @@ if [ "$rc" -ne 0 ]; then
 else
   echo "  FAIL expected nonzero"; fail=1
 fi
+if [ "$rc" -eq 126 ]; then
+  echo "  FAIL core ninja exit 1 must not become build_stdlib rc=126 (not-executable)"; fail=1
+else
+  echo "  OK  rc is not 126"
+fi
 printf '%s\n' "$out" | grep -q 'ninja: FAILED rc=' \
   && echo "  OK  ninja_checked reported failure" \
   || { echo "  FAIL missing ninja: FAILED"; fail=1; }

--- a/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
+++ b/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
@@ -455,14 +455,12 @@ printf '%s\n' "$out" | grep -q -- '-Wl,-soname,libswiftDarwin.so' \
   && echo "  OK  ninja line has -soname" || { echo "  FAIL ninja line missing -soname"; fail=1; }
 printf '%s\n' "$out" | grep -q 'overlay_link: rewritten' \
   && echo "  OK  printed rewritten link" || { echo "  FAIL missing rewritten"; fail=1; }
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -Eq -- '(^|[[:space:]])(-Wl,)?-?-soname' \
-  && { echo "  FAIL rewritten still has -soname"; fail=1; } \
-  || echo "  OK  rewritten has no -soname"
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-install_name' \
-  && echo "  OK  rewritten has -install_name" || { echo "  FAIL rewritten missing install_name"; fail=1; }
-printf '%s\n' "$out" | grep -q 'clangxx_darwin_link: linker=ld64.lld' \
-  && echo "  OK  Darwin overlay link printed linker=ld64.lld" \
-  || { echo "  FAIL missing linker=ld64.lld"; fail=1; }
+printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-Wl,-soname,libswiftDarwin.so' \
+  && echo "  OK  ELF .so rewritten keeps -soname" \
+  || { echo "  FAIL rewritten dropped ELF -soname"; fail=1; }
+printf '%s\n' "$out" | grep -q 'clangxx_darwin_link: -o lib/swift/macosx/x86_64/libswiftDarwin.so decision=elf linker=ld.lld' \
+  && echo "  OK  .so output printed decision=elf linker=ld.lld" \
+  || { echo "  FAIL missing -o decision=elf line"; fail=1; }
 
 echo
 echo "=== cmake : && clang++ && : wrapper is stripped before rewrite ==="
@@ -496,8 +494,8 @@ printf '%s\n' "$out"
 printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q '&&' \
   && { echo "  FAIL rewritten kept cmake && wrapper"; fail=1; } \
   || echo "  OK  rewritten dropped cmake && wrapper"
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-install_name' \
-  && echo "  OK  wrapper line still rewrites install_name" \
+printf '%s\n' "$out" | grep -q 'decision=elf linker=ld.lld' \
+  && echo "  OK  wrapper line still classifies .so as elf" \
   || { echo "  FAIL wrapper rewrite"; fail=1; }
 
 echo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Operator rerun after #40: the shim wrapped `/root/work/shims/clang++`, but the classifier still tagged the host ELF core as Darwin:

```
clangxx_darwin_link: linker=ld64.lld kind=darwin   ← WRONG
-o lib/swift/macosx/x86_64/libswiftCore.so
ld64.lld: error: must specify -platform_version
build_stdlib rc=126
```

**Classifier:** `-o …*.so` is always ELF / `ld.lld` / keep `-soname`, even when the path contains `macosx/` or an apple `-target`. `-o …*.dylib` (or `-install_name` / apple triple) is Darwin / `ld64.lld`. Directory names are ignored. Every shared link prints one grepable line:

```
clangxx_darwin_link: -o lib/swift/macosx/x86_64/libswiftCore.so decision=elf linker=ld.lld
```

**`--ld-path=`** replaces the deprecated `-fuse-ld=<absolute path>` (the clang 18 warning on the operator log).

**rc=126:** bash/ninja “found but not executable” (EACCES/ENOEXEC), not a link diagnostic. `ninja_checked` / `build_stdlib` now print `CANNOT_NOT_EXECUTABLE` and `build_stdlib: ninja-core rc=…` so a failed link stays **1** and a real 126 names the binary. The #40 path-form `-fuse-ld=` plus Darwin misroute is the likely source of the operator 126.

Regression in `test_clangxx_darwin_link.sh`: the exact operator CXX_SHARED_LIBRARY flag head (`-fPIC -fno-semantic-interposition … -o lib/swift/macosx/x86_64/libswiftCore.so`).

Same operator command:

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

Expected next: past the core `.so`, then the overlay scoreboard.

Does not touch `machorun/` or the arm64 `libswiftCore` pin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35369cc-b509-457d-83ef-c090127c9afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

