### PR TITLE
Onboarding umbrella: link OpenRelativeTime runtime, not the shadowed facade

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -959,7 +959,7 @@ run_link libFoundation "${LD[@]}" -dylib -dead_strip -ignore_auto_link \
     -L"$PACKAGE" -lFoundationEssentials -lFoundationInternationalization \
     -lDispatch -lOpenUIKit -lCombine -lOpenCombine \
     "$PACKAGE/libOpenCoreGraphics.dylib" \
-    -L"$RUNROOT/darwin/usr/lib" "$RELATIVE_TIME_DARWIN" \
+    "$RELATIVE_TIME_RUNTIME" \
     -L"$SYS/usr/lib/swift" "${FOUNDATION_RUNTIME_LINK_FLAGS[@]}" \
     "$SYS/usr/lib/swift/libswiftDarwin.tbd" \
     "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
@@ -976,7 +976,7 @@ foundation_graphics_load_count=$(llvm-otool-18 -L "$PACKAGE/libFoundation.dylib"
 [ "$foundation_graphics_load_count" -eq 1 ] \
     || die "libFoundation OpenCoreGraphics load count $foundation_graphics_load_count, expected 1"
 foundation_relative_time_load_count=$(llvm-otool-18 -L "$PACKAGE/libFoundation.dylib" \
-    | awk '$1 == "@rpath/libOpenRelativeTime.dylib" { count++ } END { print count + 0 }')
+    | awk '$1 == "/usr/lib/libOpenRelativeTime.dylib" { count++ } END { print count + 0 }')
 [ "$foundation_relative_time_load_count" -eq 1 ] \
     || die "libFoundation relative-time load count $foundation_relative_time_load_count, expected 1"
 run_link libSwiftUI "${LD[@]}" -dylib -dead_strip \
@@ -1096,9 +1096,13 @@ expected_symbols_inputs=$(printf '%s\n' \
     "$SYS/usr/lib/libSystem.tbd")
 # Umbrella objects plus the four input classes the failed link named:
 # libswift_Concurrency.tbd, libswiftDarwin.tbd, libOpenCoreGraphics.dylib,
