### PR TITLE
Make widget/onboarding gate inventories resolve per ARCH

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -12,6 +12,8 @@ W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
 . "$W/scripts/vendor_tree.sh"
 # shellcheck disable=SC1091
 . "$(cd "$(dirname "$0")" && pwd)/../scripts/guest_arch.inc"
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "$0")" && pwd)/guest_gate_inventories.inc"
 UIKIT=${UIKIT:-$W/uikit}
 MACHORUN=${MACHORUN:-$W/machorun}
 RESOURCE_INPUT=${1:?usage: build_focus_onboarding_guest.sh <normalized-bundles-directory>}
@@ -1011,89 +1013,17 @@ run_link libOnboarding "${LD[@]}" -dylib -dead_strip \
     -map "$AUDIT/libOnboarding.link-map" \
     -o "$PACKAGE/libOnboarding.dylib" "$OUT/onboarding.o"
 
-expected_openuikit_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libFoundationEssentials.dylib" \
-    "$PACKAGE/libOpenCoreGraphics.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd" \
-    "$MRROOT/darwin/usr/lib/libquartz.dylib" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$FULL/openuikit.o" \
-    "$FULL/cportableio.o" \
-    "$FULL/cstbtruetype.o" \
-    "$FULL/hostclock.o" \
-    "$FULL/swiftcorepatch.o" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd")
+expected_openuikit_inputs=$(guest_gate_inventory onboarding inputs openuikit)
 # removefile_compat.o is in FE_OBJECTS for the onboarding FE/umbrella
 # command lines, but the widget FE map omits inputs that contribute no
 # symbols (lld lists contributors, not the argv). Keep that object off the
 # inventory until a real map shows it.
-expected_foundationessentials_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$FE_OUT/FoundationEssentials.o" \
-    "$FE_COLLECTIONS/InternalCollectionsUtilities.o" \
-    "$FE_COLLECTIONS/OrderedCollections.o" \
-    "$FE_COLLECTIONS/_RopeModule.o" \
-    "$FE_OS/os.o" \
-    "$FE_CSHIMS/platform_shims.o" \
-    "$FE_CSHIMS/string_shims.o" \
-    "$FE_CSHIMS/uuid.o" \
-    "$FE_OUT/fm_unimplemented.o" \
-    "$FE_OUT/removefile_compat.o" \
-    "$FE_OUT/uuid_compat.o" \
-    "$FULL/swiftcorepatch.o" \
-    "$SYS/usr/lib/swift/libswiftDarwin.tbd" \
-    "$SYS/usr/lib/swift/libswift_StringProcessing.tbd" \
-    "$SYS/usr/lib/swift/libswiftSynchronization.tbd" \
-    "$SYS/usr/lib/libobjc.tbd")
-expected_opencoregraphics_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$MRROOT/darwin/usr/lib/libquartz.dylib" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$FULL/opencoregraphics.o" \
-    "$SYS/usr/lib/libobjc.tbd")
-expected_swiftui_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libOpenUIKit.dylib" \
-    "$PACKAGE/libOpenCoreGraphics.dylib" \
-    "$PACKAGE/libCombine.dylib" \
-    "$PACKAGE/libSymbols.dylib" \
-    "$PACKAGE/libFoundationEssentials.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$OUT/swiftui.o" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd" \
-    "$SYS/usr/lib/swift/libswiftObservation.tbd")
-expected_opencombine_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OPENCOMBINE_ARTIFACTS/OpenCombine.o" \
-    "$OUT/copencombinehelpers.o" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$MRROOT/darwin/usr/lib/libc++abi.dylib" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd")
-expected_combine_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OUT/combine.o" \
-    "$SYS/usr/lib/libSystem.tbd")
-expected_symbols_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OUT/symbols.o" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd")
+expected_foundationessentials_inputs=$(guest_gate_inventory onboarding inputs foundationessentials)
+expected_opencoregraphics_inputs=$(guest_gate_inventory onboarding inputs opencoregraphics)
+expected_swiftui_inputs=$(guest_gate_inventory onboarding inputs swiftui)
+expected_opencombine_inputs=$(guest_gate_inventory onboarding inputs opencombine)
+expected_combine_inputs=$(guest_gate_inventory onboarding inputs combine)
+expected_symbols_inputs=$(guest_gate_inventory onboarding inputs symbols)
 # Umbrella objects plus the four input classes the failed link named:
 # libswift_Concurrency.tbd, libswiftDarwin.tbd, libOpenCoreGraphics.dylib,
 # and the run-local OpenRelativeTime Darwin-root image. The package @rpath
@@ -1103,57 +1033,9 @@ expected_symbols_inputs=$(printf '%s\n' \
 # that keeps LC_ID /usr/lib (machorun is_runtime) and binds the symbol.
 # -ignore_auto_link means Darwin/Concurrency cannot ride in through autolink
 # the way they do on FE.
-expected_foundation_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OUT/foundation.o" \
-    "$OUT/corefoundation.o" \
-    "$FE_OUT/FoundationEssentials.o" \
-    "$FE_COLLECTIONS/InternalCollectionsUtilities.o" \
-    "$FE_COLLECTIONS/OrderedCollections.o" \
-    "$FE_COLLECTIONS/_RopeModule.o" \
-    "$FE_OS/os.o" \
-    "$FE_CSHIMS/platform_shims.o" \
-    "$FE_CSHIMS/string_shims.o" \
-    "$FE_CSHIMS/uuid.o" \
-    "$FE_OUT/fm_unimplemented.o" \
-    "$FE_OUT/removefile_compat.o" \
-    "$FE_OUT/uuid_compat.o" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd" \
-    "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
-    "$PACKAGE/libOpenUIKit.dylib" \
-    "$PACKAGE/libCombine.dylib" \
-    "$PACKAGE/libOpenCoreGraphics.dylib" \
-    "$RELATIVE_TIME_RUNTIME" \
-    "$SYS/usr/lib/swift/libswift_StringProcessing.tbd" \
-    "$SYS/usr/lib/swift/libswiftSynchronization.tbd" \
-    "$SYS/usr/lib/swift/libswiftDarwin.tbd" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd")
-expected_widget_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libSwiftUI.dylib" \
-    "$PACKAGE/libOpenUIKit.dylib" \
-    "$PACKAGE/libFoundationEssentials.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$OUT/widget.o" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd")
-expected_onboarding_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libFoundation.dylib" \
-    "$PACKAGE/libSwiftUI.dylib" \
-    "$PACKAGE/libWidget.dylib" \
-    "$PACKAGE/libOpenUIKit.dylib" \
-    "$PACKAGE/libCombine.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$OUT/onboarding.o" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd")
+expected_foundation_inputs=$(guest_gate_inventory onboarding inputs foundation)
+expected_widget_inputs=$(guest_gate_inventory onboarding inputs widget)
+expected_onboarding_inputs=$(guest_gate_inventory onboarding inputs onboarding)
 assert_exact_text "libOpenUIKit linker inputs" \
     "$(link_map_inputs "$AUDIT/libOpenUIKit.link-map")" "$expected_openuikit_inputs"
 assert_exact_text "libFoundationEssentials linker inputs" \

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -13,6 +13,8 @@ W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
 . "$W/scripts/vendor_tree.sh"
 # shellcheck disable=SC1091
 . "$(cd "$(dirname "$0")" && pwd)/../scripts/guest_arch.inc"
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "$0")" && pwd)/guest_gate_inventories.inc"
 UIKIT=${UIKIT:-$W/uikit}
 MACHORUN=${MACHORUN:-$W/machorun}
 RESOURCE_INPUT=${1:?usage: build_focus_widget_guest.sh <normalized-Focus_Widget.bundle>}
@@ -89,8 +91,8 @@ EXPECTED_SECOND_SHA=f71bc94e686809660d920da6f7804174097e038302a843c3533da45ceda4
 EXPECTED_RESOURCE_TREE_SHA=144c49c747d4689d9ca98d353cb5474b311473629383a779d99f1b705969a04d
 EXPECTED_RESOURCE_FILE_COUNT=16
 EXPECTED_RESOURCE_DIRECTORY_COUNT=7
-EXPECTED_PACKAGE_FILE_COUNT=101
-EXPECTED_PACKAGE_DIRECTORY_COUNT=12
+EXPECTED_PACKAGE_FILE_COUNT=$(guest_gate_inventory widget package file_count)
+EXPECTED_PACKAGE_DIRECTORY_COUNT=$(guest_gate_inventory widget package directory_count)
 BUILD_INPUT_MANIFEST=$FULL/focus-widget-build-inputs.manifest
 RUNTIME_CLOSURE_MANIFEST=$FULL/focus-widget-runtime-closure.manifest
 ATTEST=$W/full/swiftui/focus_widget_guest_attest.pl
