### PR TITLE
x86: pin and fetch CoreFoundation for ud-guest-x86

### DIFF
--- a/env/contract.json
+++ b/env/contract.json
@@ -37,6 +37,11 @@
       "path": "harness/Dockerfile",
       "kind": "image-lock",
       "fields": ["FROM swift:6.2-noble@sha256:29b983751c605c2d3102d2ab93438c6e0cadf110d9d2aa6e929b6dec9dcb7cbc"]
+    },
+    {
+      "path": "scripts/x86/ud_guest.inc",
+      "kind": "ud-guest-cf-lock",
+      "fields": ["PHASE2_UD_GUEST_CF_COMMIT", "PHASE2_UD_GUEST_CF_TREE", "PHASE2_UD_GUEST_CF_REPO", "PHASE2_UD_GUEST_CF_DEST_REL"]
     }
   ],
   "proof_split": {
@@ -133,6 +138,17 @@
       "destination": "scratch/swift-foundation-icu",
       "lock": "full/frameworks/build_core_guest_package.sh",
       "demanded_by": ["core-guest-package", "focus-onboarding"]
+    },
+    {
+      "id": "swift-corelibs-foundation",
+      "kind": "git",
+      "repository": "https://github.com/swiftlang/swift-corelibs-foundation.git",
+      "commit": "f3a7a34302317a95665bf4ff1a62ee1b459c1695",
+      "tree": "2f9136f253a51406f2bcb0a612bcb6a9eba03570",
+      "destination": "scratch/ud-guest-x86_64/cf",
+      "lock": "scripts/x86/ud_guest.inc",
+      "demanded_by": ["ud-guest-x86"],
+      "notes": "swift-6.2.4-RELEASE. Recipe compiles only Sources/CoreFoundation; the pin is the full git tree so HEAD^{tree} matches."
     },
     {
       "id": "dotnet-macios",

--- a/foundation-macho/scripts/build_cfobjc.sh
+++ b/foundation-macho/scripts/build_cfobjc.sh
@@ -86,6 +86,7 @@ find_cf() {
     local c
     for c in \
         "${CF:-}" \
+        "$W/cf/Sources/CoreFoundation" \
         "$W/cf" \
         "$W/cfobjc/src" \
         /work/cf \

--- a/scripts/env/contract.py
+++ b/scripts/env/contract.py
@@ -142,6 +142,22 @@ def validate_against_locks(root: Path | None = None) -> list[str]:
         raise ContractError("dotnet-macios disagrees with external-evidence-sources.json")
     notes.append("checkout dotnet-macios agrees with external-evidence-sources.json")
 
+    scf = checkouts["swift-corelibs-foundation"]
+    udinc = _read(root, "scripts/x86/ud_guest.inc")
+    for token, value in (
+        ("PHASE2_UD_GUEST_CF_COMMIT", scf["commit"]),
+        ("PHASE2_UD_GUEST_CF_TREE", scf["tree"]),
+        ("PHASE2_UD_GUEST_CF_REPO", scf["repository"]),
+        ("PHASE2_UD_GUEST_CF_DEST_REL", scf["destination"]),
+    ):
+        if f"{token}={value}" not in udinc:
+            raise ContractError(
+                f"swift-corelibs-foundation {token}={value} missing from scripts/x86/ud_guest.inc"
+            )
+    if "ud-guest-x86" not in scf["demanded_by"]:
+        raise ContractError("swift-corelibs-foundation is not demanded_by ud-guest-x86")
+    notes.append("checkout swift-corelibs-foundation agrees with scripts/x86/ud_guest.inc")
+
     swiftcore = next(
         item for item in contract["staged_externals"] if item["id"] == "libswiftCore"
     )

--- a/scripts/env/test_contract.py
+++ b/scripts/env/test_contract.py
@@ -71,6 +71,19 @@ class ContractLockTests(unittest.TestCase):
             "eccd2940f67f5f7db8d54819953d4ebc3de8e8e5",
         )
 
+    def test_ud_guest_x86_demands_pinned_corelibs_foundation(self) -> None:
+        row = checkouts_by_id(load_contract(ROOT))["swift-corelibs-foundation"]
+        self.assertEqual(row["commit"], "f3a7a34302317a95665bf4ff1a62ee1b459c1695")
+        self.assertEqual(row["tree"], "2f9136f253a51406f2bcb0a612bcb6a9eba03570")
+        self.assertEqual(row["destination"], "scratch/ud-guest-x86_64/cf")
+        self.assertIn("ud-guest-x86", row["demanded_by"])
+        self.assertEqual(
+            row["repository"],
+            "https://github.com/swiftlang/swift-corelibs-foundation.git",
+        )
+        self.assertEqual(row["lock"], "scripts/x86/ud_guest.inc")
+        self.assertEqual(row["kind"], "git")
+
     def test_focus_widget_gate_still_locks_all_attestation_pins(self) -> None:
         notes = validate_against_locks(ROOT)
         pin_notes = [n for n in notes if n.startswith("focus_widget_attestation_pins ")]

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -246,7 +246,12 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    comes from `foundation-macho/scripts/build_cfobjc.sh` (objects under
    `$ud_w/cfobjc/obj`, recipe id `cfobjc.1`) then
    `foundation-macho/scripts/build_cftest_harness.sh` (the only CF linker).
-   Missing CF sources, a failed compile, or a failed link is
+   CoreFoundation sources are the env/contract.json checkout
+   `swift-corelibs-foundation` (`f3a7a343`, tree `2f9136f2`, tagged
+   `swift-6.2.4-RELEASE`, `demanded_by ud-guest-x86`). `ud-guest-x86` fetches
+   that commit into `scratch/ud-guest-x86_64/cf` and refuses if `HEAD^{tree}`
+   differs, naming the commit. The recipe compiles only
+   `Sources/CoreFoundation`. A failed fetch/compile/link is
    `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib`. Will not invent a stub
    dylib. `UD_CFTEST_DYLIB=` still stages a provided x86 dylib.
    `link_ud_guest.sh` stays the only ud_guest linker. Any other

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -1514,6 +1514,24 @@ expect_grep 'build_full.sh argv -O1 -nostdinc' "$UDINC" \
 expect_grep 'build_cftest_harness.sh' "$UDINC" "CF path names the committed CF linker"
 expect_file "$ROOT/foundation-macho/scripts/build_cfobjc.sh"
 expect_grep 'build_cfobjc.sh' "$UDINC" "CF path names the committed cfobjc recipe"
+expect_grep 'PHASE2_UD_GUEST_CF_COMMIT=f3a7a34302317a95665bf4ff1a62ee1b459c1695' \
+    "$UDINC" "ud-guest-x86 pins the census CF commit"
+expect_grep 'PHASE2_UD_GUEST_CF_TREE=2f9136f253a51406f2bcb0a612bcb6a9eba03570' \
+    "$UDINC" "ud-guest-x86 pins the census CF tree"
+expect_grep 'scratch/ud-guest-x86_64/cf' "$UDINC" "CF checkout dest is under the suffixed work tree"
+expect_grep 'phase2_ud_guest_ensure_cf_checkout' "$UDINC" "ud-guest fetches the pinned CF checkout"
+expect_grep '"id": "swift-corelibs-foundation"' "$ROOT/env/contract.json" \
+    "contract names the CF checkout"
+expect_grep 'f3a7a34302317a95665bf4ff1a62ee1b459c1695' "$ROOT/env/contract.json" \
+    "contract pins the census CF commit"
+expect_grep '"ud-guest-x86"' "$ROOT/env/contract.json" \
+    "contract demanded_by includes ud-guest-x86"
+expect_grep 'clone-pinned-repo.sh' "$UDINC" \
+    "ud-guest fetches CF through clone-pinned-repo.sh"
+expect_not_grep 'scf-full' "$UDINC" \
+    "does not ask the operator to stage HOME/scf-full"
+expect_not_grep 'CF sources missing' "$UDINC" \
+    "does not ask the operator to stage CF sources"
 expect_grep 'build_cfobjc.sh' "$ROOT/scripts/x86/PHASE2.md" \
     "PHASE2.md names the committed cfobjc recipe"
 expect_grep 'Will not invent a stub dylib' "$UDINC" \
@@ -1606,23 +1624,46 @@ else
     die_test "x86 sysroot missing; cannot compile staging fixtures"
 fi
 
-cfreport=$(
-    CF=/no/such/cfobjc-corefoundation
-    HOME=/no/such/cfobjc-home
-    export CF HOME
-    phase2_ud_guest_ensure_cftest "$wt" "$ROOT" || true
-)
+# Wrong-tree dest refuses and names the pin. Does not fetch over it.
+mkdir -p "$wt/cf"
+git -c safe.directory="$wt/cf" init -q "$wt/cf"
+git -c safe.directory="$wt/cf" -C "$wt/cf" config user.email test@example.com
+git -c safe.directory="$wt/cf" -C "$wt/cf" config user.name test
+echo wrong > "$wt/cf/README"
+git -c safe.directory="$wt/cf" -C "$wt/cf" add README
+git -c safe.directory="$wt/cf" -C "$wt/cf" commit -q -m wrong
+cfreport=$(phase2_ud_guest_ensure_cftest "$wt" "$ROOT" || true)
 case "$cfreport" in
     CANNOT_UD_GUEST_LIBCFTEST\ file=libCFTest.dylib*)