-# and the packaged OpenRelativeTime facade (which reexports the run-local
-# /usr/lib Darwin-root bridge). -ignore_auto_link means Darwin/Concurrency
-# cannot ride in through autolink the way they do on FE.
+# and the run-local OpenRelativeTime Darwin-root image. The package @rpath
+# facade re-exports /usr/lib/libOpenRelativeTime.dylib, but ld64.lld's
+# re-export search hits -L$PACKAGE first (same basename as the empty
+# facade) and never reaches -L$RUNROOT. List the runtime dylib itself;
+# that keeps LC_ID /usr/lib (machorun is_runtime) and binds the symbol.
+# -ignore_auto_link means Darwin/Concurrency cannot ride in through autolink
+# the way they do on FE.
 expected_foundation_inputs=$(printf '%s\n' \
     'linker synthesized' \
     "$OUT/foundation.o" \
@@ -1120,7 +1124,7 @@ expected_foundation_inputs=$(printf '%s\n' \
     "$PACKAGE/libOpenUIKit.dylib" \
     "$PACKAGE/libCombine.dylib" \
     "$PACKAGE/libOpenCoreGraphics.dylib" \
-    -L"$RUNROOT/darwin/usr/lib" "$RELATIVE_TIME_DARWIN" \
+    "$RELATIVE_TIME_RUNTIME" \
     "$SYS/usr/lib/swift/libswift_StringProcessing.tbd" \
     "$SYS/usr/lib/swift/libswiftSynchronization.tbd" \
     "$SYS/usr/lib/swift/libswiftDarwin.tbd" \

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -10,6 +10,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 BUILD = ROOT / "full/swiftui/build_focus_onboarding_guest.sh"
 FI_BUILDER = ROOT / "full/foundationinternationalization/build_foundation_internationalization.sh"
+RELATIVE_TIME_REEXPORT_LINK = ROOT / "full/swiftui/test_relative_time_reexport_link.sh"
 HARNESS = ROOT / "full/swiftui/FocusOnboardingGuestMain.swift"
 UUID_PROBE = ROOT / "full/swiftui/FocusOnboardingUUIDProbe.c"
 UUID_COMPAT = ROOT / "full/foundation/uuid_compat.c"
@@ -55,6 +56,7 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
     def test_build_script_has_valid_shell_syntax(self) -> None:
         subprocess.run(["bash", "-n", str(BUILD)], check=True)
         subprocess.run(["bash", "-n", str(FI_BUILDER)], check=True)
+        subprocess.run(["bash", "-n", str(RELATIVE_TIME_REEXPORT_LINK)], check=True)
 
     def test_exact_twelve_source_boundary_is_hash_pinned_and_direct(self) -> None:
         text = BUILD.read_text()
@@ -152,7 +154,8 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("libswift_Concurrency.tbd", foundation_link)
         self.assertIn("libswiftDarwin.tbd", foundation_link)
         self.assertIn("libOpenCoreGraphics.dylib", foundation_link)
-        self.assertIn("$RELATIVE_TIME_DARWIN", foundation_link)
+        self.assertIn("$RELATIVE_TIME_RUNTIME", foundation_link)
+        self.assertNotIn("$RELATIVE_TIME_DARWIN", foundation_link)
         self.assertIn('"$SYS/usr/lib/swift/libswiftDarwin.tbd"', foundation_link)
         self.assertIn('"$SYS/usr/lib/swift/libswift_Concurrency.tbd"', foundation_link)
         self.assertIn('"$PACKAGE/libOpenCoreGraphics.dylib"', foundation_link)
@@ -183,7 +186,7 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
             "libswift_Concurrency.tbd",
             "libswiftDarwin.tbd",
             "libOpenCoreGraphics.dylib",
-            "$RELATIVE_TIME_DARWIN",
+            "$RELATIVE_TIME_RUNTIME",
         ):
             self.assertIn(required, foundation_expected)
         self.assertIn(
@@ -229,6 +232,37 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn(
             "== clone shared machorun root into a writable run-local overlay",
             text,
+        )
+        self.assertIn('"$RELATIVE_TIME_RUNTIME"', text)
+        foundation_link = text.split("run_link libFoundation ", 1)[1].split(
+            "run_link libSwiftUI ", 1
+        )[0]
+        self.assertIn('"$RELATIVE_TIME_RUNTIME"', foundation_link)
+        self.assertNotIn('"$RELATIVE_TIME_DARWIN"', foundation_link)
+        self.assertIn(
+            'awk \'$1 == "/usr/lib/libOpenRelativeTime.dylib"',
+            text,
+        )
+        self.assertIn("-L$PACKAGE first (same basename as the empty", text)
+
+    def test_relative_time_reexport_link_binds_via_explicit_runtime(self) -> None:
+        result = subprocess.run(
+            ["bash", str(RELATIVE_TIME_REEXPORT_LINK)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            result.stderr or result.stdout,
+        )
+        self.assertIn(
+            "RELATIVE_TIME_REEXPORT_LINK_OK "
+            "facade=package-L-shadows-runtime "
+            "runtime=explicit-input "
+            "id=/usr/lib/libOpenRelativeTime.dylib",
+            result.stdout,
         )
 
     def test_foundation_intl_bridge_is_packaged_preloaded_and_in_closure(self) -> None:

--- a/full/swiftui/test_relative_time_reexport_link.sh
+++ b/full/swiftui/test_relative_time_reexport_link.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Reproduce the d53a3510 libFoundation argv against ld64.lld-18.
+#
+# The package @rpath facade re-exports /usr/lib/libOpenRelativeTime.dylib
+# (machorun is_runtime). ld64.lld searches that absolute install name
+# through -syslibroot, then each -L. The umbrella already has -L$PACKAGE
+# for -lFoundationEssentials etc., so the first hit is the facade itself
+# (no symbols). -L$RUNROOT after that never runs. The undefined is
+# _openui_relative_time_v1_format, not "unable to locate re-export".
+#
+# Passing the Darwin-root runtime dylib as an explicit input binds the
+# symbol and keeps LC_ID /usr/lib/libOpenRelativeTime.dylib.
+set -euo pipefail
+
+W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
+# shellcheck source=../../full/scripts/guest_arch.inc
+. "$W/full/scripts/guest_arch.inc"
+MRROOT_CANDIDATE=$W/scratch/mrroot_full${FULL_OUT_SUFFIX}
+SYS_CANDIDATE=$W/scratch/sysroot_fe4${FULL_OUT_SUFFIX}
+if [ -f "$MRROOT_CANDIDATE/darwin/usr/lib/libSystem.B.dylib" ] \
+    && [ -d "$SYS_CANDIDATE/usr/lib" ]; then
+    MRROOT=$MRROOT_CANDIDATE
+    SYS=$SYS_CANDIDATE
+else
+    MRROOT=$W/scratch/mrroot_full
+    SYS=$W/scratch/sysroot_fe4
+    TARGET=arm64-apple-macos15.0
+    ARCH=arm64
+fi
+[ -d "$SYS/usr/lib" ] || {
+    echo "relative_time_reexport_link: Darwin sysroot is missing: $SYS" >&2
+    exit 2
+}
+[ -f "$MRROOT/darwin/usr/lib/libSystem.B.dylib" ] || {
+    echo "relative_time_reexport_link: libSystem.B.dylib is missing: $MRROOT" >&2
+    exit 2
+}
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/relative-time-reexport-link.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+mkdir -p "$WORKDIR/runroot/darwin/usr/lib" "$WORKDIR/package"
+
+clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
+    -fvisibility=hidden -Wall -Wextra -Werror \
+    -I "$W/full/relativetime/include" \
+    -c "$W/full/relativetime/OpenRelativeTimeBridge.c" \
+    -o "$WORKDIR/bridge.o"
+RUNTIME=$WORKDIR/runroot/darwin/usr/lib/libOpenRelativeTime.dylib
+ld64.lld-18 -arch "$ARCH" -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
+    -dylib -dead_strip -undefined dynamic_lookup \
+    -install_name /usr/lib/libOpenRelativeTime.dylib \
+    -o "$RUNTIME" "$WORKDIR/bridge.o"
+[ "$(llvm-otool-18 -D "$RUNTIME" | tail -n 1)" = "/usr/lib/libOpenRelativeTime.dylib" ] \
+    || { echo "relative_time_reexport_link: runtime LC_ID drifted" >&2; exit 2; }
+llvm-nm-18 --defined-only --extern-only --just-symbol-name "$RUNTIME" \
+    | grep -Fxq _openui_relative_time_v1_format \
+    || { echo "relative_time_reexport_link: runtime does not define _openui_relative_time_v1_format" >&2; exit 2; }
+
+FACADE=$WORKDIR/package/libOpenRelativeTime.dylib
+ld64.lld-18 -arch "$ARCH" -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
+    -L"$MRROOT/darwin/usr/lib" -dylib -dead_strip -ignore_auto_link \
+    -install_name @rpath/libOpenRelativeTime.dylib -rpath @loader_path \
+    -o "$FACADE" \
+    -reexport_library "$RUNTIME" \
+    "$MRROOT/darwin/usr/lib/libSystem.B.dylib"
+if llvm-nm-18 --defined-only --extern-only --just-symbol-name "$FACADE" 2>/dev/null \
+    | grep -Fq _openui_relative_time_v1_format; then
+    echo "relative_time_reexport_link: facade unexpectedly defines _openui_relative_time_v1_format" >&2
+    exit 2
+fi
+llvm-otool-18 -l "$FACADE" | awk '
+    $1 == "cmd" && $2 == "LC_REEXPORT_DYLIB" { reexport = 1 }
+    reexport && $1 == "name" && $2 == "/usr/lib/libOpenRelativeTime.dylib" { found = 1 }
+    END { exit found ? 0 : 1 }
+' || {
+    echo "relative_time_reexport_link: facade does not re-export /usr/lib/libOpenRelativeTime.dylib" >&2
+    exit 2
+}
+
+cat > "$WORKDIR/consumer.c" <<'EOF'
+extern int openui_relative_time_v1_format(void);
+int consumer(void) { return openui_relative_time_v1_format(); }
+EOF
+clang-18 -target "$TARGET" -isysroot "$SYS" -std=c11 -O2 \
+    -c "$WORKDIR/consumer.c" -o "$WORKDIR/consumer.o"
+
+# d53a3510 argv: -L$PACKAGE already on the umbrella, then -L$RUNROOT + facade.
+set +e
+ld64.lld-18 -arch "$ARCH" -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
+    -dylib -dead_strip -ignore_auto_link \
+    -install_name @rpath/libConsumer.dylib \
+    -o "$WORKDIR/consumer.fail.dylib" \
+    "$WORKDIR/consumer.o" \
+    -L"$WORKDIR/package" \
+    -L"$WORKDIR/runroot/darwin/usr/lib" \
+    "$FACADE" \
+    --print-dylib-search \
+    >"$WORKDIR/fail.trace" 2>"$WORKDIR/fail.err"
+fail_rc=$?
+set -e
+[ "$fail_rc" -ne 0 ] \
+    || { echo "relative_time_reexport_link: shadowed facade consumer unexpectedly linked" >&2; exit 2; }
+grep -Fq '_openui_relative_time_v1_format' "$WORKDIR/fail.err" \
+    || { echo "relative_time_reexport_link: shadowed facade miss did not name the relative-time symbol" >&2; cat "$WORKDIR/fail.err" >&2; exit 2; }
+grep -Fq 'unable to locate re-export' "$WORKDIR/fail.err" \
+    && { echo "relative_time_reexport_link: shadowed facade miss was a missing re-export, not a package -L hit" >&2; cat "$WORKDIR/fail.err" >&2; exit 2; }
+grep -Fq "package/libOpenRelativeTime.dylib, found" "$WORKDIR/fail.trace" \
+    || { echo "relative_time_reexport_link: re-export search did not hit the package facade" >&2; cat "$WORKDIR/fail.trace" >&2; exit 2; }
+grep -Fq "runroot/darwin/usr/lib/libOpenRelativeTime.dylib, found" "$WORKDIR/fail.trace" \
+    && { echo "relative_time_reexport_link: re-export search reached the runtime after the package facade" >&2; cat "$WORKDIR/fail.trace" >&2; exit 2; }
+
+ld64.lld-18 -arch "$ARCH" -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
+    -dylib -dead_strip -ignore_auto_link -undefined dynamic_lookup \
+    -install_name @rpath/libConsumer.dylib \
+    -o "$WORKDIR/consumer.ok.dylib" \
+    "$WORKDIR/consumer.o" \
+    "$RUNTIME"
+[ "$(llvm-otool-18 -D "$RUNTIME" | tail -n 1)" = "/usr/lib/libOpenRelativeTime.dylib" ] \
+    || { echo "relative_time_reexport_link: runtime LC_ID changed after consumer link" >&2; exit 2; }
+llvm-otool-18 -L "$WORKDIR/consumer.ok.dylib" \
+    | awk '$1 == "/usr/lib/libOpenRelativeTime.dylib" { count++ } END { exit count == 1 ? 0 : 1 }' \
+    || { echo "relative_time_reexport_link: consumer did not LC_LOAD the /usr/lib runtime image" >&2; exit 2; }
+llvm-otool-18 -L "$WORKDIR/consumer.ok.dylib" \
+    | awk '$1 == "@rpath/libOpenRelativeTime.dylib" { count++ } END { exit count == 0 ? 0 : 1 }' \
+    || { echo "relative_time_reexport_link: consumer LC_LOADed the @rpath facade" >&2; exit 2; }
+llvm-objdump-18 --macho --lazy-bind "$WORKDIR/consumer.ok.dylib" \
+    | grep -Eq 'libOpenRelativeTime[[:space:]]+_openui_relative_time_v1_format' \
+    || { echo "relative_time_reexport_link: consumer did not bind _openui_relative_time_v1_format through the runtime" >&2; exit 2; }
+
+echo "RELATIVE_TIME_REEXPORT_LINK_OK facade=package-L-shadows-runtime runtime=explicit-input id=/usr/lib/libOpenRelativeTime.dylib"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why `_openui_relative_time_v1_format` stayed undefined after d53a3510

PR #42 stages the Darwin-root runtime at `/usr/lib/libOpenRelativeTime.dylib` (machorun `is_runtime`) and a package `@rpath` facade that re-exports it. Operator follow-on d53a3510 put `-L$RUNROOT/darwin/usr/lib` in front of the facade on the libFoundation argv. The arm64 gate still died at `== package ten reusable guest dylibs`:

```
ld64.lld-18: error: undefined symbol: _openui_relative_time_v1_format
(referenced by foundation.o RelativeDateTimeFormatter._hostFormat)
```

Reproduced in this VM with ld64.lld-18 `-t`/`--print-dylib-search` against the same two dylibs.

ld64.lld resolves a re-export whose install name is an absolute `/usr/lib/...` through `-syslibroot`, then each `-L`. The umbrella already has `-L$PACKAGE` (for `-lFoundationEssentials` etc.), so the first hit is `$PACKAGE/libOpenRelativeTime.dylib` — the empty facade, same basename. `-L$RUNROOT` never runs. There is no `unable to locate re-export` diagnostic; the linker found a file that does not define the symbol.

## Fix

Keep building the `@rpath` facade for package inventory / ID checks. Do not put it on the libFoundation argv. Pass `"$RELATIVE_TIME_RUNTIME"` as an explicit input. Foundation LC_LOADs `/usr/lib/libOpenRelativeTime.dylib`; the runtime LC_ID stays `/usr/lib` (machorun `is_runtime`).

`full/swiftui/test_relative_time_reexport_link.sh` builds both dylibs, reproduces the d53a3510 `-L$PACKAGE` then `-L$RUNROOT` + facade miss, then links a tiny C consumer against the runtime and checks the LC_LOAD / lazy-bind. `test_relative_time_reexport_link_binds_via_explicit_runtime` runs that script.

## Operator rerun

Same gate: `full/swiftui/build_focus_onboarding_guest.sh <normalized-bundles-directory>`

Expect `== package ten reusable guest dylibs` to print the libFoundation argv with the run-local `/usr/lib` image (not the package facade), then continue through the interaction path to:

`FOCUS_ONBOARDING_MACHO_GUEST_OK sources=12 pages=2 touches=3 uuid=full telemetry=getStartedAppeared,getStartedButtonTapped,defaultBrowserAppeared,defaultBrowserSettingsTapped,defaultBrowserSkip`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858de52d-be30-4054-a6e8-fd4cad93d033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858de52d-be30-4054-a6e8-fd4cad93d033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

