### PR TITLE
Darwin driver pass-through: keep -fuse-ld=lld; ninja commands via file

### DIFF
--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -178,15 +178,23 @@ the `.so` suffix is the object format — `stage_artifacts` ships the same
 bytes as `libswiftCore.dylib`. `scripts/clangxx_darwin_link.py` is
 `CMAKE_C_COMPILER` / `CMAKE_CXX_COMPILER` and
 `SWIFT_NATIVE_CLANG_TOOLS_PATH`. It classifies from **`-target`**:
-`-target …-apple-…` (and `-isysroot …MacOSX.sdk`) is Darwin — keep the
-driver argv (`-shared`, `-isysroot`; do **not** inject `-dynamiclib` /
-`-nostdlib`, which dropped `-platform_version` / `-arch` in PR #40) and
-only add `--ld-path=`**ld64.lld** so clang's Darwin driver can compose
-`-dynamic -dylib -arch -syslibroot -platform_version` for ld64. A leftover
-GNU `-soname` is rewritten to `-Wl,-install_name,/usr/lib/swift/libswiftX.dylib`
-because ld64.lld rejects `-soname`. `-target …-unknown-linux-gnu` is ELF:
+`-target …-apple-…` (and `-isysroot …MacOSX.sdk`) is Darwin — exec the
+real clang++ with the **original** argv plus `--ld-path=`**ld64.lld**,
+and **keep** `-fuse-ld=lld` (the Darwin driver maps that name to ld64.lld
+and emits `-platform_version` / `-arch`). Replacing `-fuse-ld=lld` with
+`--ld-path=` alone made the driver emit `-macosx_version_min` instead, so
+ld64.lld failed `must specify -platform_version` / `missing -arch`. Do
+**not** inject `-dynamiclib` / `-nostdlib` / `-arch` / `-platform_version`
+(PR #40 dropped driver flags that way; PR #46 still logged a `rewritten
+argv` that re-issued the link). A leftover GNU `-soname` is rewritten to
+`-Wl,-install_name,/usr/lib/swift/libswiftX.dylib` because ld64.lld
+rejects `-soname`. `-target …-unknown-linux-gnu` is ELF:
 `--ld-path=`**ld.lld**, keep `-soname`. Each shared link prints
 `clangxx_darwin_link: -o <path> decision={darwin|elf} linker={ld64.lld|ld.lld}`.
+Darwin logs `driver argv:`, never `rewritten argv:`.
+`overlay_print_darwin_link_from_ninja` reads `ninja -t commands` from a
+temp file (that node is megabytes of objects; passing it as a python argv
+is E2BIG → bash rc=126 blaming `/usr/bin/python3`).
 `build_stdlib.sh` `chmod +x`s `$W/shims/{clang++,clang,lipo}` before every
 ninja and traps rc=126 (`CANNOT_NOT_EXECUTABLE rc=126 cmd=…` plus `ls -l`
 of the attempted exec) — bash 126 is EACCES/ENOEXEC on a helper, not a
@@ -299,7 +307,8 @@ compiler/ninja error>` so a Darwin.o wall is not mistaken for their own.
 Before the overlay ninja loop, `build_stdlib.sh` prints each required
 sysroot header's sha, the Darwin.o `-sdk`/`-isysroot` from
 `ninja -t commands`, and the Darwin dylib link as `overlay_link: ninja`
-plus `overlay_link: rewritten` (Linux `-soname` must be gone). Cross-built
+plus `overlay_link: driver argv` (Linux `-soname` must be gone; no
+`rewritten argv`). Cross-built
 overlays remain the redistributable path; do not gate on operator-staged
 Apple copies under `scratch/apple-x86-overlays`.
 

--- a/swiftcore-macho/scripts/clangxx_darwin_link.py
+++ b/swiftcore-macho/scripts/clangxx_darwin_link.py
@@ -9,8 +9,11 @@ Forcing ld.lld at that argv made:
 
     ld.lld: error: unknown argument '-dynamic' / '-dylib' / '-arch' / '-syslibroot'
 
-Apple triple → leave the driver's flags alone, only resolve ld64.lld via
-`--ld-path=`. Linux/unknown-linux-gnu → ld.lld, keep `-soname`.
+Apple triple → exec the real clang++ with the original argv plus
+`--ld-path=` and keep `-fuse-ld=lld` so the Darwin driver still emits
+`-platform_version`/`-arch`. Replacing `-fuse-ld=lld` with `--ld-path=`
+alone made ld64.lld fail `must specify -platform_version`.
+Linux/unknown-linux-gnu → ld.lld, keep `-soname`.
 `-soname` is rewritten to `-install_name` only so ld64 never sees the GNU
 flag; nothing else is rewritten (PR #40's -dynamiclib/-nostdlib pass
 dropped -platform_version/-arch).
@@ -100,7 +103,10 @@ def _is_linker_select_flag(tok: str) -> bool:
 
 
 def _set_ld_path(argv: list[str], linker_path: str) -> list[str]:
-    """Drop -fuse-ld=* / --ld-path=* and set `--ld-path=<absolute linker>` once."""
+    """Drop -fuse-ld=* / --ld-path=* and set `--ld-path=<absolute linker>` once.
+
+    ELF only. Darwin must keep `-fuse-ld=lld` (see darwin_driver_argv).
+    """
     out: list[str] = []
     replaced = False
     flag = _ld_path_flag(linker_path)
@@ -264,28 +270,75 @@ def rewrite_darwin_soname(argv: list[str]) -> list[str]:
     return out
 
 
-def rewrite_darwin_shared(argv: list[str]) -> list[str]:
-    """Do not re-compose the Mach-O link. Only pick ld64.lld and translate -soname.
+def darwin_driver_argv(argv: list[str]) -> list[str]:
+    """Exec clang++ with the original driver argv plus linker resolution.
 
-    Clang's Darwin driver turns -target/-isysroot/-shared into
-    -dynamic/-dylib/-arch/-syslibroot/-platform_version for ld64. Replacing
-    -shared with -dynamiclib and injecting -nostdlib (PR #40) dropped those
-    driver-provided arguments.
+    Do not re-issue the Mach-O link. Clang's Darwin driver turns
+    -target/-isysroot/-shared/-fuse-ld=lld into
+    -dynamic/-dylib/-arch/-syslibroot/-platform_version for ld64.
+    Replacing `-fuse-ld=lld` with `--ld-path=<ld64.lld>` alone made the
+    driver emit `-macosx_version_min` instead of `-platform_version`, so
+    ld64.lld failed with `must specify -platform_version` / `missing -arch`.
+    Keep `-fuse-ld=lld` (drop gold) and add `--ld-path=` so resolution
+    hits ld64.lld. Translate GNU `-soname` only if it is still in argv.
     """
-    return _set_ld_path(rewrite_darwin_soname(argv), _ld64_lld())
+    out = rewrite_darwin_soname(argv) if _has_soname_flag(argv) else list(argv)
+    kept: list[str] = []
+    saw_fuse_lld = False
+    saw_ld64_path = False
+    ld_path = _ld_path_flag(_ld64_lld())
+    for a in out:
+        if a.startswith("-fuse-ld="):
+            val = a.split("=", 1)[1]
+            base = os.path.basename(val.rstrip("/"))
+            if val == "lld" or base in ("ld64.lld", "ld64.lld-18"):
+                if not saw_fuse_lld:
+                    kept.append("-fuse-ld=lld")
+                    saw_fuse_lld = True
+            # gold / bfd / -fuse-ld=<absolute path>: drop. Darwin maps
+            # the name `lld` to ld64.lld; an absolute -fuse-ld= is deprecated
+            # and skips -platform_version the same way --ld-path-alone does.
+            continue
+        if a.startswith("--ld-path="):
+            path = a.split("=", 1)[1]
+            if "ld64" in os.path.basename(path):
+                if not saw_ld64_path:
+                    kept.append(ld_path)
+                    saw_ld64_path = True
+            continue
+        kept.append(a)
+    if not saw_fuse_lld:
+        kept.append("-fuse-ld=lld")
+    if not saw_ld64_path:
+        kept.append(ld_path)
+    return kept
+
+
+def rewrite_darwin_shared(argv: list[str]) -> list[str]:
+    """Back-compat name: Darwin is driver pass-through, not a Mach-O rewrite."""
+    return darwin_driver_argv(argv)
 
 
 def log_link(
     kind: str,
     linker: str,
     original: list[str],
+    *,
+    driver_argv: list[str] | None = None,
     rewritten: list[str] | None = None,
 ) -> None:
     out = _output_path(original) or "ABSENT"
     # One line the operator can grep: -o and the decision together.
     sys.stderr.write(f"clangxx_darwin_link: -o {out} decision={kind} linker={linker}\n")
     sys.stderr.write("clangxx_darwin_link: ninja argv: " + shlex.join(original) + "\n")
-    if rewritten is not None:
+    if kind == "darwin":
+        # Never log "rewritten argv" for Darwin — that was the re-issued
+        # link that dropped driver -platform_version/-arch.
+        if driver_argv is not None:
+            sys.stderr.write(
+                "clangxx_darwin_link: driver argv: " + shlex.join(driver_argv) + "\n"
+            )
+    elif rewritten is not None:
         sys.stderr.write("clangxx_darwin_link: rewritten argv: " + shlex.join(rewritten) + "\n")
     sys.stderr.flush()
 
@@ -335,18 +388,18 @@ def main(argv: list[str]) -> int:
     flavor = link_flavor(args)
     print_rewritten = bool(os.environ.get("SWIFTCORE_CLANGXX_PRINT_REWRITTEN"))
     if flavor == "darwin":
-        rewritten = rewrite_darwin_shared(args)
-        log_link("darwin", linker_label(_ld64_lld()), args, rewritten)
+        driver_argv = darwin_driver_argv(args)
+        log_link("darwin", linker_label(_ld64_lld()), args, driver_argv=driver_argv)
         if print_rewritten:
-            print(" ".join(rewritten))
+            print(" ".join(driver_argv))
             return 0
-        rc = _run_compiler(real, rewritten)
+        rc = _run_compiler(real, driver_argv)
         if rc == 0:
-            mirror_so_to_dylib(rewritten)
+            mirror_so_to_dylib(driver_argv)
         return rc
     if flavor == "elf":
         rewritten = rewrite_elf_shared(args)
-        log_link("elf", linker_label(_ld_lld()), args, rewritten)
+        log_link("elf", linker_label(_ld_lld()), args, rewritten=rewritten)
         if print_rewritten:
             print(" ".join(rewritten))
             return 0

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -17,6 +17,19 @@ if [ -n "${SWIFTCORE_OVERLAY_TARGETS_INC:-}" ]; then
 fi
 SWIFTCORE_OVERLAY_TARGETS_INC=1
 
+# ninja -t commands for a dylib node is megabytes (every object). Passing
+# that string as a python argv is E2BIG; bash then reports rc=126 and
+# CANNOT_NOT_EXECUTABLE blames /usr/bin/python3. Write a temp file.
+overlay_write_ninja_commands() {
+    local dest=${1:?overlay_write_ninja_commands: dest}
+    local build_dir=${2:?overlay_write_ninja_commands: build dir}
+    local node=${3:?overlay_write_ninja_commands: node}
+    local ninja_bin=${NINJA:-ninja}
+    if ! "$ninja_bin" -C "$build_dir" -t commands "$node" >"$dest" 2>/dev/null; then
+        : > "$dest"
+    fi
+}
+
 overlay_candidate_targets() {
     local arch=${1:?overlay_candidate_targets: arch}
     printf '%s\n' \
@@ -178,24 +191,25 @@ overlay_flatten_unarch() {
 overlay_print_isysroot_from_ninja() {
     local build_dir=${1:?overlay_print_isysroot_from_ninja: build dir}
     local arch=${2:?overlay_print_isysroot_from_ninja: arch}
-    local ninja_bin=${NINJA:-ninja}
     local darwin_o="stdlib/public/Platform/OSX/${arch}/Darwin.o"
-    local cmds="" node
+    local cmds_file node
+    cmds_file=$(mktemp)
     echo "overlay_sysroot: ninja -t commands for Darwin overlay compile (arch=$arch)"
     for node in "$darwin_o" "swiftDarwin-macosx-${arch}"; do
-        cmds=$("$ninja_bin" -C "$build_dir" -t commands "$node" 2>/dev/null) || cmds=""
-        if [ -n "$cmds" ]; then
+        overlay_write_ninja_commands "$cmds_file" "$build_dir" "$node"
+        if [ -s "$cmds_file" ]; then
             echo "overlay_sysroot: ninja -t commands node=$node"
             break
         fi
     done
-    if [ -z "$cmds" ]; then
+    if [ ! -s "$cmds_file" ]; then
         echo "overlay_sysroot: ninja -t commands Darwin.o ABSENT (no -isysroot/-sdk in graph yet)"
+        rm -f "$cmds_file"
         return 0
     fi
-    python3 - "$cmds" <<'PY'
-import sys
-text = sys.argv[1]
+    python3 - "$cmds_file" <<'PY'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text(errors="replace")
 tokens = text.split()
 flags = ("-isysroot", "-sdk")
 seen = {f: [] for f in flags}
@@ -224,6 +238,7 @@ for f in flags:
     else:
         print("overlay_sysroot: ninja Darwin.o %s=ABSENT" % f)
 PY
+    rm -f "$cmds_file"
 }
 
 # Prove overlay compiles load Darwin via -sdk, not libc++ via -fmodule-map-file.
@@ -273,27 +288,30 @@ overlay_print_overlay_module_evidence() {
 
 # Print the ninja link for libswiftDarwin.so and the argv the shim would
 # run. Classify by `-target` (apple → Darwin/ld64.lld even when CMake names
-# the output .so). GNU -soname becomes -install_name; driver flags stay.
+# the output .so). Darwin is driver pass-through (no rewritten argv);
+# GNU -soname becomes -install_name. ninja -t commands is read from a
+# temp file (never argv — E2BIG is bash rc=126).
 # overlay_print_darwin_link_from_ninja <build_dir> <arch>
 overlay_print_darwin_link_from_ninja() {
     local build_dir=${1:?overlay_print_darwin_link_from_ninja: build dir}
     local arch=${2:?overlay_print_darwin_link_from_ninja: arch}
-    local ninja_bin=${NINJA:-ninja}
     local py
     py=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/clangxx_darwin_link.py
     local node="lib/swift/macosx/${arch}/libswiftDarwin.so"
-    local cmds=""
+    local cmds_file
+    cmds_file=$(mktemp)
     echo "overlay_link: ninja -t commands for Darwin dylib (arch=$arch node=$node)"
-    cmds=$("$ninja_bin" -C "$build_dir" -t commands "$node" 2>/dev/null) || cmds=""
-    if [ -z "$cmds" ]; then
-        cmds=$("$ninja_bin" -C "$build_dir" -t commands "swiftDarwin-macosx-${arch}" 2>/dev/null) || cmds=""
+    overlay_write_ninja_commands "$cmds_file" "$build_dir" "$node"
+    if [ ! -s "$cmds_file" ]; then
+        overlay_write_ninja_commands "$cmds_file" "$build_dir" "swiftDarwin-macosx-${arch}"
     fi
-    if [ -z "$cmds" ]; then
+    if [ ! -s "$cmds_file" ]; then
         echo "overlay_link: ninja Darwin dylib command ABSENT"
+        rm -f "$cmds_file"
         return 0
     fi
-    python3 - "$py" "$cmds" <<'PY'
-import os, shlex, subprocess, sys
+    python3 - "$py" "$cmds_file" <<'PY'
+import os, pathlib, shlex, subprocess, sys
 
 def compiler_args(line):
     argv = shlex.split(line)
@@ -312,7 +330,8 @@ def compiler_args(line):
             break
     return argv[i + 1 :]
 
-py, text = sys.argv[1], sys.argv[2]
+py, cmds_path = sys.argv[1], sys.argv[2]
+text = pathlib.Path(cmds_path).read_text(errors="replace")
 line = None
 for raw in text.splitlines():
     if "libswiftDarwin.so" in raw and " -o " in raw and (
@@ -335,12 +354,14 @@ env["SWIFTCORE_CLANGXX_PRINT_REWRITTEN"] = "1"
 proc = subprocess.run(
     [sys.executable, py, *args], env=env, text=True, capture_output=True
 )
-rewritten = (proc.stdout or "").strip()
+executed = (proc.stdout or "").strip()
 err = (proc.stderr or "").strip()
 if err:
     for eline in err.splitlines():
         print(eline)
-print("overlay_link: rewritten", rewritten if rewritten else "ABSENT")
+        if "rewritten argv:" in eline:
+            print("overlay_link: Darwin must not log rewritten argv")
+            sys.exit(1)
 
 def flavor_from_argv(tokens):
     for i, tok in enumerate(tokens):
@@ -366,32 +387,45 @@ if not decision:
     sys.exit(1)
 flavor = flavor_from_argv(args)
 if flavor == "elf":
+    print("overlay_link: rewritten", executed if executed else "ABSENT")
     if "decision=elf" not in decision or "linker=ld.lld" not in decision:
         print("overlay_link: linux-target .so must be decision=elf linker=ld.lld")
         sys.exit(1)
-    if "soname" not in rewritten:
+    if "soname" not in executed:
         print("overlay_link: ELF rewritten dropped soname")
         sys.exit(1)
-    if "ld64.lld" in rewritten:
+    if "ld64.lld" in executed:
         print("overlay_link: ELF linux-target link still targets ld64.lld")
         sys.exit(1)
 else:
+    print("overlay_link: driver argv", executed if executed else "ABSENT")
     if "decision=darwin" not in decision or "linker=ld64.lld" not in decision:
         print("overlay_link: apple-target .so must be decision=darwin linker=ld64.lld")
         sys.exit(1)
-    if "soname" in rewritten:
-        print("overlay_link: Darwin rewritten still has GNU -soname")
+    if "soname" in executed:
+        print("overlay_link: Darwin driver argv still has GNU -soname")
         sys.exit(1)
-    if rewritten and "-install_name" not in rewritten and "-Wl,-install_name" not in rewritten:
-        print("overlay_link: rewritten missing -install_name")
+    if executed and "-install_name" not in executed and "-Wl,-install_name" not in executed:
+        print("overlay_link: driver argv missing -install_name")
         sys.exit(1)
-    if "ld64.lld" not in rewritten:
-        print("overlay_link: Darwin rewritten missing ld64.lld")
+    if "ld64.lld" not in executed:
+        print("overlay_link: Darwin driver argv missing ld64.lld")
         sys.exit(1)
-    if "-dynamiclib" in rewritten.split() or "-nostdlib" in rewritten.split():
-        print("overlay_link: Darwin rewritten injected -dynamiclib/-nostdlib")
+    if "-fuse-ld=lld" not in executed:
+        print("overlay_link: Darwin driver argv missing -fuse-ld=lld")
+        sys.exit(1)
+    if "-dynamiclib" in executed.split() or "-nostdlib" in executed.split():
+        print("overlay_link: Darwin driver argv injected -dynamiclib/-nostdlib")
+        sys.exit(1)
+    if "-platform_version" in executed.split() or (
+        "-arch" in executed.split() and "ld64" not in executed
+    ):
+        print("overlay_link: Darwin shim injected linker flags the driver should compose")
         sys.exit(1)
 PY
+    local st=$?
+    rm -f "$cmds_file"
+    return "$st"
 }
 
 # Resolve the phony overlay target to its libswift*.so and see whether that

--- a/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
+++ b/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
@@ -60,11 +60,26 @@ printf '%s\n' "$got" | grep -F -- '-dynamiclib' >/dev/null \
 printf '%s\n' "$got" | grep -F -- '-nostdlib' >/dev/null \
   && { echo "  FAIL shim injected -nostdlib"; fail=1; } \
   || echo "  OK  did not inject -nostdlib"
+printf '%s\n' "$got" | grep -F -- '-fuse-ld=lld' >/dev/null \
+  && echo "  OK  kept -fuse-ld=lld (Darwin maps lld → ld64.lld + -platform_version)" \
+  || { echo "  FAIL dropped -fuse-ld=lld"; fail=1; }
 printf '%s\n' "$got" | grep -F -- "--ld-path=${LD64_LLD}" >/dev/null \
   && echo "  OK  --ld-path=ld64.lld" || { echo "  FAIL missing --ld-path=ld64.lld"; fail=1; }
 printf '%s\n' "$got" | grep -F -- "--ld-path=${LD_LLD}" >/dev/null \
   && { echo "  FAIL apple-target .so selected ld.lld"; fail=1; } \
   || echo "  OK  did not select ld.lld"
+printf '%s\n' "$got" | grep -F -- '-platform_version' >/dev/null \
+  && { echo "  FAIL shim injected -platform_version (driver must compose it)"; fail=1; } \
+  || echo "  OK  did not inject -platform_version into clang argv"
+printf '%s\n' "$got" | grep -E '(^|[[:space:]])-arch[[:space:]]' >/dev/null \
+  && { echo "  FAIL shim injected -arch (driver must compose it)"; fail=1; } \
+  || echo "  OK  did not inject -arch into clang argv"
+grep -q 'rewritten argv:' "$tmp/link.err" \
+  && { echo "  FAIL Darwin logged rewritten argv (re-issued the link)"; fail=1; } \
+  || echo "  OK  no rewritten argv log for Darwin"
+grep -q 'clangxx_darwin_link: driver argv:' "$tmp/link.err" \
+  && echo "  OK  logged driver argv" \
+  || { echo "  FAIL missing driver argv log"; fail=1; }
 printf '%s\n' "$got" | grep -F -- '-isysroot /root/work/sdk/MacOSX.sdk' >/dev/null \
   && echo "  OK  kept -isysroot for the Darwin driver" \
   || { echo "  FAIL dropped -isysroot"; fail=1; }
@@ -99,7 +114,7 @@ printf '%s\n' "$got" | grep -F -- '-c' >/dev/null \
   && echo "  OK  still -c" || { echo "  FAIL lost -c"; fail=1; }
 
 echo
-echo "=== Darwin gold -fuse-ld becomes --ld-path=ld64; -shared kept ==="
+echo "=== Darwin gold -fuse-ld becomes -fuse-ld=lld plus --ld-path; -shared kept ==="
 got=$(rewrite -target x86_64-apple-macosx13.0 -isysroot /sdk \
   -fuse-ld=gold -B/usr/bin -shared -Wl,-soname,libswiftDarwin.dylib \
   -o libswiftDarwin.dylib foo.o)
@@ -109,6 +124,9 @@ printf '%s\n' "$got" | grep -F -- '-shared' >/dev/null \
 printf '%s\n' "$got" | grep -F -- "-fuse-ld=gold" >/dev/null \
   && { echo "  FAIL gold survived"; fail=1; } \
   || echo "  OK  gold dropped"
+printf '%s\n' "$got" | grep -F -- '-fuse-ld=lld' >/dev/null \
+  && echo "  OK  -fuse-ld=lld (required for -platform_version)" \
+  || { echo "  FAIL missing -fuse-ld=lld after dropping gold"; fail=1; }
 printf '%s\n' "$got" | grep -F -- "--ld-path=${LD64_LLD}" >/dev/null \
   && echo "  OK  --ld-path=ld64.lld" || { echo "  FAIL missing ld64 --ld-path"; fail=1; }
 printf '%s\n' "$got" | grep -E -- '-fuse-ld=/' >/dev/null \
@@ -177,8 +195,50 @@ printf '%s\n' "$got" | grep -F -- '-Wl,-install_name,/usr/lib/swift/libswiftDarw
   && echo "  OK  -Xlinker -soname -> install_name" || { echo "  FAIL -Xlinker soname"; fail=1; }
 
 echo
+echo "=== Darwin driver -###: ld64.lld receives -platform_version and -arch ==="
+clang_real=$(command -v clang++-18 || command -v clang++)
+if [ ! -x "$clang_real" ]; then
+  echo "  FAIL no clang++ to run -###"; fail=1
+else
+  set +e
+  SWIFTCORE_REAL_CLANGXX="$clang_real" python3 "$py" \
+    -fPIC -B/usr/lib/llvm-18/bin \
+    -target x86_64-apple-macosx13.0 \
+    -isysroot /root/work/sdk/MacOSX.sdk \
+    -fuse-ld=lld \
+    -shared -Wl,-soname,libswiftCore.so \
+    -o lib/swift/macosx/x86_64/libswiftCore.so \
+    foo.o \
+    -### >"$tmp/hash.out" 2>"$tmp/hash.err"
+  set -e
+  grep '^clangxx_darwin_link:' "$tmp/hash.err" || true
+  grep -q 'rewritten argv:' "$tmp/hash.err" \
+    && { echo "  FAIL -### path logged rewritten argv"; fail=1; } \
+    || echo "  OK  -### path has no rewritten argv"
+  job=$(grep -E 'ld64\.lld' "$tmp/hash.err" | tail -1 || true)
+  printf '%s\n' "$job"
+  printf '%s\n' "$job" | grep -q 'ld64.lld' \
+    && echo "  OK  -### invoked ld64.lld" || { echo "  FAIL no ld64.lld in -###"; fail=1; }
+  printf '%s\n' "$job" | grep -q -- '-platform_version' \
+    && echo "  OK  ld64.lld received -platform_version from the Darwin driver" \
+    || { echo "  FAIL ld64.lld job missing -platform_version"; fail=1; }
+  printf '%s\n' "$job" | grep -q -- '"-arch"' \
+    && echo "  OK  ld64.lld received -arch from the Darwin driver" \
+    || { echo "  FAIL ld64.lld job missing -arch"; fail=1; }
+  printf '%s\n' "$job" | grep -q -- 'x86_64' \
+    && echo "  OK  ld64.lld -arch x86_64" || { echo "  FAIL missing x86_64 on ld64 job"; fail=1; }
+  # Contrast: --ld-path= alone (no -fuse-ld=lld) omits -platform_version.
+  "$clang_real" -### -target x86_64-apple-macosx13.0 -shared \
+    --ld-path="$LD64_LLD" -o /tmp/x.so /dev/null >"$tmp/bare.out" 2>"$tmp/bare.err"
+  bare=$(grep -E 'ld64\.lld' "$tmp/bare.err" | tail -1 || true)
+  printf '%s\n' "$bare" | grep -q -- '-platform_version' \
+    && { echo "  FAIL expected --ld-path= alone to omit -platform_version"; fail=1; } \
+    || echo "  OK  control: --ld-path= alone does not emit -platform_version"
+fi
+
+echo
 if [ "$fail" -eq 0 ]; then
-  echo "PASS -- apple-target .so → ld64 (driver flags kept); linux-gnu .so → ld.lld"
+  echo "PASS -- apple-target .so → Darwin driver + ld64; linux-gnu .so → ld.lld"
   exit 0
 fi
 echo "FAIL"

--- a/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
+++ b/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
@@ -453,17 +453,20 @@ printf '%s\n' "$out" | grep -q 'overlay_link: ninja' \
   && echo "  OK  printed ninja Darwin link" || { echo "  FAIL missing ninja link"; fail=1; }
 printf '%s\n' "$out" | grep -q -- '-Wl,-soname,libswiftDarwin.so' \
   && echo "  OK  ninja line has -soname" || { echo "  FAIL ninja line missing -soname"; fail=1; }
-printf '%s\n' "$out" | grep -q 'overlay_link: rewritten' \
-  && echo "  OK  printed rewritten link" || { echo "  FAIL missing rewritten"; fail=1; }
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -Eq -- '(^|[[:space:]])(-Wl,)?-?-soname' \
-  && { echo "  FAIL rewritten still has GNU -soname"; fail=1; } \
-  || echo "  OK  rewritten dropped GNU -soname"
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' \
-  && echo "  OK  rewritten has -install_name" \
-  || { echo "  FAIL rewritten missing -install_name"; fail=1; }
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q -- '-dynamiclib' \
-  && { echo "  FAIL rewritten injected -dynamiclib"; fail=1; } \
+printf '%s\n' "$out" | grep -q 'overlay_link: driver argv' \
+  && echo "  OK  printed driver argv" || { echo "  FAIL missing driver argv"; fail=1; }
+printf '%s\n' "$out" | grep 'overlay_link: driver argv' | grep -Eq -- '(^|[[:space:]])(-Wl,)?-?-soname' \
+  && { echo "  FAIL driver argv still has GNU -soname"; fail=1; } \
+  || echo "  OK  driver argv dropped GNU -soname"
+printf '%s\n' "$out" | grep 'overlay_link: driver argv' | grep -q -- '-Wl,-install_name,/usr/lib/swift/libswiftDarwin.dylib' \
+  && echo "  OK  driver argv has -install_name" \
+  || { echo "  FAIL driver argv missing -install_name"; fail=1; }
+printf '%s\n' "$out" | grep 'overlay_link: driver argv' | grep -q -- '-dynamiclib' \
+  && { echo "  FAIL driver argv injected -dynamiclib"; fail=1; } \
   || echo "  OK  did not inject -dynamiclib"
+printf '%s\n' "$out" | grep -q 'rewritten argv:' \
+  && { echo "  FAIL Darwin logged rewritten argv"; fail=1; } \
+  || echo "  OK  no rewritten argv for Darwin"
 printf '%s\n' "$out" | grep -q 'clangxx_darwin_link: -o lib/swift/macosx/x86_64/libswiftDarwin.so decision=darwin linker=ld64.lld' \
   && echo "  OK  apple-target .so printed decision=darwin linker=ld64.lld" \
   || { echo "  FAIL missing -o decision=darwin line"; fail=1; }
@@ -497,12 +500,53 @@ st=$?
 set -e
 printf '%s\n' "$out"
 [ "$st" -eq 0 ] && echo "  OK  cmake-wrapper print rc=0" || { echo "  FAIL cmake-wrapper rc=$st"; fail=1; }
-printf '%s\n' "$out" | grep 'overlay_link: rewritten' | grep -q '&&' \
-  && { echo "  FAIL rewritten kept cmake && wrapper"; fail=1; } \
-  || echo "  OK  rewritten dropped cmake && wrapper"
+printf '%s\n' "$out" | grep 'overlay_link: driver argv' | grep -q '&&' \
+  && { echo "  FAIL driver argv kept cmake && wrapper"; fail=1; } \
+  || echo "  OK  driver argv dropped cmake && wrapper"
 printf '%s\n' "$out" | grep -q 'decision=darwin linker=ld64.lld' \
   && echo "  OK  wrapper line classifies apple-target .so as darwin" \
   || { echo "  FAIL wrapper rewrite"; fail=1; }
+
+echo
+echo "=== ninja -t commands >2MB is not passed as python argv (E2BIG→126) ==="
+# ARG_MAX is 2 MiB on this host. Passing ninja -t commands as sys.argv
+# made python3 die with "Argument list too long" and bash rc=126.
+cat > "$fake/ninja" <<'EOF'
+#!/bin/bash
+args=("$@")
+i=0
+tool=""
+while [ $i -lt ${#args[@]} ]; do
+  a=${args[$i]}
+  case "$a" in
+    -C) i=$((i+2)); continue ;;
+    -t)
+      i=$((i+1)); tool=${args[$i]:-}; i=$((i+1)); continue ;;
+    *) i=$((i+1)); continue ;;
+  esac
+done
+if [ "$tool" = commands ]; then
+  python3 -c 'import sys; sys.stdout.write("padding " * 400000); sys.stdout.write("\n")'
+  echo "clang++ -target x86_64-apple-macosx13.0 -shared -Wl,-soname,libswiftDarwin.so -o lib/swift/macosx/x86_64/libswiftDarwin.so Darwin.o"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$fake/ninja"
+set +e
+out=$(NINJA="$fake/ninja" overlay_print_darwin_link_from_ninja "$tmp/ninjabuild" x86_64)
+st=$?
+set -e
+printf '%s\n' "$out" | grep '^overlay_link:' | head -5
+[ "$st" -eq 0 ] && echo "  OK  >2MB commands print rc=0 (not 126)" \
+  || { echo "  FAIL >2MB commands rc=$st"; fail=1; }
+[ "$st" -eq 126 ] && { echo "  FAIL E2BIG still reported as rc=126"; fail=1; } || true
+printf '%s\n' "$out" | grep -q 'Argument list too long' \
+  && { echo "  FAIL python still got E2BIG"; fail=1; } \
+  || echo "  OK  no Argument list too long"
+printf '%s\n' "$out" | grep -q 'decision=darwin linker=ld64.lld' \
+  && echo "  OK  huge commands still classified Darwin" \
+  || { echo "  FAIL huge commands lost the clang++ line"; fail=1; }
 
 echo
 echo "=== overlay FAILED dep=swiftDarwin vs first_error from the graph ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Operator rerun after #46: classification was right (`decision=darwin linker=ld64.lld`) but the shim still logged `rewritten argv:` and replaced `-fuse-ld=lld` with `--ld-path=<ld64.lld>`. Clang’s Darwin driver then emitted `-macosx_version_min` instead of `-platform_version`, so ld64.lld failed:

```
ld64.lld: error: must specify -platform_version
ld64.lld: error: missing or unsupported -arch x86_64
```

`--ld-path=` **alone** is the wrong Darwin resolution. Keep `-fuse-ld=lld` (the driver maps that name to ld64.lld and composes `-platform_version`/`-arch`/`-syslibroot`) and **add** `--ld-path=<ld64.lld>`. Exec the original clang++ argv plus that pair; translate GNU `-soname` only. Log `driver argv:`, never `rewritten argv:`. `-###` on the operator argv head shows ld64.lld receiving `-platform_version macos 13.0.0` and `-arch x86_64` from the driver. A control with `--ld-path=` alone does **not** emit `-platform_version`.

**rc=126:** `overlay_targets.inc` passed the whole `ninja -t commands` dump for the Darwin dylib node as `python3 - "$py" "$cmds"`. That node is every object (megabytes) → E2BIG → bash 126, and `CANNOT_NOT_EXECUTABLE` blamed `/usr/bin/python3`. Commands go through a temp file (Darwin.o `-isysroot` extract too). Regression: a >2 MB commands blob still classifies Darwin and does not 126.

Same operator command:

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

Expected next: core `.so` links via the Darwin driver, then the overlay scoreboard.

Does not touch `machorun/` or the arm64 `libswiftCore` pin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35369cc-b509-457d-83ef-c090127c9afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35369cc-b509-457d-83ef-c090127c9afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