@@ -143,6 +145,8 @@ support_digest() {
             "$W/full/swiftui/FocusWidgetBundle.generated.swift" \
             "$W/full/swiftui/FocusWidgetGuestMain.swift" \
             "$W/full/swiftui/focus_widget_guest_attest.pl" \
+            "$W/full/swiftui/guest_gate_inventories.py" \
+            "$W/full/swiftui/guest_gate_inventories.inc" \
             "$W/full/oracle-opencombine/Combine.swift" \
             "$W/full/oracle-opencombine/patches/COpenCombineHelpers-pthread-recursive.patch" \
             "$W/full/scripts/build_full.sh" \
@@ -686,76 +690,15 @@ package_directory_count=$(find "$PACKAGE" -mindepth 1 -type d | wc -l | tr -d '[
     echo "focus_widget_guest: package has $package_directory_count directories, expected $EXPECTED_PACKAGE_DIRECTORY_COUNT" >&2
     exit 2
 }
-expected_package_names=$(printf '%s\n' \
-    Combine.abi.json \
-    Combine.swiftdoc \
-    Combine.swiftmodule \
-    Combine.swiftsourceinfo \
-    OpenCombine.swiftdoc \
-    OpenCombine.swiftmodule \
-    OpenCoreGraphics.abi.json \
-    OpenCoreGraphics.swiftdoc \
-    OpenCoreGraphics.swiftmodule \
-    OpenCoreGraphics.swiftsourceinfo \
-    OpenUIKit.abi.json \
-    OpenUIKit.swiftdoc \
-    OpenUIKit.swiftmodule \
-    OpenUIKit.swiftsourceinfo \
-    SwiftUI.abi.json \
-    SwiftUI.swiftdoc \
-    SwiftUI.swiftmodule \
-    SwiftUI.swiftsourceinfo \
-    Symbols.abi.json \
-    Symbols.swiftdoc \
-    Symbols.swiftmodule \
-    Symbols.swiftsourceinfo \
-    libCombine.dylib \
-    libFoundationEssentials.dylib \
-    libOpenCombine.dylib \
-    libOpenCoreGraphics.dylib \
-    libOpenUIKit.dylib \
-    libSwiftUI.dylib \
-    libSymbols.dylib)
+expected_package_names=$(guest_gate_inventory widget package names)
 actual_package_names=$(find "$PACKAGE" -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort)
 assert_exact_text "package top-level inventory" "$actual_package_names" "$expected_package_names"
-expected_package_directories=$(printf '%s\n' \
-    include \
-    include/CHostClock \
-    include/COpenCombineHelpers \
-    include/CPortableIO \
-    include/CQuartz \
-    include/CQuartz/quartz \
-    include/CSTBTrueType \
-    include/_FoundationCShims \
-    modules \
-    modules/Collections \
-    modules/FoundationEssentials \
-    modules/os)
+expected_package_directories=$(guest_gate_inventory widget package directories)
 actual_package_directories=$(find "$PACKAGE" -mindepth 1 -type d | \
     sed "s#^$PACKAGE/##" | LC_ALL=C sort)
 assert_exact_text "package directory inventory" \
     "$actual_package_directories" "$expected_package_directories"
-expected_fe_module_files=$(printf '%s\n' \
-    Collections/InternalCollectionsUtilities.abi.json \
-    Collections/InternalCollectionsUtilities.swiftdoc \
-    Collections/InternalCollectionsUtilities.swiftmodule \
-    Collections/InternalCollectionsUtilities.swiftsourceinfo \
-    Collections/OrderedCollections.abi.json \
-    Collections/OrderedCollections.swiftdoc \
-    Collections/OrderedCollections.swiftmodule \
-    Collections/OrderedCollections.swiftsourceinfo \
-    Collections/_RopeModule.abi.json \
-    Collections/_RopeModule.swiftdoc \
-    Collections/_RopeModule.swiftmodule \
-    Collections/_RopeModule.swiftsourceinfo \
-    FoundationEssentials/FoundationEssentials.abi.json \
-    FoundationEssentials/FoundationEssentials.swiftdoc \
-    FoundationEssentials/FoundationEssentials.swiftmodule \
-    FoundationEssentials/FoundationEssentials.swiftsourceinfo \
-    os/os.abi.json \
-    os/os.swiftdoc \
-    os/os.swiftmodule \
-    os/os.swiftsourceinfo)
+expected_fe_module_files=$(guest_gate_inventory widget package fe_module_files)
 actual_fe_module_files=$(find "$PACKAGE/modules" -type f | \
     sed "s#^$PACKAGE/modules/##" | LC_ALL=C sort)
 assert_exact_text "FoundationEssentials module inventory" \
@@ -856,82 +799,14 @@ assert_exact_text "guest LC_RPATH set" \
     "$(rpaths "$OUT/focus_widget_guest")" \
     "$(printf '%s\n' /usr/lib/swift @loader_path/package)"
 
-expected_openuikit_loads=$(printf '%s\n' \
-    @rpath/libOpenUIKit.dylib \
-    @rpath/libFoundationEssentials.dylib \
-    @rpath/libOpenCoreGraphics.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libswiftcompat.dylib \
-    /usr/lib/libSystem.B.dylib \
-    /usr/lib/libobjc.A.dylib \
-    /usr/lib/libquartz.dylib \
-    /usr/lib/swift/libswift_Concurrency.dylib \
-    /usr/lib/swift/libswiftObjectiveC.dylib \
-    /usr/lib/swift/libswift_errno.dylib)
-expected_foundationessentials_loads=$(printf '%s\n' \
-    @rpath/libFoundationEssentials.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libswiftcompat.dylib \
-    /usr/lib/libSystem.B.dylib \
-    /usr/lib/swift/libswiftDarwin.dylib \
-    /usr/lib/swift/libswift_StringProcessing.dylib \
-    /usr/lib/swift/libswiftSynchronization.dylib \
-    /usr/lib/libobjc.A.dylib \
-    /usr/lib/swift/libswift_errno.dylib)
-expected_opencoregraphics_loads=$(printf '%s\n' \
-    @rpath/libOpenCoreGraphics.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libswiftcompat.dylib \
-    /usr/lib/libSystem.B.dylib \
-    /usr/lib/libquartz.dylib \
-    /usr/lib/libobjc.A.dylib)
-expected_swiftui_loads=$(printf '%s\n' \
-    @rpath/libSwiftUI.dylib \
-    @rpath/libOpenUIKit.dylib \
-    @rpath/libOpenCoreGraphics.dylib \
-    @rpath/libCombine.dylib \
-    @rpath/libOpenCombine.dylib \
-    @rpath/libSymbols.dylib \
-    @rpath/libFoundationEssentials.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libswiftcompat.dylib \
-    /usr/lib/libSystem.B.dylib \
-    /usr/lib/libobjc.A.dylib \
-    /usr/lib/libquartz.dylib \
-    /usr/lib/swift/libswift_Concurrency.dylib \
-    /usr/lib/swift/libswiftObjectiveC.dylib \
-    /usr/lib/swift/libswiftObservation.dylib)
-expected_opencombine_loads=$(printf '%s\n' \
-    @rpath/libOpenCombine.dylib \
-    /usr/lib/swift/libswift_Concurrency.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libc++abi.dylib \
-    /usr/lib/libSystem.B.dylib \
-    /usr/lib/libSystem.real.dylib \
-    /usr/lib/libobjc.A.dylib)
-expected_combine_loads=$(printf '%s\n' \
-    @rpath/libCombine.dylib \
-    @rpath/libOpenCombine.dylib \
-    @rpath/libOpenCombine.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libSystem.B.dylib)
-expected_symbols_loads=$(printf '%s\n' \
-    @rpath/libSymbols.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libswiftcompat.dylib \
-    /usr/lib/libSystem.B.dylib)
-expected_guest_loads=$(printf '%s\n' \
-    @rpath/libSwiftUI.dylib \
-    @rpath/libOpenUIKit.dylib \
-    @rpath/libFoundationEssentials.dylib \
-    @rpath/libOpenCoreGraphics.dylib \
-    @rpath/libSymbols.dylib \
-    /usr/lib/swift/libswiftCore.dylib \
-    /usr/lib/libswiftcompat.dylib \
-    /usr/lib/libSystem.B.dylib \
-    /usr/lib/libobjc.A.dylib \
-    /usr/lib/libquartz.dylib \
-    /usr/lib/swift/libswiftObjectiveC.dylib)
+expected_openuikit_loads=$(guest_gate_inventory widget loads openuikit)
+expected_foundationessentials_loads=$(guest_gate_inventory widget loads foundationessentials)
+expected_opencoregraphics_loads=$(guest_gate_inventory widget loads opencoregraphics)
+expected_swiftui_loads=$(guest_gate_inventory widget loads swiftui)
+expected_opencombine_loads=$(guest_gate_inventory widget loads opencombine)
+expected_combine_loads=$(guest_gate_inventory widget loads combine)
+expected_symbols_loads=$(guest_gate_inventory widget loads symbols)
+expected_guest_loads=$(guest_gate_inventory widget loads guest)
 assert_exact_text "libOpenUIKit dylib loads" \
     "$(load_paths "$PACKAGE/libOpenUIKit.dylib")" "$expected_openuikit_loads"
 assert_exact_text "libFoundationEssentials dylib loads" \
@@ -1046,107 +921,24 @@ grep -Fqx $'import\tlibSwiftUI\tOpenUIKit\tlibOpenUIKit\t'"$foreign_extension" \
 # that compatibility entry point; the project-owned libSystem umbrella does,
 # and is already the image behind the exact /usr/lib/libSystem.B.dylib load.
 # Keep the physical provider explicit in the link-input allowlist.
-expected_openuikit_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libFoundationEssentials.dylib" \
-    "$PACKAGE/libOpenCoreGraphics.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd" \
-    "$MRROOT/darwin/usr/lib/libquartz.dylib" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$FULL/openuikit.o" \
-    "$FULL/cportableio.o" \
-    "$FULL/cstbtruetype.o" \
-    "$FULL/hostclock.o" \
-    "$FULL/swiftcorepatch.o" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd")
-expected_foundationessentials_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$MRROOT/darwin/usr/lib/libswiftcompat.dylib" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$FE_OUT/FoundationEssentials.o" \
-    "$FE_COLLECTIONS/InternalCollectionsUtilities.o" \
-    "$FE_COLLECTIONS/OrderedCollections.o" \
-    "$FE_COLLECTIONS/_RopeModule.o" \
-    "$FE_OS/os.o" \
-    "$FE_CSHIMS/platform_shims.o" \
-    "$FE_CSHIMS/string_shims.o" \
-    "$FE_CSHIMS/uuid.o" \
-    "$FE_OUT/fm_unimplemented.o" \
-    "$FE_OUT/uuid_compat.o" \
-    "$FULL/swiftcorepatch.o" \
-    "$SYS/usr/lib/swift/libswiftDarwin.tbd" \
-    "$SYS/usr/lib/swift/libswift_StringProcessing.tbd" \
-    "$SYS/usr/lib/swift/libswiftSynchronization.tbd" \
-    "$SYS/usr/lib/libobjc.tbd")
+expected_openuikit_inputs=$(guest_gate_inventory widget inputs openuikit)
+expected_foundationessentials_inputs=$(guest_gate_inventory widget inputs foundationessentials)
 # libSystem.B.dylib (mrroot) resolves _remquo and _nan for
 # OpenCoreGraphics/PortableCGFloat.swift's CGFloat remquo(_:_:) / nan(_:)
 # wrappers: the sysroot libSystem.tbd re-exports libsystem_m, but the sysroot
 # carries no usr/lib/system/*.tbd to follow, so lld binds the real image --
 # the same image the loader maps for /usr/lib/libSystem.B.dylib.