-        if echo "$cfreport" | grep -q 'build_cfobjc.sh' \
+        if echo "$cfreport" | grep -q 'f3a7a34302317a95665bf4ff1a62ee1b459c1695' \
+            && echo "$cfreport" | grep -q 'CF checkout tree differs' \
             && echo "$cfreport" | grep -q 'Will not invent a stub dylib'; then
-            ok "absent libCFTest.dylib is CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib (recipe named, no stub)"
+            ok "wrong CF tree is CANNOT_UD_GUEST_LIBCFTEST naming commit f3a7a343"
         else
-            die_test "libCFTest refusal did not name the recipe: $cfreport"
+            die_test "wrong-tree refusal did not name the pin: $cfreport"
         fi
         ;;
-    *) die_test "libCFTest refusal got: $cfreport" ;;
+    *) die_test "wrong-tree CF refusal got: $cfreport" ;;
 esac
+rm -rf "$wt/cf"
+
+# A leftover non-git dest (operator-staged tree) is also a named refusal.
+mkdir -p "$wt/cf"
+echo staged-by-operator > "$wt/cf/README"
+cfreport=$(phase2_ud_guest_ensure_cftest "$wt" "$ROOT" || true)
+case "$cfreport" in
+    CANNOT_UD_GUEST_LIBCFTEST\ file=libCFTest.dylib*)
+        if echo "$cfreport" | grep -q 'f3a7a34302317a95665bf4ff1a62ee1b459c1695' \
+            && echo "$cfreport" | grep -q 'not a git checkout' \
+            && [ -f "$wt/cf/README" ]; then
+            ok "non-git CF dest is CANNOT_UD_GUEST_LIBCFTEST naming commit f3a7a343 (not overwritten)"
+        else
+            die_test "non-git dest refusal did not name the pin: $cfreport"
+        fi
+        ;;
+    *) die_test "non-git CF dest refusal got: $cfreport" ;;
+esac
+rm -rf "$wt/cf"
 
 # A provided x86 dylib is accepted (resolution path for the CF hole).
 echo 'int ud_cftest=1;' | clang-18 -target x86_64-apple-macos15.0 \
@@ -1647,6 +1688,17 @@ if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
     unset UD_CFTEST_DYLIB
 else
     die_test "could not emit an x86 libCFTest.dylib fixture"
+fi
+
+echo "== ud-guest-x86 fetches the pinned swift-corelibs-foundation checkout"
+ck=$(phase2_ud_guest_ensure_cf_checkout "$wt" "$ROOT" || true)
+if [ -z "$ck" ] \
+    && [ -f "$wt/cf/Sources/CoreFoundation/CFRuntime.c" ] \
+    && [ "$(git -c safe.directory="$wt/cf" -C "$wt/cf" rev-parse HEAD)" = "$PHASE2_UD_GUEST_CF_COMMIT" ] \
+    && [ "$(git -c safe.directory="$wt/cf" -C "$wt/cf" rev-parse 'HEAD^{tree}')" = "$PHASE2_UD_GUEST_CF_TREE" ]; then
+    ok "fetched $PHASE2_UD_GUEST_CF_ID commit=$PHASE2_UD_GUEST_CF_COMMIT tree=$PHASE2_UD_GUEST_CF_TREE"
+else
+    die_test "CF pin fetch got: '${ck:-empty}' dest=$wt/cf"
 fi
 
 echo "== cfobjc recipe argv is the documented flag set"

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -34,6 +34,15 @@ fi
 PHASE2_UD_GUEST_INC=1
 
 PHASE2_UD_GUEST_LINKER=foundation-macho/scripts/link_ud_guest.sh