-expected_opencoregraphics_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$MRROOT/darwin/usr/lib/libquartz.dylib" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$FULL/opencoregraphics.o" \
-    "$SYS/usr/lib/libobjc.tbd")
-expected_swiftui_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libOpenUIKit.dylib" \
-    "$PACKAGE/libOpenCoreGraphics.dylib" \
-    "$PACKAGE/libCombine.dylib" \
-    "$PACKAGE/libSymbols.dylib" \
-    "$PACKAGE/libFoundationEssentials.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$OUT/swiftui.o" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd" \
-    "$SYS/usr/lib/swift/libswiftObservation.tbd")
-expected_opencombine_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OPENCOMBINE_ARTIFACTS/OpenCombine.o" \
-    "$OUT/copencombinehelpers.o" \
-    "$SYS/usr/lib/swift/libswift_Concurrency.tbd" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$MRROOT/darwin/usr/lib/libc++abi.dylib" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd")
-expected_combine_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OUT/combine.o" \
-    "$SYS/usr/lib/libSystem.tbd")
+expected_opencoregraphics_inputs=$(guest_gate_inventory widget inputs opencoregraphics)
+expected_swiftui_inputs=$(guest_gate_inventory widget inputs swiftui)
+expected_opencombine_inputs=$(guest_gate_inventory widget inputs opencombine)
+expected_combine_inputs=$(guest_gate_inventory widget inputs combine)
 # libswiftcompat.dylib is on libSymbols' link line and in its load commands,
 # but symbols.o binds nothing from it, so lld's map omits it (the map lists
 # inputs that contributed symbols, not the command line).
-expected_symbols_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$OUT/symbols.o" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd")
+expected_symbols_inputs=$(guest_gate_inventory widget inputs symbols)
 # libSymbols.dylib is a guest load command (expected_guest_loads) but the
 # widget binds no Symbols symbol, so it is absent from the guest link map.
-expected_guest_inputs=$(printf '%s\n' \
-    'linker synthesized' \
-    "$PACKAGE/libSwiftUI.dylib" \
-    "$PACKAGE/libOpenUIKit.dylib" \
-    "$PACKAGE/libFoundationEssentials.dylib" \
-    "$PACKAGE/libOpenCoreGraphics.dylib" \
-    "$SYS/usr/lib/swift/libswiftCore.tbd" \
-    "$SYS/usr/lib/libSystem.tbd" \
-    "$SYS/usr/lib/libobjc.tbd" \
-    "$MRROOT/darwin/usr/lib/libSystem.B.dylib" \
-    "$OUT/guest-main.o" \
-    "$OUT/focuswidget.o" \
-    "$SYS/usr/lib/swift/libswiftObjectiveC.tbd")
+expected_guest_inputs=$(guest_gate_inventory widget inputs guest)
 assert_exact_text "libOpenUIKit linker inputs" \
     "$(link_map_inputs "$AUDIT/libOpenUIKit.link-map")" "$expected_openuikit_inputs"
 assert_exact_text "libFoundationEssentials linker inputs" \