+# Census comparison pin (PR #50 arm64 rebuild). Tagged swift-6.2.4-RELEASE.
+# Clone the full git tree so HEAD^{tree} matches env/contract.json; the recipe
+# compiles only Sources/CoreFoundation.
+PHASE2_UD_GUEST_CF_ID=swift-corelibs-foundation
+PHASE2_UD_GUEST_CF_REPO=https://github.com/swiftlang/swift-corelibs-foundation.git
+PHASE2_UD_GUEST_CF_COMMIT=f3a7a34302317a95665bf4ff1a62ee1b459c1695
+PHASE2_UD_GUEST_CF_TREE=2f9136f253a51406f2bcb0a612bcb6a9eba03570
+PHASE2_UD_GUEST_CF_DEST_REL=scratch/ud-guest-x86_64/cf
+PHASE2_UD_GUEST_CF_SOURCES_REL=Sources/CoreFoundation
 PHASE2_UD_GUEST_EXPECTED_LOADS=(
     libswiftCore
     libswiftDarwin
@@ -378,26 +387,93 @@ phase2_ud_guest_ensure_swiftcompat() {
     rm -f "$log"
 }
 
-# Same search list as foundation-macho/scripts/build_cfobjc.sh find_cf.
-# Keep the two in sync; this copy exists so a missing-CF refusal does not
-# invoke clang.
-phase2_ud_guest_find_cf() {
+# Pin from env/contract.json. dest is the full git checkout; CF TUs are under
+# Sources/CoreFoundation. An existing dest whose HEAD^{tree} differs is a
+# refusal that names the commit — not a silent restage.
+phase2_ud_guest_ensure_cf_checkout() {
     local ud_w=$1 repo=$2
-    local c
-    for c in \
-        "${CF:-}" \
-        "$ud_w/cf" \
-        /work/cf \
-        "$HOME/scf-full/Sources/CoreFoundation" \
-        "$repo/scratch/swift-corelibs-foundation/Sources/CoreFoundation" \
-        "$repo/scratch/scf/Sources/CoreFoundation"
-    do
-        [ -n "$c" ] || continue
-        [ -f "$c/CFRuntime.c" ] && [ -f "$c/CFPreferences.c" ] || continue
-        printf '%s\n' "$c"
-        return 0
-    done
-    return 1
+    local dest=$ud_w/cf
+    local commit=$PHASE2_UD_GUEST_CF_COMMIT
+    local tree=$PHASE2_UD_GUEST_CF_TREE
+    local origin=$PHASE2_UD_GUEST_CF_REPO
+    local cloner=$repo/.cursor/clone-pinned-repo.sh
+    local live_commit live_tree tree_root lock_dir lock log st
+    local sources=$dest/$PHASE2_UD_GUEST_CF_SOURCES_REL
+
+    if [ -e "$dest" ]; then
+        if [ -d "$dest/.git" ]; then
+            live_commit=$(git -c "safe.directory=$dest" -C "$dest" rev-parse HEAD 2>/dev/null || true)
+            live_tree=$(git -c "safe.directory=$dest" -C "$dest" rev-parse 'HEAD^{tree}' 2>/dev/null || true)
+            if [ "$live_commit" = "$commit" ] && [ "$live_tree" = "$tree" ]; then
+                if [ -f "$sources/CFRuntime.c" ] && [ -f "$sources/CFPreferences.c" ]; then
+                    return 0
+                fi
+                phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+                    "no x86_64 Mach-O. pinned CF checkout $commit at $dest is missing $PHASE2_UD_GUEST_CF_SOURCES_REL (recipe compiles only that directory). Will not invent a stub dylib."
+                return 1
+            fi
+            # Existing dest with a different tree is a refusal that names the
+            # pin. clone-pinned-repo.sh would replace it; we must not.
+            phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+                "no x86_64 Mach-O. CF checkout tree differs at $dest live_commit=${live_commit:-unreadable} want=$commit live_tree=${live_tree:-unreadable} want=$tree (env/contract.json $PHASE2_UD_GUEST_CF_ID). Will not invent a stub dylib."
+            return 1
+        fi
+        if [ -d "$dest" ] && [ -z "$(ls -A "$dest" 2>/dev/null || true)" ]; then
+            rmdir "$dest" || {
+                phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+                    "no x86_64 Mach-O. empty $dest could not be cleared to fetch $commit (env/contract.json $PHASE2_UD_GUEST_CF_ID). Will not invent a stub dylib."
+                return 1
+            }
+        else
+            phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+                "no x86_64 Mach-O. $dest exists and is not a git checkout of $commit (env/contract.json $PHASE2_UD_GUEST_CF_ID). Will not invent a stub dylib."
+            return 1
+        fi
+    fi
+
+    if [ ! -f "$cloner" ]; then
+        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+            "no x86_64 Mach-O. missing $cloner; cannot fetch $PHASE2_UD_GUEST_CF_ID commit=$commit. Will not invent a stub dylib."
+        return 1
+    fi
+    tree_root=$(CDPATH= cd -- "$ud_w/../.." && pwd)
+    lock_dir=$(mktemp -d "$ud_w/.cf-pin-lock.XXXXXX")
+    lock=$lock_dir/lock.json
+    printf '%s\n' "{
+  \"sources\": [{
+    \"id\": \"$PHASE2_UD_GUEST_CF_ID\",
+    \"repository\": \"$origin\",
+    \"commit\": \"$commit\",
+    \"tree\": \"$tree\",
+    \"destination\": \"$PHASE2_UD_GUEST_CF_DEST_REL\"
+  }]
+}" >"$lock"
+    log=$ud_w/lib/cf-checkout.log
+    mkdir -p "$ud_w/lib"
+    set +e
+    bash "$cloner" --lock "$lock" --id "$PHASE2_UD_GUEST_CF_ID" --repo-root "$tree_root" \
+        >"$log" 2>&1
+    st=$?
+    set -e
+    rm -rf "$lock_dir"
+    if [ "$st" -ne 0 ] || [ ! -d "$dest/.git" ]; then
+        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+            "no x86_64 Mach-O. failed to fetch $PHASE2_UD_GUEST_CF_ID commit=$commit tree=$tree dest=$PHASE2_UD_GUEST_CF_DEST_REL log=$log. Will not invent a stub dylib."
+        return 1
+    fi
+    live_commit=$(git -c "safe.directory=$dest" -C "$dest" rev-parse HEAD)
+    live_tree=$(git -c "safe.directory=$dest" -C "$dest" rev-parse 'HEAD^{tree}')
+    if [ "$live_commit" != "$commit" ] || [ "$live_tree" != "$tree" ]; then
+        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+            "no x86_64 Mach-O. CF checkout tree differs at $dest live_commit=$live_commit want=$commit live_tree=$live_tree want=$tree (env/contract.json $PHASE2_UD_GUEST_CF_ID). Will not invent a stub dylib."
+        return 1
+    fi
+    if [ ! -f "$sources/CFRuntime.c" ] || [ ! -f "$sources/CFPreferences.c" ]; then
+        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+            "no x86_64 Mach-O. pinned CF checkout $commit at $dest is missing $PHASE2_UD_GUEST_CF_SOURCES_REL. Will not invent a stub dylib."
+        return 1
+    fi
+    return 0
 }
 
 phase2_ud_guest_find_icu() {
@@ -436,7 +512,7 @@ phase2_ud_guest_ensure_cftest() {
     linker=$repo/foundation-macho/scripts/build_cftest_harness.sh
     if [ ! -f "$recipe" ]; then
         phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
-            "no x86_64 Mach-O. missing committed recipe $recipe. Will not invent a stub dylib. Operator: set CF= to Sources/CoreFoundation or UD_CFTEST_DYLIB=x86_64 libCFTest.dylib."
+            "no x86_64 Mach-O. missing committed recipe $recipe. Will not invent a stub dylib."
         return 1
     fi
     if [ ! -f "$linker" ]; then
@@ -445,10 +521,13 @@ phase2_ud_guest_ensure_cftest() {
         return 1
     fi
 
-    cf=$(phase2_ud_guest_find_cf "$ud_w" "$repo" || true)
-    if [ -z "$cf" ]; then
+    if ! phase2_ud_guest_ensure_cf_checkout "$ud_w" "$repo"; then
+        return 1
+    fi
+    cf=$ud_w/cf/$PHASE2_UD_GUEST_CF_SOURCES_REL
+    if [ ! -f "$cf/CFRuntime.c" ]; then
         phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
-            "no x86_64 Mach-O. CF sources missing (looked at \$CF, $ud_w/cf, /work/cf, \$HOME/scf-full/Sources/CoreFoundation, $repo/scratch/swift-corelibs-foundation, $repo/scratch/scf). Committed recipe is foundation-macho/scripts/build_cfobjc.sh; committed CF linker is foundation-macho/scripts/build_cftest_harness.sh. Will not invent a stub dylib. Operator: set CF= to Sources/CoreFoundation or UD_CFTEST_DYLIB=x86_64 libCFTest.dylib."
+            "no x86_64 Mach-O. pinned CF checkout $PHASE2_UD_GUEST_CF_COMMIT missing $cf. Will not invent a stub dylib."
         return 1
     fi
     if [ ! -d "$sys/usr/include" ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Operator rerun after PR #50 failed with `CANNOT_UD_GUEST_LIBCFTEST … CF sources missing` because `ud-guest-x86` searched `$CF`, `scratch/ud-guest-x86_64/cf`, `/work/cf`, and `$HOME/scf-full/Sources/CoreFoundation` instead of fetching the census pin.

## Census pin (question 1)

The arm64 census comparison in PR #50 cloned swift-corelibs-foundation into `/tmp/cfsrc/swift-corelibs-foundation`. That checkout is:

- **commit:** `f3a7a34302317a95665bf4ff1a62ee1b459c1695`
- **tree:** `2f9136f253a51406f2bcb0a612bcb6a9eba03570`
- **tag:** `swift-6.2.4-RELEASE` (same SHA; `clone-pinned-repo.sh` pins commits, never tags)
- **origin:** `https://github.com/swiftlang/swift-corelibs-foundation.git`
- **message:** `Fix buffer overflow in _NSCFString.getBytes (#5287)`

Recorded in `env/contract.json` as checkout `swift-corelibs-foundation` (`demanded_by: ["ud-guest-x86"]`, dest `scratch/ud-guest-x86_64/cf`), matching the `swift-foundation-icu` row shape. Lock-agreement requires the same values in `scripts/x86/ud_guest.inc`.

`git ls-remote --tags` on origin confirms `refs/tags/swift-6.2.4-RELEASE` → `f3a7a34302317a95665bf4ff1a62ee1b459c1695`.

## What the recipe needs (question 2)

`build_cfobjc.sh` compiles **only** `Sources/CoreFoundation` (`CFRuntime.c` + `CFPreferences.c` must exist). The git pin is the **full repo tree** so `HEAD^{tree}` can match the contract. Checkout dest is the repo root; compile from `Sources/CoreFoundation`. Measured on the fetched tree: 88 `.c` files / 218 files under `Sources/CoreFoundation` vs 621 files in the full checkout.

## Fetch / verify

`ud-guest-x86` calls `.cursor/clone-pinned-repo.sh` into `scratch/ud-guest-x86_64/cf` when dest is missing. Network is assumed on the box. If dest already exists as git and commit/tree differ, it **refuses** naming `want=f3a7a343…` — it does not overwrite. `UD_CFTEST_DYLIB=` still short-circuits before fetch.

## Operator command (x86_64 box)

```bash
bash x86_stage_inputs_phase2.sh
```

Do **not** stage CF sources. Expected: fetch `f3a7a343` into `scratch/ud-guest-x86_64/cf`, then `build_cfobjc.sh` + `build_cftest_harness.sh`. A mismatched tree is `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib` naming that commit, not “CF sources missing”.

## Tests (this VM)

- `python3 scripts/env/test_contract.py` — 8/8, including `test_ud_guest_x86_demands_pinned_corelibs_foundation`.
- `python3 scripts/env/contract.py` — `ENV_CONTRACT_LOCKS_OK agreements=14/14` (checkout swift-corelibs-foundation agrees with `ud_guest.inc`).
- `bash scripts/x86/test_phase2.sh` — pin greps; wrong-tree and non-git dest refuse naming `f3a7a343`; live fetch verified `HEAD=f3a7a343…` / `HEAD^{tree}=2f9136f2…` and `Sources/CoreFoundation/{CFRuntime,CFPreferences}.c`. Pre-existing `fail=8` on this VM is missing x86 sysroot / libobjc.tbd / mrroot, not the CF pin.
- Direct `phase2_ud_guest_ensure_cf_checkout`: `CURSOR_CORPUS_OK id=swift-corelibs-foundation commit=f3a7a343… tree=2f9136f2… dest=scratch/ud-guest-x86_64/cf reused=0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cede442a-3f9a-443b-aa2b-f42bcba0da41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cede442a-3f9a-443b-aa2b-f42bcba0da41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