--- a/full/swiftui/focus_widget_guest_attest.pl
+++ b/full/swiftui/focus_widget_guest_attest.pl
@@ -109,6 +109,8 @@ sub inventory_command {
     my @files = (
         [ "$w/full/swiftui/build_focus_widget_guest.sh", 'project/full/swiftui/build_focus_widget_guest.sh' ],
         [ "$w/full/swiftui/focus_widget_guest_attest.pl", 'project/full/swiftui/focus_widget_guest_attest.pl' ],
+        [ "$w/full/swiftui/guest_gate_inventories.py", 'project/full/swiftui/guest_gate_inventories.py' ],
+        [ "$w/full/swiftui/guest_gate_inventories.inc", 'project/full/swiftui/guest_gate_inventories.inc' ],
         [ "$w/full/swiftui/FocusWidgetBundle.generated.swift", 'project/full/swiftui/FocusWidgetBundle.generated.swift' ],
         [ "$w/full/swiftui/FocusWidgetGuestMain.swift", 'project/full/swiftui/FocusWidgetGuestMain.swift' ],
         [ "$w/full/scripts/build_full.sh", 'project/full/scripts/build_full.sh' ],

--- a/full/swiftui/guest_gate_inventories.inc
+++ b/full/swiftui/guest_gate_inventories.inc
@@ -1,0 +1,25 @@
+# guest_gate_inventories.inc -- ARCH-keyed widget/onboarding gate inventories.
+# Sourced after full/scripts/guest_arch.inc. Python is the source of truth.
+_GUEST_GATE_INVENTORIES_PY="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/guest_gate_inventories.py"
+
+guest_gate_inventory() {
+    local gate=$1 kind=$2 name=${3:-}
+    local -a args=(
+        --arch "${ARCH:?}"
+        --gate "$gate"
+        --kind "$kind"
+        --bind "PACKAGE=${PACKAGE:-}"
+        --bind "SYS=${SYS:-}"
+        --bind "MRROOT=${MRROOT:-}"
+        --bind "FULL=${FULL:-}"
+        --bind "OUT=${OUT:-}"
+        --bind "FE_OUT=${FE_OUT:-}"
+        --bind "FE_COLLECTIONS=${FE_COLLECTIONS:-}"
+        --bind "FE_OS=${FE_OS:-}"
+        --bind "FE_CSHIMS=${FE_CSHIMS:-}"
+        --bind "OPENCOMBINE_ARTIFACTS=${OPENCOMBINE_ARTIFACTS:-}"
+        --bind "RELATIVE_TIME_RUNTIME=${RELATIVE_TIME_RUNTIME:-}"
+    )
+    [ -n "$name" ] && args+=(--name "$name")
+    python3 "$_GUEST_GATE_INVENTORIES_PY" "${args[@]}"
+}

--- a/full/swiftui/guest_gate_inventories.py
+++ b/full/swiftui/guest_gate_inventories.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+"""Arch-keyed inventories the Focus widget/onboarding gates assert.
+
+One source for expected_*_loads, expected_*_inputs, package file lists, and
+otool CPU strings. Arm64 tuples are the historical literals (Gate B at
+e93727e0). x86_64 load lists apply the operator-evidenced overlay autolink
+swap; x86_64 input/package lists start as the arm64 lists (paths already go
+through $SYS/$PACKAGE/$FULL which carry FULL_OUT_SUFFIX).
+
+Operator dumps on the x86_64 EC2 box (FULL_OUT_SUFFIX=-x86_64):
+
+  otool -L every packaged dylib / guest:
+    build/swiftui-guest-x86_64/package/libOpenUIKit.dylib
+    build/swiftui-guest-x86_64/package/libFoundationEssentials.dylib
+    build/swiftui-guest-x86_64/package/libOpenCoreGraphics.dylib
+    build/swiftui-guest-x86_64/package/libSwiftUI.dylib
+    build/swiftui-guest-x86_64/package/libOpenCombine.dylib
+    build/swiftui-guest-x86_64/package/libCombine.dylib
+    build/swiftui-guest-x86_64/package/libSymbols.dylib
+    build/swiftui-guest-x86_64/focus_widget_guest
+
+  link maps (widget gate writes these under audit/):
+    build/swiftui-guest-x86_64/audit/libOpenUIKit.link-map
+    build/swiftui-guest-x86_64/audit/libFoundationEssentials.link-map
+    build/swiftui-guest-x86_64/audit/libOpenCoreGraphics.link-map
+    build/swiftui-guest-x86_64/audit/libSwiftUI.link-map
+    build/swiftui-guest-x86_64/audit/libOpenCombine.link-map
+    build/swiftui-guest-x86_64/audit/libCombine.link-map
+    build/swiftui-guest-x86_64/audit/libSymbols.link-map
+    build/swiftui-guest-x86_64/audit/focus_widget_guest.link-map
+
+  onboarding link maps:
+    build/focus-onboarding-guest-x86_64/audit/libOpenUIKit.link-map
+    build/focus-onboarding-guest-x86_64/audit/libFoundationEssentials.link-map
+    build/focus-onboarding-guest-x86_64/audit/libOpenCoreGraphics.link-map
+    build/focus-onboarding-guest-x86_64/audit/libSwiftUI.link-map
+    build/focus-onboarding-guest-x86_64/audit/libOpenCombine.link-map
+    build/focus-onboarding-guest-x86_64/audit/libCombine.link-map
+    build/focus-onboarding-guest-x86_64/audit/libSymbols.link-map
+    build/focus-onboarding-guest-x86_64/audit/libFoundation.link-map
+    build/focus-onboarding-guest-x86_64/audit/libWidget.link-map
+    build/focus-onboarding-guest-x86_64/audit/libOnboarding.link-map
+
+Keep in lockstep with full/scripts/guest_arch.py for otool CPU. Input templates
+use {PACKAGE}/{SYS}/… so the gate binds run paths; tests hash the templates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+
+ARCHES = ("arm64", "x86_64")
+GATES = ("widget", "onboarding")
+KINDS = ("loads", "inputs", "package", "otool-cpu")
+
+# Operator evidence (x86_64 EC2, main e93727e0): the packaged dylib records
+# LC_LOAD_DYLIB of libswift_DarwinFoundation1.dylib where arm64 records
+# libswift_errno.dylib. Arm64 overlays are the iOS simulator runtime; x86_64
+# overlays are Apple's macOS dyld shared cache (scratch/apple-x86-overlays).
+# libswift_errno there re-exports _DarwinFoundation1, and the toolchain's
+# autolink/-l choice follows the re-export target.
+ARM64_OVERLAY_AUTOLINK = "/usr/lib/swift/libswift_errno.dylib"
+X86_OVERLAY_AUTOLINK = "/usr/lib/swift/libswift_DarwinFoundation1.dylib"
+ARM64_OVERLAY_AUTOLINK_TBD = "{SYS}/usr/lib/swift/libswift_errno.tbd"
+X86_OVERLAY_AUTOLINK_TBD = "{SYS}/usr/lib/swift/libswift_DarwinFoundation1.tbd"
+
+BIND_NAMES = (
+    "PACKAGE",
+    "SYS",
+    "MRROOT",
+    "FULL",
+    "OUT",
+    "FE_OUT",
+    "FE_COLLECTIONS",
+    "FE_OS",
+    "FE_CSHIMS",
+    "OPENCOMBINE_ARTIFACTS",
+    "RELATIVE_TIME_RUNTIME",
+)
+
+_PLACEHOLDER = re.compile(r"\{([A-Z][A-Z0-9_]*)\}")
+
+
+def canonical_text(items: tuple[str, ...]) -> str:
+    """Same bytes `printf '%s\\n' item...` feeds into bash $(...) before strip."""
+    if not items:
+        return ""
+    return "\n".join(items) + "\n"
+
+
+def inventory_sha256(items: tuple[str, ...]) -> str:
+    return hashlib.sha256(canonical_text(items).encode("utf-8")).hexdigest()
+
+
+def macos_overlay_autolink_loads(items: tuple[str, ...], arch: str) -> tuple[str, ...]:
+    if arch == "arm64":
+        return items
+    if arch != "x86_64":
+        raise ValueError(f"unsupported arch {arch!r}")
+    return tuple(
+        X86_OVERLAY_AUTOLINK if item == ARM64_OVERLAY_AUTOLINK else item
+        for item in items
+    )
+
+
+def macos_overlay_autolink_inputs(items: tuple[str, ...], arch: str) -> tuple[str, ...]:
+    if arch == "arm64":
+        return items
+    if arch != "x86_64":
+        raise ValueError(f"unsupported arch {arch!r}")
+    return tuple(
+        X86_OVERLAY_AUTOLINK_TBD if item == ARM64_OVERLAY_AUTOLINK_TBD else item
+        for item in items
+    )
+
+
+# --- widget LC_LOAD_DYLIB inventories (otool -L, no path binds) ---
+
+WIDGET_LOADS_ARM64: dict[str, tuple[str, ...]] = {
+    "openuikit": (
+        "@rpath/libOpenUIKit.dylib",
+        "@rpath/libFoundationEssentials.dylib",
+        "@rpath/libOpenCoreGraphics.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libswiftcompat.dylib",
+        "/usr/lib/libSystem.B.dylib",
+        "/usr/lib/libobjc.A.dylib",
+        "/usr/lib/libquartz.dylib",
+        "/usr/lib/swift/libswift_Concurrency.dylib",
+        "/usr/lib/swift/libswiftObjectiveC.dylib",
+        "/usr/lib/swift/libswift_errno.dylib",
+    ),
+    "foundationessentials": (
+        "@rpath/libFoundationEssentials.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libswiftcompat.dylib",
+        "/usr/lib/libSystem.B.dylib",
+        "/usr/lib/swift/libswiftDarwin.dylib",
+        "/usr/lib/swift/libswift_StringProcessing.dylib",
+        "/usr/lib/swift/libswiftSynchronization.dylib",
+        "/usr/lib/libobjc.A.dylib",
+        "/usr/lib/swift/libswift_errno.dylib",
+    ),
+    "opencoregraphics": (
+        "@rpath/libOpenCoreGraphics.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libswiftcompat.dylib",
+        "/usr/lib/libSystem.B.dylib",
+        "/usr/lib/libquartz.dylib",
+        "/usr/lib/libobjc.A.dylib",
+    ),
+    "swiftui": (
+        "@rpath/libSwiftUI.dylib",
+        "@rpath/libOpenUIKit.dylib",
+        "@rpath/libOpenCoreGraphics.dylib",
+        "@rpath/libCombine.dylib",
+        "@rpath/libOpenCombine.dylib",
+        "@rpath/libSymbols.dylib",
+        "@rpath/libFoundationEssentials.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libswiftcompat.dylib",
+        "/usr/lib/libSystem.B.dylib",
+        "/usr/lib/libobjc.A.dylib",
+        "/usr/lib/libquartz.dylib",
+        "/usr/lib/swift/libswift_Concurrency.dylib",
+        "/usr/lib/swift/libswiftObjectiveC.dylib",
+        "/usr/lib/swift/libswiftObservation.dylib",
+    ),
+    "opencombine": (
+        "@rpath/libOpenCombine.dylib",
+        "/usr/lib/swift/libswift_Concurrency.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libc++abi.dylib",
+        "/usr/lib/libSystem.B.dylib",
+        "/usr/lib/libSystem.real.dylib",
+        "/usr/lib/libobjc.A.dylib",
+    ),
+    "combine": (
+        "@rpath/libCombine.dylib",
+        "@rpath/libOpenCombine.dylib",
+        "@rpath/libOpenCombine.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libSystem.B.dylib",
+    ),
+    "symbols": (
+        "@rpath/libSymbols.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libswiftcompat.dylib",
+        "/usr/lib/libSystem.B.dylib",
+    ),
+    "guest": (
+        "@rpath/libSwiftUI.dylib",
+        "@rpath/libOpenUIKit.dylib",
+        "@rpath/libFoundationEssentials.dylib",
+        "@rpath/libOpenCoreGraphics.dylib",
+        "@rpath/libSymbols.dylib",
+        "/usr/lib/swift/libswiftCore.dylib",
+        "/usr/lib/libswiftcompat.dylib",
+        "/usr/lib/libSystem.B.dylib",
+        "/usr/lib/libobjc.A.dylib",
+        "/usr/lib/libquartz.dylib",
+        "/usr/lib/swift/libswiftObjectiveC.dylib",
+    ),
+}
+
+# --- widget link-map Object-files inventories ---
+
+WIDGET_INPUTS_ARM64: dict[str, tuple[str, ...]] = {
+    "openuikit": (
+        "linker synthesized",
+        "{PACKAGE}/libFoundationEssentials.dylib",
+        "{PACKAGE}/libOpenCoreGraphics.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+        "{MRROOT}/darwin/usr/lib/libquartz.dylib",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{FULL}/openuikit.o",
+        "{FULL}/cportableio.o",
+        "{FULL}/cstbtruetype.o",
+        "{FULL}/hostclock.o",
+        "{FULL}/swiftcorepatch.o",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+    ),
+    "foundationessentials": (
+        "linker synthesized",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{MRROOT}/darwin/usr/lib/libswiftcompat.dylib",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{FE_OUT}/FoundationEssentials.o",
+        "{FE_COLLECTIONS}/InternalCollectionsUtilities.o",
+        "{FE_COLLECTIONS}/OrderedCollections.o",
+        "{FE_COLLECTIONS}/_RopeModule.o",
+        "{FE_OS}/os.o",
+        "{FE_CSHIMS}/platform_shims.o",
+        "{FE_CSHIMS}/string_shims.o",
+        "{FE_CSHIMS}/uuid.o",
+        "{FE_OUT}/fm_unimplemented.o",
+        "{FE_OUT}/uuid_compat.o",
+        "{FULL}/swiftcorepatch.o",
+        "{SYS}/usr/lib/swift/libswiftDarwin.tbd",
+        "{SYS}/usr/lib/swift/libswift_StringProcessing.tbd",
+        "{SYS}/usr/lib/swift/libswiftSynchronization.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "opencoregraphics": (
+        "linker synthesized",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{MRROOT}/darwin/usr/lib/libquartz.dylib",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{FULL}/opencoregraphics.o",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "swiftui": (
+        "linker synthesized",
+        "{PACKAGE}/libOpenUIKit.dylib",
+        "{PACKAGE}/libOpenCoreGraphics.dylib",
+        "{PACKAGE}/libCombine.dylib",
+        "{PACKAGE}/libSymbols.dylib",
+        "{PACKAGE}/libFoundationEssentials.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{OUT}/swiftui.o",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+        "{SYS}/usr/lib/swift/libswiftObservation.tbd",
+    ),
+    "opencombine": (
+        "linker synthesized",
+        "{OPENCOMBINE_ARTIFACTS}/OpenCombine.o",
+        "{OUT}/copencombinehelpers.o",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{MRROOT}/darwin/usr/lib/libc++abi.dylib",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "combine": (
+        "linker synthesized",
+        "{OUT}/combine.o",
+        "{SYS}/usr/lib/libSystem.tbd",
+    ),
+    "symbols": (
+        "linker synthesized",
+        "{OUT}/symbols.o",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+    ),
+    "guest": (
+        "linker synthesized",
+        "{PACKAGE}/libSwiftUI.dylib",
+        "{PACKAGE}/libOpenUIKit.dylib",
+        "{PACKAGE}/libFoundationEssentials.dylib",
+        "{PACKAGE}/libOpenCoreGraphics.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{OUT}/guest-main.o",
+        "{OUT}/focuswidget.o",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+    ),
+}
+
+# --- onboarding link-map Object-files inventories ---
+
+ONBOARDING_INPUTS_ARM64: dict[str, tuple[str, ...]] = {
+    "openuikit": (
+        "linker synthesized",
+        "{PACKAGE}/libFoundationEssentials.dylib",
+        "{PACKAGE}/libOpenCoreGraphics.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+        "{MRROOT}/darwin/usr/lib/libquartz.dylib",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{FULL}/openuikit.o",
+        "{FULL}/cportableio.o",
+        "{FULL}/cstbtruetype.o",
+        "{FULL}/hostclock.o",
+        "{FULL}/swiftcorepatch.o",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+    ),
+    "foundationessentials": (
+        "linker synthesized",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{MRROOT}/darwin/usr/lib/libswiftcompat.dylib",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{FE_OUT}/FoundationEssentials.o",
+        "{FE_COLLECTIONS}/InternalCollectionsUtilities.o",
+        "{FE_COLLECTIONS}/OrderedCollections.o",
+        "{FE_COLLECTIONS}/_RopeModule.o",
+        "{FE_OS}/os.o",
+        "{FE_CSHIMS}/platform_shims.o",
+        "{FE_CSHIMS}/string_shims.o",
+        "{FE_CSHIMS}/uuid.o",
+        "{FE_OUT}/fm_unimplemented.o",
+        "{FE_OUT}/removefile_compat.o",
+        "{FE_OUT}/uuid_compat.o",
+        "{FULL}/swiftcorepatch.o",
+        "{SYS}/usr/lib/swift/libswiftDarwin.tbd",
+        "{SYS}/usr/lib/swift/libswift_StringProcessing.tbd",
+        "{SYS}/usr/lib/swift/libswiftSynchronization.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "opencoregraphics": (
+        "linker synthesized",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{MRROOT}/darwin/usr/lib/libquartz.dylib",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{FULL}/opencoregraphics.o",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "swiftui": (
+        "linker synthesized",
+        "{PACKAGE}/libOpenUIKit.dylib",
+        "{PACKAGE}/libOpenCoreGraphics.dylib",
+        "{PACKAGE}/libCombine.dylib",
+        "{PACKAGE}/libSymbols.dylib",
+        "{PACKAGE}/libFoundationEssentials.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{OUT}/swiftui.o",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+        "{SYS}/usr/lib/swift/libswiftObservation.tbd",
+    ),
+    "opencombine": (
+        "linker synthesized",
+        "{OPENCOMBINE_ARTIFACTS}/OpenCombine.o",
+        "{OUT}/copencombinehelpers.o",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{MRROOT}/darwin/usr/lib/libc++abi.dylib",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "combine": (
+        "linker synthesized",
+        "{OUT}/combine.o",
+        "{SYS}/usr/lib/libSystem.tbd",
+    ),
+    "symbols": (
+        "linker synthesized",
+        "{OUT}/symbols.o",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+    ),
+    "foundation": (
+        "linker synthesized",
+        "{OUT}/foundation.o",
+        "{OUT}/corefoundation.o",
+        "{FE_OUT}/FoundationEssentials.o",
+        "{FE_COLLECTIONS}/InternalCollectionsUtilities.o",
+        "{FE_COLLECTIONS}/OrderedCollections.o",
+        "{FE_COLLECTIONS}/_RopeModule.o",
+        "{FE_OS}/os.o",
+        "{FE_CSHIMS}/platform_shims.o",
+        "{FE_CSHIMS}/string_shims.o",
+        "{FE_CSHIMS}/uuid.o",
+        "{FE_OUT}/fm_unimplemented.o",
+        "{FE_OUT}/removefile_compat.o",
+        "{FE_OUT}/uuid_compat.o",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+        "{MRROOT}/darwin/usr/lib/libswiftcompat.dylib",
+        "{PACKAGE}/libOpenUIKit.dylib",
+        "{PACKAGE}/libCombine.dylib",
+        "{PACKAGE}/libOpenCoreGraphics.dylib",
+        "{RELATIVE_TIME_RUNTIME}",
+        "{SYS}/usr/lib/swift/libswift_StringProcessing.tbd",
+        "{SYS}/usr/lib/swift/libswiftSynchronization.tbd",
+        "{SYS}/usr/lib/swift/libswiftDarwin.tbd",
+        "{SYS}/usr/lib/swift/libswift_Concurrency.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+    ),
+    "widget": (
+        "linker synthesized",
+        "{PACKAGE}/libSwiftUI.dylib",
+        "{PACKAGE}/libOpenUIKit.dylib",
+        "{PACKAGE}/libFoundationEssentials.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{OUT}/widget.o",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+    ),
+    "onboarding": (
+        "linker synthesized",
+        "{PACKAGE}/libFoundation.dylib",
+        "{PACKAGE}/libSwiftUI.dylib",
+        "{PACKAGE}/libWidget.dylib",
+        "{PACKAGE}/libOpenUIKit.dylib",
+        "{PACKAGE}/libCombine.dylib",
+        "{SYS}/usr/lib/swift/libswiftCore.tbd",
+        "{SYS}/usr/lib/libSystem.tbd",
+        "{SYS}/usr/lib/libobjc.tbd",
+        "{MRROOT}/darwin/usr/lib/libSystem.B.dylib",
+        "{OUT}/onboarding.o",
+        "{SYS}/usr/lib/swift/libswiftObjectiveC.tbd",
+    ),
+}
+
+# --- widget package tree inventories (identical on both arches today) ---
+
+WIDGET_PACKAGE_NAMES_ARM64: tuple[str, ...] = (
+    "Combine.abi.json",
+    "Combine.swiftdoc",
+    "Combine.swiftmodule",
+    "Combine.swiftsourceinfo",
+    "OpenCombine.swiftdoc",
+    "OpenCombine.swiftmodule",
+    "OpenCoreGraphics.abi.json",
+    "OpenCoreGraphics.swiftdoc",
+    "OpenCoreGraphics.swiftmodule",
+    "OpenCoreGraphics.swiftsourceinfo",
+    "OpenUIKit.abi.json",
+    "OpenUIKit.swiftdoc",
+    "OpenUIKit.swiftmodule",
+    "OpenUIKit.swiftsourceinfo",
+    "SwiftUI.abi.json",
+    "SwiftUI.swiftdoc",
+    "SwiftUI.swiftmodule",
+    "SwiftUI.swiftsourceinfo",
+    "Symbols.abi.json",
+    "Symbols.swiftdoc",
+    "Symbols.swiftmodule",
+    "Symbols.swiftsourceinfo",
+    "libCombine.dylib",
+    "libFoundationEssentials.dylib",
+    "libOpenCombine.dylib",
+    "libOpenCoreGraphics.dylib",
+    "libOpenUIKit.dylib",
+    "libSwiftUI.dylib",
+    "libSymbols.dylib",
+)
+
+WIDGET_PACKAGE_DIRECTORIES_ARM64: tuple[str, ...] = (
+    "include",
+    "include/CHostClock",
+    "include/COpenCombineHelpers",
+    "include/CPortableIO",
+    "include/CQuartz",
+    "include/CQuartz/quartz",
+    "include/CSTBTrueType",
+    "include/_FoundationCShims",
+    "modules",
+    "modules/Collections",
+    "modules/FoundationEssentials",
+    "modules/os",
+)
+
+WIDGET_FE_MODULE_FILES_ARM64: tuple[str, ...] = (
+    "Collections/InternalCollectionsUtilities.abi.json",
+    "Collections/InternalCollectionsUtilities.swiftdoc",
+    "Collections/InternalCollectionsUtilities.swiftmodule",
+    "Collections/InternalCollectionsUtilities.swiftsourceinfo",
+    "Collections/OrderedCollections.abi.json",
+    "Collections/OrderedCollections.swiftdoc",
+    "Collections/OrderedCollections.swiftmodule",
+    "Collections/OrderedCollections.swiftsourceinfo",
+    "Collections/_RopeModule.abi.json",
+    "Collections/_RopeModule.swiftdoc",
+    "Collections/_RopeModule.swiftmodule",
+    "Collections/_RopeModule.swiftsourceinfo",
+    "FoundationEssentials/FoundationEssentials.abi.json",
+    "FoundationEssentials/FoundationEssentials.swiftdoc",
+    "FoundationEssentials/FoundationEssentials.swiftmodule",
+    "FoundationEssentials/FoundationEssentials.swiftsourceinfo",
+    "os/os.abi.json",
+    "os/os.swiftdoc",
+    "os/os.swiftmodule",
+    "os/os.swiftsourceinfo",
+)
+
+WIDGET_PACKAGE_FILE_COUNT = 101
+WIDGET_PACKAGE_DIRECTORY_COUNT = 12
+
+OTOOL_CPU = {
+    "arm64": "ARM64",
+    "x86_64": "X86_64",
+}
+
+
+def _loads_table(gate: str) -> dict[str, tuple[str, ...]]:
+    if gate == "widget":
+        return WIDGET_LOADS_ARM64
+    raise KeyError(f"gate {gate!r} has no LC_LOAD_DYLIB inventories")
+
+
+def _inputs_table(gate: str) -> dict[str, tuple[str, ...]]:
+    if gate == "widget":
+        return WIDGET_INPUTS_ARM64
+    if gate == "onboarding":
+        return ONBOARDING_INPUTS_ARM64
+    raise KeyError(f"unknown gate {gate!r}")
+
+
+def loads(gate: str, name: str, arch: str) -> tuple[str, ...]:
+    return macos_overlay_autolink_loads(_loads_table(gate)[name], arch)
+
+
+def inputs(gate: str, name: str, arch: str) -> tuple[str, ...]:
+    return macos_overlay_autolink_inputs(_inputs_table(gate)[name], arch)
+
+
+def package_items(name: str, arch: str) -> tuple[str, ...]:
+    if arch not in ARCHES:
+        raise ValueError(f"unsupported arch {arch!r}")
+    # Package topology is the same on both arches today; keep the lookup
+    # arch-keyed so a later x86-only file can land without rewriting the gate.
+    tables = {
+        "names": WIDGET_PACKAGE_NAMES_ARM64,
+        "directories": WIDGET_PACKAGE_DIRECTORIES_ARM64,
+        "fe_module_files": WIDGET_FE_MODULE_FILES_ARM64,
+    }
+    try:
+        return tables[name]
+    except KeyError as exc:
+        raise KeyError(f"unknown package inventory {name!r}") from exc
+
+
+def package_scalar(name: str, arch: str) -> str:
+    if arch not in ARCHES:
+        raise ValueError(f"unsupported arch {arch!r}")
+    scalars = {
+        "file_count": str(WIDGET_PACKAGE_FILE_COUNT),
+        "directory_count": str(WIDGET_PACKAGE_DIRECTORY_COUNT),
+    }
+    try:
+        return scalars[name]
+    except KeyError as exc:
+        raise KeyError(f"unknown package scalar {name!r}") from exc
+
+
+def otool_cpu(arch: str) -> str:
+    try:
+        return OTOOL_CPU[arch]
+    except KeyError as exc:
+        raise ValueError(f"unsupported arch {arch!r}") from exc
+
+
+def expand(items: tuple[str, ...], binds: dict[str, str]) -> tuple[str, ...]:
+    expanded = []
+    for item in items:
+        def repl(match: re.Match[str]) -> str:
+            key = match.group(1)
+            if key not in binds:
+                raise ValueError(f"unbound inventory placeholder {{{key}}} in {item!r}")
+            return binds[key]
+
+        expanded.append(_PLACEHOLDER.sub(repl, item))
+    leftover = [item for item in expanded if _PLACEHOLDER.search(item)]
+    if leftover:
+        raise ValueError(f"unexpanded inventory placeholders: {leftover}")
+    return tuple(expanded)
+
+
+def parse_binds(raw: list[str]) -> dict[str, str]:
+    binds: dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            raise ValueError(f"bind must be KEY=VALUE, got {item!r}")
+        key, value = item.split("=", 1)
+        binds[key] = value
+    return binds
+
+
+def emit(arch: str, gate: str, kind: str, name: str, binds: dict[str, str]) -> str:
+    if kind == "otool-cpu":
+        return otool_cpu(arch) + "\n"
+    if kind == "package":
+        if name in ("file_count", "directory_count"):
+            return package_scalar(name, arch) + "\n"
+        return canonical_text(package_items(name, arch))
+    if kind == "loads":
+        return canonical_text(loads(gate, name, arch))
+    if kind == "inputs":
+        return canonical_text(expand(inputs(gate, name, arch), binds))
+    raise ValueError(f"unknown kind {kind!r}")
+
+
+def check_names(gate: str, kind: str) -> tuple[str, ...]:
+    if kind == "loads":
+        return tuple(sorted(_loads_table(gate)))
+    if kind == "inputs":
+        return tuple(sorted(_inputs_table(gate)))
+    if kind == "package":
+        if gate != "widget":
+            raise KeyError(f"gate {gate!r} has no package inventories")
+        return (
+            "directory_count",
+            "directories",
+            "fe_module_files",
+            "file_count",
+            "names",
+        )
+    if kind == "otool-cpu":
+        return ("otool-cpu",)
+    raise KeyError(f"unknown kind {kind!r}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch", required=True, choices=ARCHES)
+    parser.add_argument("--gate", required=True, choices=GATES)
+    parser.add_argument("--kind", required=True, choices=KINDS)
+    parser.add_argument("--name", default="")
+    parser.add_argument("--bind", action="append", default=[], metavar="KEY=VALUE")
+    args = parser.parse_args(argv)
+    name = args.name
+    if args.kind != "otool-cpu" and not name:
+        parser.error("--name is required unless --kind otool-cpu")
+    try:
+        sys.stdout.write(
+            emit(args.arch, args.gate, args.kind, name, parse_binds(args.bind))
+        )
+    except (KeyError, ValueError) as exc:
+        print(f"guest_gate_inventories: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression teeth for the unchanged Focus onboarding guest boundary."""
 
+import importlib.util
 from pathlib import Path
 import re
 import subprocess
@@ -32,6 +33,14 @@ FOUNDATION_RUNTIME_UNDEFINED_CONTRACT = (
     ("EXPECTED_FOUNDATION_SYNCHRONIZATION_UNDEFINEDS", 2, "15Synchronization"),
     ("EXPECTED_FOUNDATION_REGEX_PARSER_UNDEFINEDS", 0, "12_RegexParser"),
 )
+
+_inv_spec = importlib.util.spec_from_file_location(
+    "guest_gate_inventories",
+    ROOT / "full/swiftui/guest_gate_inventories.py",
+)
+inventories = importlib.util.module_from_spec(_inv_spec)
+assert _inv_spec.loader is not None
+_inv_spec.loader.exec_module(inventories)
 
 
 def validate_foundation_runtime_contract(source: str) -> None:
@@ -179,14 +188,17 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("run_link libFoundationEssentials ", text)
         self.assertIn("run_link libWidget ", text)
         self.assertIn("run_link libOnboarding ", text)
-        foundation_expected = text.split("expected_foundation_inputs=", 1)[1].split(
-            "expected_widget_inputs=", 1
-        )[0]
+        self.assertIn(
+            'guest_gate_inventory onboarding inputs foundation', text
+        )
+        foundation_expected = "\n".join(
+            inventories.inputs("onboarding", "foundation", "arm64")
+        )
         for required in (
             "libswift_Concurrency.tbd",
             "libswiftDarwin.tbd",
             "libOpenCoreGraphics.dylib",
-            "$RELATIVE_TIME_RUNTIME",
+            "{RELATIVE_TIME_RUNTIME}",
         ):
             self.assertIn(required, foundation_expected)
         self.assertIn(

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Static regression teeth for the source-unchanged guest proof boundary."""
 
+import importlib.util
 import os
 from pathlib import Path
 import subprocess
@@ -15,6 +16,21 @@ HARNESS = ROOT / "full/swiftui/FocusWidgetGuestMain.swift"
 ATTEST = ROOT / "full/swiftui/focus_widget_guest_attest.pl"
 ADVERSARIAL = ROOT / "full/swiftui/test_focus_widget_guest_adversarial.sh"
 BUILD_FULL = ROOT / "full/scripts/build_full.sh"
+INVENTORIES_PY = ROOT / "full/swiftui/guest_gate_inventories.py"
+INVENTORIES_INC = ROOT / "full/swiftui/guest_gate_inventories.inc"
+GUEST_ARCH_PY = ROOT / "full/scripts/guest_arch.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+inventories = _load_module(INVENTORIES_PY, "guest_gate_inventories")
+guest_arch = _load_module(GUEST_ARCH_PY, "guest_arch")
 
 
 class FocusWidgetGuestProofTests(unittest.TestCase):
@@ -173,23 +189,16 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         self.assertIn("expected_swiftui_inputs", text)
         self.assertIn("expected_symbols_loads", text)
         self.assertIn("expected_guest_loads", text)
-        swiftui_loads = text.split("expected_swiftui_loads=", 1)[1].split(
-            "expected_opencombine_loads=", 1
-        )[0]
-        self.assertIn("@rpath/libFoundationEssentials.dylib", swiftui_loads)
-        # FE's own Darwin/StringProcessing/Synchronization/errno loads stay on
-        # libFoundationEssentials, matching OpenUIKit's existing -lFoundationEssentials
-        # edge. The recursive runtime-closure manifest walks those at runtime.
-        self.assertNotIn("libswiftDarwin.dylib", swiftui_loads)
-        self.assertNotIn("libswift_StringProcessing.dylib", swiftui_loads)
-        self.assertNotIn("libswiftSynchronization.dylib", swiftui_loads)
-        self.assertNotIn("libswift_errno.dylib", swiftui_loads)
-        swiftui_inputs = text.split("expected_swiftui_inputs=", 1)[1].split(
-            "expected_opencombine_inputs=", 1
-        )[0]
-        self.assertIn('"$PACKAGE/libFoundationEssentials.dylib"', swiftui_inputs)
-        self.assertIn("EXPECTED_PACKAGE_FILE_COUNT=101", text)
-        self.assertIn("EXPECTED_PACKAGE_DIRECTORY_COUNT=12", text)
+        self.assertIn('guest_gate_inventory widget loads swiftui', text)
+        self.assertIn('guest_gate_inventory widget inputs swiftui', text)
+        self.assertIn(
+            "EXPECTED_PACKAGE_FILE_COUNT=$(guest_gate_inventory widget package file_count)",
+            text,
+        )
+        self.assertIn(
+            "EXPECTED_PACKAGE_DIRECTORY_COUNT=$(guest_gate_inventory widget package directory_count)",
+            text,
+        )
         self.assertIn('assert_exact_text "package top-level inventory"', text)
         self.assertIn('assert_exact_text "package directory inventory"', text)
         self.assertIn('assert_exact_text "FoundationEssentials module inventory"', text)
@@ -228,11 +237,10 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
 
     def test_openuikit_link_inputs_cover_main_actor_deinit_provider(self) -> None:
         text = BUILD.read_text()
-        expected = text.split("expected_openuikit_inputs=", 1)[1].split(
-            "expected_swiftui_inputs=", 1
-        )[0]
-        self.assertIn('"$MRROOT/darwin/usr/lib/libSystem.B.dylib"', expected)
-        self.assertIn('"$FULL/openuikit.o"', expected)
+        self.assertIn('guest_gate_inventory widget inputs openuikit', text)
+        expected = inventories.inputs("widget", "openuikit", "arm64")
+        self.assertIn("{MRROOT}/darwin/usr/lib/libSystem.B.dylib", expected)
+        self.assertIn("{FULL}/openuikit.o", expected)
 
     def test_swiftui_package_compiles_and_attests_complete_source_directory(self) -> None:
         text = BUILD.read_text()
@@ -354,6 +362,8 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
         self.assertIn("DejaVuSans.ttf", text)
         self.assertIn("DejaVuSans-Bold.ttf", text)
         self.assertIn("support_before=$(support_digest)", text)
+        self.assertIn("guest_gate_inventories.py", text)
+        self.assertIn("guest_gate_inventories.inc", text)
         self.assertIn("runtime_before=$(runtime_fingerprint)", text)
         self.assertIn("runtime_after=$(runtime_fingerprint)", text)
         self.assertIn("BUILD_INPUT_MANIFEST=$FULL/focus-widget-build-inputs.manifest", text)
@@ -374,6 +384,8 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
             "build-full/foundation/os",
             "build-full/foundation/cshims",
             "sdk/sysroot_fe4",
+            "guest_gate_inventories.py",
+            "guest_gate_inventories.inc",
             '"$full/OpenUIKit.$_"',
             '"$full/OpenCoreGraphics.$_"',
             "qw(swiftmodule swiftdoc swiftsourceinfo abi.json)",
@@ -689,6 +701,300 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
                 proc.stdout,
                 r"id=sysroot_fe4 .*scratch/sysroot_fe4(?:/|\s)",
             )
+
+
+# Arm64 hashes of the inventories Gate B asserted at e93727e0 / current main.
+# Changing an arm64 list without updating these pins is a false-green: the
+# operator's arm64 widget gate would then diverge from what this file records.
+_ARM64_WIDGET_LOAD_SHA256 = {
+    "combine": "de782fb75c10a6708b718b419a715b0ed820a27cf643a5148ec277e520895039",
+    "foundationessentials": "4d3801b04b67184a933564c1bcb608884a2b76a40ab0000bd3a4391dc51552e4",
+    "guest": "ef127146815795ff4d28287450c8d3dcf45b7b02d763da1b025c998bb64b5d81",
+    "opencombine": "cb7dd88fea0eee87eb156ebd2a1a2191366a1bcfef4579cc6306764297fc2c36",
+    "opencoregraphics": "8ca2ac9655c5d0e3854addfa8d08e0258a4da34d22d379ab6b4ce0789c8709e8",
+    "openuikit": "9042a6ca8b30f5f7f8c017401449e737d139a86a40239240a8a72219bfbe663f",
+    "swiftui": "f1285a0e3a49dc1aebf1c8753a14f1a51ba39f7323ae2577042c8b7abf4025a5",
+    "symbols": "33355a1f20997221c9fd5a7557f44ff0fcbc8a235fbb5a7b35ea5015aa6984bf",
+}
+_X86_WIDGET_LOAD_SHA256 = {
+    "openuikit": "9ace743214c8f1e735b4c0226167e698f73c6485d0772e7379e7893bb8da49f8",
+    "foundationessentials": "da582aef71d6a72f3fad3128b08d2aa7eff41046193836badd5d0ab3bd5134e5",
+}
+_ARM64_WIDGET_INPUT_SHA256 = {
+    "combine": "2fb8cf23b974cfc6272337e5992a6273ddbcfe8f7b3748b82e3a4868c2fac00e",
+    "foundationessentials": "78afd92924bdac73f65eb37fef87f163f88ff5f9b7e74d1b0fca969fc9d4459e",
+    "guest": "fe87b72e55f03dac218cd9cc6069fdc501eed9814d0870ff6920a4c890bfc1b3",
+    "opencombine": "1759c45b9efb1161ab8fda800dd89285d13aa8393ade080ff1a1fc70fa8b3f7c",
+    "opencoregraphics": "24691bdfddb9f4f2a5e8d3dcab92f0cbce3f935ea661630aba5eddb800e9bd2f",
+    "openuikit": "420fde904d3f834b0448821995abc3596a9845599f290bee04f2aab8d1bf052f",
+    "swiftui": "c3e54e497e1a5a77603407803c0581a6b50443114a77434e5da3a776bec4e608",
+    "symbols": "028d043be0132451b21a39d37dc0e368b3a5299638ba3393df108f79d647531b",
+}
+_ARM64_ONBOARDING_INPUT_SHA256 = {
+    "combine": "2fb8cf23b974cfc6272337e5992a6273ddbcfe8f7b3748b82e3a4868c2fac00e",
+    "foundation": "aeda8311f2404b181030892be67d698cffe1e0444f7e7b14ac37e608b2f5db34",
+    "foundationessentials": "b92946a085dfec9da20d0cfb2d013adedd2823f92718716e399c6eaf132c59b4",
+    "onboarding": "3f9f79428632bbf02dd3be042c9f3aa36bc0a1e41df9e179d0334cc1188248d2",
+    "opencombine": "1759c45b9efb1161ab8fda800dd89285d13aa8393ade080ff1a1fc70fa8b3f7c",
+    "opencoregraphics": "24691bdfddb9f4f2a5e8d3dcab92f0cbce3f935ea661630aba5eddb800e9bd2f",
+    "openuikit": "e69497be0b2108c1292902c44201b3dae932a9722aa76525561f1e942a946280",
+    "swiftui": "c3e54e497e1a5a77603407803c0581a6b50443114a77434e5da3a776bec4e608",
+    "symbols": "028d043be0132451b21a39d37dc0e368b3a5299638ba3393df108f79d647531b",
+    "widget": "37110da55798084f729b85ab7c2f5b3898ad4ac19edfcb43e67bfb0299a3b537",
+}
+_ARM64_PACKAGE_SHA256 = {
+    "names": "f7f24a6f88a070a04f7c2225a991d42379d5bcfe6681541dc87a3864dc035cef",
+    "directories": "6f919ab8362dc40f9cea64edd9b93a1e59aee0be48fdb2622c956392b02406be",
+    "fe_module_files": "f3bdd5f1c2f371c76a19a96bab86c624318d21b8e85d253c805cbe033d9f50cb",
+}
+
+
+class FocusWidgetGuestInventoryTests(unittest.TestCase):
+    """Arch-conditional inventories: arm64 byte-identical, x86 present for every check."""
+
+    def test_gate_scripts_resolve_inventories_from_one_place(self) -> None:
+        widget = BUILD.read_text()
+        onboarding = (
+            ROOT / "full/swiftui/build_focus_onboarding_guest.sh"
+        ).read_text()
+        self.assertIn("guest_gate_inventories.inc", widget)
+        self.assertIn("guest_gate_inventories.inc", onboarding)
+        self.assertIn("guest_gate_inventory widget loads", widget)
+        self.assertIn("guest_gate_inventory widget inputs", widget)
+        self.assertIn("guest_gate_inventory widget package", widget)
+        self.assertIn("guest_gate_inventory onboarding inputs", onboarding)
+        self.assertNotIn("libswift_errno.dylib", widget)
+        self.assertNotIn("/usr/lib/swift/libswift_DarwinFoundation1.dylib", widget)
+        self.assertIn("MH_MAGIC_64[[:space:]]+${OTOOL_CPU}", widget)
+        self.assertIn("MH_MAGIC_64[[:space:]]+${OTOOL_CPU}", onboarding)
+
+    def test_arm64_widget_loads_are_hash_pinned(self) -> None:
+        self.assertEqual(
+            tuple(sorted(_ARM64_WIDGET_LOAD_SHA256)),
+            inventories.check_names("widget", "loads"),
+        )
+        for name, digest in _ARM64_WIDGET_LOAD_SHA256.items():
+            items = inventories.loads("widget", name, "arm64")
+            self.assertEqual(inventories.inventory_sha256(items), digest, name)
+            self.assertEqual(
+                inventories.loads("widget", name, "arm64"),
+                inventories.WIDGET_LOADS_ARM64[name],
+                name,
+            )
+
+    def test_arm64_widget_inputs_are_hash_pinned(self) -> None:
+        self.assertEqual(
+            tuple(sorted(_ARM64_WIDGET_INPUT_SHA256)),
+            inventories.check_names("widget", "inputs"),
+        )
+        for name, digest in _ARM64_WIDGET_INPUT_SHA256.items():
+            items = inventories.inputs("widget", name, "arm64")
+            self.assertEqual(inventories.inventory_sha256(items), digest, name)
+
+    def test_arm64_onboarding_inputs_are_hash_pinned(self) -> None:
+        self.assertEqual(
+            tuple(sorted(_ARM64_ONBOARDING_INPUT_SHA256)),
+            inventories.check_names("onboarding", "inputs"),
+        )
+        for name, digest in _ARM64_ONBOARDING_INPUT_SHA256.items():
+            items = inventories.inputs("onboarding", name, "arm64")
+            self.assertEqual(inventories.inventory_sha256(items), digest, name)
+
+    def test_arm64_package_inventories_are_hash_pinned(self) -> None:
+        self.assertEqual(inventories.WIDGET_PACKAGE_FILE_COUNT, 101)
+        self.assertEqual(inventories.WIDGET_PACKAGE_DIRECTORY_COUNT, 12)
+        self.assertEqual(
+            inventories.package_scalar("file_count", "arm64"), "101"
+        )
+        self.assertEqual(
+            inventories.package_scalar("directory_count", "arm64"), "12"
+        )
+        for name, digest in _ARM64_PACKAGE_SHA256.items():
+            items = inventories.package_items(name, "arm64")
+            self.assertEqual(inventories.inventory_sha256(items), digest, name)
+
+    def test_x86_64_has_every_widget_check(self) -> None:
+        for kind in ("loads", "inputs", "package"):
+            names = inventories.check_names("widget", kind)
+            self.assertTrue(names, kind)
+            for name in names:
+                if kind == "loads":
+                    arm = inventories.loads("widget", name, "arm64")
+                    x86 = inventories.loads("widget", name, "x86_64")
+                elif kind == "inputs":
+                    arm = inventories.inputs("widget", name, "arm64")
+                    x86 = inventories.inputs("widget", name, "x86_64")
+                else:
+                    if name in ("file_count", "directory_count"):
+                        arm = inventories.package_scalar(name, "arm64")
+                        x86 = inventories.package_scalar(name, "x86_64")
+                        self.assertEqual(arm, x86, name)
+                        continue
+                    arm = inventories.package_items(name, "arm64")
+                    x86 = inventories.package_items(name, "x86_64")
+                self.assertEqual(len(x86), len(arm), f"{kind}/{name}")
+                self.assertTrue(x86, f"{kind}/{name} empty")
+        self.assertEqual(
+            inventories.otool_cpu("x86_64"), guest_arch.otool_cpu("x86_64")
+        )
+        self.assertEqual(
+            inventories.otool_cpu("arm64"), guest_arch.otool_cpu("arm64")
+        )
+        self.assertEqual(inventories.otool_cpu("x86_64"), "X86_64")
+        self.assertEqual(inventories.otool_cpu("arm64"), "ARM64")
+
+    def test_x86_64_has_every_onboarding_input_check(self) -> None:
+        for name in inventories.check_names("onboarding", "inputs"):
+            arm = inventories.inputs("onboarding", name, "arm64")
+            x86 = inventories.inputs("onboarding", name, "x86_64")
+            self.assertEqual(x86, arm, name)
+            self.assertEqual(
+                inventories.inventory_sha256(x86),
+                _ARM64_ONBOARDING_INPUT_SHA256[name],
+                name,
+            )
+
+    def test_x86_overlay_autolink_is_darwinfoundation1_not_errno(self) -> None:
+        for name in ("openuikit", "foundationessentials"):
+            arm = inventories.loads("widget", name, "arm64")
+            x86 = inventories.loads("widget", name, "x86_64")
+            self.assertIn(inventories.ARM64_OVERLAY_AUTOLINK, arm)
+            self.assertNotIn(inventories.ARM64_OVERLAY_AUTOLINK, x86)
+            self.assertIn(inventories.X86_OVERLAY_AUTOLINK, x86)
+            self.assertNotIn(inventories.X86_OVERLAY_AUTOLINK, arm)
+            self.assertEqual(
+                inventories.macos_overlay_autolink_loads(arm, "x86_64"), x86
+            )
+            self.assertEqual(
+                inventories.inventory_sha256(x86),
+                _X86_WIDGET_LOAD_SHA256[name],
+                name,
+            )
+        # FE Darwin/StringProcessing/Synchronization/errno stay off libSwiftUI
+        # on both arches; DarwinFoundation1 is the x86 errno stand-in and must
+        # not leak onto SwiftUI either.
+        swiftui_arm = inventories.loads("widget", "swiftui", "arm64")
+        swiftui_x86 = inventories.loads("widget", "swiftui", "x86_64")
+        self.assertEqual(swiftui_arm, swiftui_x86)
+        for forbidden in (
+            "libswiftDarwin.dylib",
+            "libswift_StringProcessing.dylib",
+            "libswiftSynchronization.dylib",
+            "libswift_errno.dylib",
+            "libswift_DarwinFoundation1.dylib",
+        ):
+            self.assertFalse(
+                any(forbidden in item for item in swiftui_arm), forbidden
+            )
+        self.assertIn("@rpath/libFoundationEssentials.dylib", swiftui_arm)
+        swiftui_inputs = inventories.inputs("widget", "swiftui", "arm64")
+        self.assertIn("{PACKAGE}/libFoundationEssentials.dylib", swiftui_inputs)
+
+    def test_cli_emits_printf_compatible_lists(self) -> None:
+        arm = subprocess.check_output(
+            [
+                "python3",
+                str(INVENTORIES_PY),
+                "--arch",
+                "arm64",
+                "--gate",
+                "widget",
+                "--kind",
+                "loads",
+                "--name",
+                "openuikit",
+            ],
+            text=True,
+        )
+        x86 = subprocess.check_output(
+            [
+                "python3",
+                str(INVENTORIES_PY),
+                "--arch",
+                "x86_64",
+                "--gate",
+                "widget",
+                "--kind",
+                "loads",
+                "--name",
+                "openuikit",
+            ],
+            text=True,
+        )
+        self.assertTrue(arm.endswith("libswift_errno.dylib\n"))
+        self.assertTrue(x86.endswith("libswift_DarwinFoundation1.dylib\n"))
+        binds = [
+            "--bind",
+            "PACKAGE=/pkg",
+            "--bind",
+            "SYS=/sys",
+            "--bind",
+            "MRROOT=/mr",
+            "--bind",
+            "FULL=/full",
+            "--bind",
+            "OUT=/out",
+            "--bind",
+            "FE_OUT=/fe",
+            "--bind",
+            "FE_COLLECTIONS=/col",
+            "--bind",
+            "FE_OS=/os",
+            "--bind",
+            "FE_CSHIMS=/cs",
+            "--bind",
+            "OPENCOMBINE_ARTIFACTS=/oc",
+            "--bind",
+            "RELATIVE_TIME_RUNTIME=/rt",
+        ]
+        emitted = subprocess.check_output(
+            [
+                "python3",
+                str(INVENTORIES_PY),
+                "--arch",
+                "arm64",
+                "--gate",
+                "widget",
+                "--kind",
+                "inputs",
+                "--name",
+                "openuikit",
+                *binds,
+            ],
+            text=True,
+        )
+        self.assertIn("/pkg/libFoundationEssentials.dylib\n", emitted)
+        self.assertIn("/full/openuikit.o\n", emitted)
+        self.assertIn("/mr/darwin/usr/lib/libSystem.B.dylib\n", emitted)
+
+    def test_inc_and_python_are_present(self) -> None:
+        self.assertTrue(INVENTORIES_PY.is_file())
+        self.assertTrue(INVENTORIES_INC.is_file())
+        self.assertIn("guest_gate_inventory()", INVENTORIES_INC.read_text())
+
+    def test_bash_helper_emits_arch_conditional_openuikit_loads(self) -> None:
+        script = r"""
+set -euo pipefail
+W=%s
+. "$W/full/scripts/guest_arch.inc"
+. "$W/full/swiftui/guest_gate_inventories.inc"
+ARCH=arm64
+guest_gate_inventory widget loads openuikit
+printf '==SPLIT==\n'
+ARCH=x86_64
+guest_gate_inventory widget loads openuikit
+""" % ROOT
+        result = subprocess.run(
+            ["bash", "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        arm, x86 = result.stdout.split("==SPLIT==\n", 1)
+        self.assertTrue(arm.strip().endswith("libswift_errno.dylib"))
+        self.assertTrue(x86.strip().endswith("libswift_DarwinFoundation1.dylib"))
+        self.assertNotIn("libswift_DarwinFoundation1.dylib", arm)
+        self.assertNotIn("libswift_errno.dylib", x86)
 
 
 if __name__ == "__main__":

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -50,12 +50,16 @@ REMINDER=$ROOT/full/xcodeplan/build_and_run_reminder_scene_guest.sh
 UD_RUNNER=$ROOT/foundation-macho/tests/ud_guest_runner.swift
 PREPARE=$ROOT/scripts/env/prepare.py
 BUILD_FULL=$ROOT/full/scripts/build_full.sh
+INVENTORIES=$ROOT/full/swiftui/guest_gate_inventories.py
+INVENTORIES_INC=$ROOT/full/swiftui/guest_gate_inventories.inc
 
 expect_file "$PHASE2"
 expect_file "$COMMON"
 expect_file "$STAGE"
 expect_file "$OC"
 expect_file "$GUEST"
+expect_file "$INVENTORIES"
+expect_file "$INVENTORIES_INC"
 
 echo "== bash -n"
 for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
@@ -67,6 +71,7 @@ for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
     "$ROOT/scripts/x86/ud_guest.inc" \
     "$ROOT/scripts/x86/gen_swift_tbd.sh" \
     "$ROOT/scripts/x86/test_gen_swift_tbd.sh" \
+    "$ROOT/full/swiftui/guest_gate_inventories.inc" \
     "$ROOT/scripts/build_runtime_shims.sh" \
     "$ROOT/swiftcore-macho/scripts/test_compat_source.sh"; do
     if bash -n "$s"; then
@@ -347,9 +352,12 @@ expect_grep 'NOTE extra Apple-SDK' "$PHASE2" \
 expect_grep 'libquartz.tbd' "$COMMON" "consumer set includes libquartz.tbd"
 expect_grep '[-]lobjc' "$BUILD_FULL" "build_full link names -lobjc"
 expect_grep '[-]lSystem' "$BUILD_FULL" "build_full link names -lSystem"
-expect_grep 'libswift_Concurrency.dylib' "$WIDGET" "widget expected loads name Concurrency"
-expect_grep 'libswiftObjectiveC.dylib' "$WIDGET" "widget expected loads name ObjectiveC"
-expect_grep 'libswiftObservation.dylib' "$WIDGET" "widget expected loads name Observation"
+expect_grep 'libswift_Concurrency.dylib' "$INVENTORIES" "widget expected loads name Concurrency"
+expect_grep 'libswiftObjectiveC.dylib' "$INVENTORIES" "widget expected loads name ObjectiveC"
+expect_grep 'libswiftObservation.dylib' "$INVENTORIES" "widget expected loads name Observation"
+expect_grep 'libswift_DarwinFoundation1.dylib' "$INVENTORIES" \
+    "x86 widget loads name DarwinFoundation1"
+expect_grep 'libswift_errno.dylib' "$INVENTORIES" "arm64 widget loads still name errno"
 expect_grep 'libswiftCore.tbd' "$ROOT/full/swiftui/focus_widget_guest_attest.pl" \
     "widget attest requires named libswiftCore.tbd"
 expect_grep '[-]lswiftCore' "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
@@ -361,13 +369,13 @@ want=$(phase2_consumer_tbd_relpaths)
 derived=$(
     {
         grep -hoE 'libswift[A-Za-z0-9_]+\.tbd' \
-            "$BUILD_FULL" "$WIDGET" "$ONBOARD" "$ATTEST" "$LINK_UD" 2>/dev/null \
+            "$BUILD_FULL" "$WIDGET" "$ONBOARD" "$ATTEST" "$LINK_UD" "$INVENTORIES" 2>/dev/null \
             | sed 's|^|usr/lib/swift/|'
         grep -hoE 'lib(System(\.B)?|objc(\.A)?|c\+\+(\.1)?|c\+\+abi|quartz)\.tbd' \
-            "$BUILD_FULL" "$WIDGET" "$ONBOARD" "$ATTEST" "$LINK_UD" 2>/dev/null \
+            "$BUILD_FULL" "$WIDGET" "$ONBOARD" "$ATTEST" "$LINK_UD" "$INVENTORIES" 2>/dev/null \
             | sed 's|^|usr/lib/|'
         grep -hoE -- '-l(swift[A-Za-z0-9_]+|objc|System)' \
-            "$BUILD_FULL" "$WIDGET" "$ONBOARD" "$ATTEST" "$LINK_UD" 2>/dev/null \
+            "$BUILD_FULL" "$WIDGET" "$ONBOARD" "$ATTEST" "$LINK_UD" "$INVENTORIES" 2>/dev/null \
             | while IFS= read -r flag; do
                 name=${flag#-l}
                 case "$name" in
@@ -377,7 +385,7 @@ derived=$(
                 esac
             done
         grep -hoE '/usr/lib/swift/libswift[A-Za-z0-9_]+\.dylib' \
-            "$WIDGET" "$ONBOARD" "$LINK_UD" 2>/dev/null \
+            "$WIDGET" "$ONBOARD" "$LINK_UD" "$INVENTORIES" 2>/dev/null \
             | sed 's|^/||; s/\.dylib$/.tbd/'
     } | grep -E '^usr/lib/' | sort -u
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Phase 2 on the x86_64 EC2 box now reaches the widget gate (env-prepare 38/38) and exits 2 on an inventory diff of expected dylib **LOADS**:

```
    /usr/lib/libquartz.dylib
    /usr/lib/swift/libswift_Concurrency.dylib
    /usr/lib/swift/libswiftObjectiveC.dylib
   -/usr/lib/swift/libswift_errno.dylib
   +/usr/lib/swift/libswift_DarwinFoundation1.dylib
```

PR #23 made env-prepare arch-parametric (`FULL_OUT_SUFFIX`); the `expected_*_loads` / `expected_*_inputs` / package file lists were still literal arm64 inventories. On arm64 the Swift overlays come from the iOS simulator runtime; on x86_64 they come from Apple’s macOS dyld shared cache (`scratch/apple-x86-overlays`). `libswift_errno` there re-exports `_DarwinFoundation1`, and the toolchain autolink/`-l` choice follows the re-export target.

## What

One source: `full/swiftui/guest_gate_inventories.py` (bash wrapper `guest_gate_inventories.inc`).

- **arm64** lists are the historical literals (hash-pinned in `test_focus_widget_guest.py`). Gate B on the authority must keep passing.
- **x86_64 loads** apply the operator-evidenced overlay autolink swap (`libswift_errno.dylib` → `libswift_DarwinFoundation1.dylib`) on the two inventories that named errno (`openuikit`, `foundationessentials`). Other load lists are unchanged.
- **inputs / package lists** are arch-keyed from the same module; x86_64 currently matches arm64 (no errno.tbd in the arm64 maps). otool CPU stays `guest_arch.inc` (`ARM64` / `X86_64`).
- Widget `support_digest` + `focus_widget_guest_attest.pl` inventory now include the new files (changing lists is a real input, not a silent skip).
- Onboarding `expected_*_inputs` go through the same helper (arm64 byte-identical).

`uikit/`, `machorun/`, and `swiftcore-macho/` are untouched.

## Operator dumps (if a later inventory still diffs)

Widget (`FULL_OUT_SUFFIX=-x86_64`):

```
build/swiftui-guest-x86_64/package/libOpenUIKit.dylib          # otool -L
build/swiftui-guest-x86_64/audit/libOpenUIKit.link-map
build/swiftui-guest-x86_64/audit/libFoundationEssentials.link-map
build/swiftui-guest-x86_64/audit/*.link-map
```

Onboarding:

```
build/focus-onboarding-guest-x86_64/audit/*.link-map
```

## Operator reruns

**arm64 (must stay PASS)** — same invocation as Gate B at e93727e0:

```bash
full/swiftui/build_focus_widget_guest.sh
```

**x86** — same phase-2 command; expected: rung b past the loads inventory to the next `==` step (or PASS):

```bash
bash x86_stage_inputs_phase2.sh
```

(`FULL_OUT_SUFFIX=-x86_64`; widget log `scratch/phase2-rung-b-widget.log`.)

## Tests (this VM)

```
python3 full/swiftui/test_focus_widget_guest.py     # 35 OK
python3 full/swiftui/test_focus_onboarding_guest.py # 23 OK
```

`bash scripts/x86/test_phase2.sh` inventory greps pass (Concurrency/ObjectiveC/Observation/DarwinFoundation1/errno; consumer tbd subset). Remaining phase2 fails are the pre-existing missing x86 sysroot / gen_tbd environment, not these lists.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f54965d2-26e6-4885-a911-9b5240801de1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f54965d2-26e6-4885-a911-9b5240801de1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

