### PR TITLE
x86: capture link_ud_guest log and fix the Darwin link argv

### DIFF
--- a/foundation-macho/scripts/link_ud_guest.sh
+++ b/foundation-macho/scripts/link_ud_guest.sh
@@ -40,6 +40,18 @@ W=${W:-/work}
 SDK=${SDK:-$W/fe/sysroot}
 LLD=${LLD_BIN:-/usr/lib/llvm-18/bin}
 OUT=${OUT:-$W/bin/ud_guest}
+# Swift's /usr/bin/clang is clang-17; its bundled lld refuses macOS. Distro
+# clang-18 + ld64.lld-18 is the Darwin driver this tree measures (same as
+# build_cftest_harness.sh / machorun guest_arch.inc DARWIN_CLANG).
+CC=${CC:-}
+if [ -z "$CC" ]; then
+    if command -v clang-18 >/dev/null 2>&1; then CC=clang-18
+    elif command -v clang >/dev/null 2>&1; then CC=clang
+    else
+        echo "link_ud_guest: no clang-18/clang" >&2
+        exit 2
+    fi
+fi
 
 OBJS=(
   "${RUNNER:-$W/fe/runner.o}"
@@ -47,16 +59,21 @@ OBJS=(
   "$W/fe/module/FoundationEssentials.o"
   "$W/fe/collections/OrderedCollections.o"
   "$W/fe/collections/InternalCollectionsUtilities.o"
-  "$W/fe/collections/_RopeModule.o"
-  "$W/fe/_RopeModule.o"
   "$W/fe/os/os.o"
   "$W/fe/cshims/platform_shims.o"
   "$W/fe/cshims/string_shims.o"
   "$W/fe/cshims/uuid.o"
   "$W/fe/fm_unimplemented.o"
 )
-# The optional entry above keeps the list honest if the tree is rearranged;
-# drop anything that is not there rather than failing on a path that moved.
+# collections/_RopeModule.o is the #87 staged path. fe/_RopeModule.o is a
+# fallback when collections/ was not staged. Never both: they are the same
+# object and ld64 reports duplicate symbols for every Rope export.
+if [ -f "$W/fe/collections/_RopeModule.o" ]; then
+    OBJS+=("$W/fe/collections/_RopeModule.o")
+elif [ -f "$W/fe/_RopeModule.o" ]; then
+    OBJS+=("$W/fe/_RopeModule.o")
+fi
+# Drop anything that is not there rather than failing on a path that moved.
 INPUTS=()
 for o in "${OBJS[@]}"; do [ -f "$o" ] && INPUTS+=("$o"); done
 
@@ -96,10 +113,12 @@ for o in "${INPUTS[@]}"; do
         "$(date -r "$o" -u '+%H:%M:%S')"
 done
 
-echo "==> linking $OUT"
+echo "==> linking $OUT CC=$CC"
 mkdir -p "$(dirname "$OUT")"
-clang -target $TRIPLE -isysroot "$SDK" \
-  -fuse-ld=lld -B "$LLD" \
+# -nostdlib: Linux-hosted Darwin links must not pull host crt. Same as
+# run_bundle_guest.sh / run_tests.sh. clang-18 still passes -syslibroot.
+"$CC" -target "$TRIPLE" -isysroot "$SDK" \
+  -fuse-ld=lld -B "$LLD" -nostdlib \
   "${LIBDIRS[@]}" \
   -Wl,-rpath,/usr/lib/swift -Wl,-rpath,@loader_path \
   "${INPUTS[@]}" "${DYLIBS[@]}" \

--- a/foundation-macho/scripts/test_link_ud_guest.sh
+++ b/foundation-macho/scripts/test_link_ud_guest.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Teeth for scripts/link_ud_guest.sh: clang-18, -nostdlib, one _RopeModule.o,
+# and a dummy x86 link that would duplicate-symbol if both rope copies were
+# on the line.
+#
+#   bash foundation-macho/scripts/test_link_ud_guest.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+FM=$(cd "$HERE/.." && pwd)
+ROOT=$(cd "$FM/.." && pwd)
+S=$HERE/link_ud_guest.sh
+pass=0
+fail=0
+
+ok() { echo "PASS: $*"; pass=$((pass + 1)); }
+die_test() { echo "FAIL: $*" >&2; fail=$((fail + 1)); }
+
+expect_grep() {
+    local needle=$1 hay=$2 label=$3
+    if printf '%s\n' "$hay" | grep -q -- "$needle"; then
+        ok "$label"
+    else
+        die_test "$label (missing: $needle)"
+    fi
+}
+
+echo "== bash -n"
+if bash -n "$S"; then
+    ok "bash -n link_ud_guest.sh"
+else
+    die_test "bash -n link_ud_guest.sh"
+fi
+
+script=$(cat "$S")
+expect_grep 'clang-18' "$script" "prefers clang-18 over Swift clang-17"
+expect_grep '-nostdlib' "$script" "Linux-hosted Darwin link is -nostdlib"
+expect_grep 'collections/_RopeModule.o' "$script" "prefers staged collections/_RopeModule.o"
+expect_grep 'Never both' "$script" "refuses to link both rope copies"
+
+echo "== dummy x86 link: both rope copies present, only one on the line"
+W=$(mktemp -d /tmp/link-ud-guest.XXXXXX)
+cleanup() { rm -rf "$W"; }
+trap cleanup EXIT
+
+mkdir -p "$W/fe/module" "$W/fe/collections" "$W/fe/os" "$W/fe/cshims" \
+    "$W/fe/sysroot/usr/lib/swift" "$W/lib" "$W/bin"
+SDK=$W/fe/sysroot
+TRIPLE=x86_64-apple-macos13.0
+
+cc_obj() {
+    local dest=$1 src=$2
+    echo "$src" | clang-18 -target "$TRIPLE" -c -o "$dest" -x c -
+}
+
+cc_obj "$W/fe/runner.o" 'int main(void){return 0;}'
+cc_obj "$W/fe/UserDefaultsGuest.o" 'int ud_guest_port=1;'
+cc_obj "$W/fe/module/FoundationEssentials.o" 'int fe_essentials=1;'
+cc_obj "$W/fe/collections/OrderedCollections.o" 'int fe_ordered=1;'
+cc_obj "$W/fe/collections/InternalCollectionsUtilities.o" 'int fe_icu=1;'
+# Same defined symbol in both copies — linking both is duplicate _rope_dup.
+cc_obj "$W/fe/collections/_RopeModule.o" 'int rope_dup=1;'
+cp -a "$W/fe/collections/_RopeModule.o" "$W/fe/_RopeModule.o"
+cc_obj "$W/fe/os/os.o" 'int fe_os=1;'
+cc_obj "$W/fe/cshims/platform_shims.o" 'int fe_plat=1;'
+cc_obj "$W/fe/cshims/string_shims.o" 'int fe_str=1;'
+cc_obj "$W/fe/cshims/uuid.o" 'int fe_uuid=1;'
+cc_obj "$W/fe/fm_unimplemented.o" 'int fe_fm=1;'
+
+emit_tbd() {
+    local dest=$1 install=$2
+    mkdir -p "$(dirname "$dest")"
+    cat >"$dest" <<EOF
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos ]
+install-name:    '$install'
+current-version: 1
+compatibility-version: 1
+exports:
+  - targets:   [ x86_64-macos ]
+    symbols:   [
+                  '_dummy_tbd',
+               ]
+...
+EOF
+}
+
+emit_tbd "$SDK/usr/lib/libSystem.B.tbd" "/usr/lib/libSystem.B.dylib"
+ln -sfn libSystem.B.tbd "$SDK/usr/lib/libSystem.tbd"
+emit_tbd "$SDK/usr/lib/libobjc.A.tbd" "/usr/lib/libobjc.A.dylib"
+ln -sfn libobjc.A.tbd "$SDK/usr/lib/libobjc.tbd"
+for n in libswiftCore libswiftDarwin libswift_StringProcessing \
+    libswiftSynchronization libswift_errno; do
+    emit_tbd "$SDK/usr/lib/swift/$n.tbd" "/usr/lib/swift/$n.dylib"
+done
+
+echo 'int cftest=1;' | clang-18 -target "$TRIPLE" -c -o "$W/cftest.o" -x c -
+clang-18 -target "$TRIPLE" -isysroot "$SDK" -fuse-ld=lld -B /usr/lib/llvm-18/bin \
+    -nostdlib -dynamiclib -install_name /usr/lib/libCFTest.dylib \
+    "$W/cftest.o" -o "$W/lib/libCFTest.dylib"
+cp -a "$W/lib/libCFTest.dylib" "$W/lib/libswiftcompat.dylib"
+
+log=$W/link_ud_guest.log
+set +e
+W="$W" SDK="$SDK" OUT="$W/bin/ud_guest" LLD_BIN=/usr/lib/llvm-18/bin \
+    bash "$S" >"$log" 2>&1
+st=$?
+set -e
+echo "$log:"
+cat "$log"
+
+rope_n=$(grep -c '_RopeModule.o' "$log" || true)
+if [ "$rope_n" -eq 1 ] && grep -q 'collections/_RopeModule.o' "$log" \
+    && ! grep -qE '[[:space:]]fe/_RopeModule\.o' "$log"; then
+    ok "inputs list collections/_RopeModule.o once (not the flat duplicate)"
+else
+    die_test "rope inputs: count=$rope_n (want 1 collections/). log=$(tr '\n' ' ' < "$log")"
+fi
+if grep -q 'duplicate symbol' "$log"; then
+    die_test "ld64 still reports duplicate symbol (both rope copies on the line)"
+else
+    ok "no duplicate-symbol diagnostic"
+fi
+if grep -q 'CC=clang-18' "$log"; then
+    ok "link log names CC=clang-18"
+else
+    die_test "link log missing CC=clang-18"
+fi
+if [ "$st" -eq 0 ] && [ -f "$W/bin/ud_guest" ] \
+    && llvm-otool-18 -hv "$W/bin/ud_guest" | grep -Eq 'MH_MAGIC_64[[:space:]]+X86_64'; then
+    ok "dummy ud_guest is MH_MAGIC_64 X86_64"
+else
+    die_test "dummy link exit $st (want 0 + X86_64 Mach-O). log=$(tr '\n' ' ' < "$log")"
+fi
+
+echo "test_link_ud_guest: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -240,7 +240,12 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    (runner: `fe/runner.swiftc.log`); the CANNOT line names `log=` that path
    instead of inlining swiftc text. Link is **only**
    `foundation-macho/scripts/link_ud_guest.sh` (macos13 `TRIPLE`, tbd-first
-   `-L` order). `fm_unimplemented.o` is compiled once into essentials/ with
+   `-L` order, clang-18, `-nostdlib`). stdout+stderr land in
+   `scratch/ud-guest-x86_64/link_ud_guest.log`; a failed link is
+   `CANNOT_UD_GUEST_UD_GUEST file=ud_guest` naming `log=` that path (same
+   spill as the swiftc logs — do not flatten ld64 onto the CANNOT line).
+   `collections/_RopeModule.o` and `fe/_RopeModule.o` are the same object;
+   the linker takes one, never both. `fm_unimplemented.o` is compiled once into essentials/ with
    `build_full.sh`'s clang argv. `libswiftcompat.dylib` comes from an existing
    x86 Mach-O or `swiftcore-macho/scripts/build_compat.sh`. `libCFTest.dylib`
    comes from `foundation-macho/scripts/build_cfobjc.sh` (objects under

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -69,6 +69,8 @@ for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
     "$ROOT/full/relativetime/build_host_helper.sh" \
     "$ROOT/full/foundationinternationalization/build_host_helper.sh" \
     "$ROOT/scripts/x86/ud_guest.inc" \
+    "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
+    "$ROOT/foundation-macho/scripts/test_link_ud_guest.sh" \
     "$ROOT/scripts/x86/gen_swift_tbd.sh" \
     "$ROOT/scripts/x86/test_gen_swift_tbd.sh" \
     "$ROOT/full/swiftui/guest_gate_inventories.inc" \
@@ -1485,6 +1487,15 @@ expect_grep 'foundation-macho/scripts/link_ud_guest.sh' "$UDINC" \
     "producer names the committed linker"
 expect_grep 'foundation-macho/scripts/link_ud_guest.sh' "$PHASE2" \
     "phase2 still names the committed linker"
+expect_grep 'link_ud_guest.log' "$UDINC" "ud-guest spills the linker log to the work-tree root"
+expect_grep 'link_ud_guest.sh exit $st log=$log' "$UDINC" \
+    "UD_GUEST CANNOT names log= (does not flatten ld64)"
+expect_grep 'Never both' "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
+    "linker takes one _RopeModule.o, never both copies"
+expect_grep 'clang-18' "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
+    "link_ud_guest prefers clang-18"
+expect_grep '-nostdlib' "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
+    "link_ud_guest is -nostdlib"
 if grep -E '^[^#]*build_fe\.sh' "$UDINC" >/dev/null; then
     die_test "ud-guest-x86 invokes build_fe.sh"
 else
@@ -1714,6 +1725,30 @@ if CFOBJC_SKIP_COMPILE=1 bash "$ROOT/foundation-macho/scripts/test_build_cfobjc.
     ok "test_build_cfobjc.sh (argv + missing-CF)"
 else
     die_test "test_build_cfobjc.sh"
+fi
+
+echo "== link_ud_guest.sh clang-18, one rope, dummy X86_64 binary"
+if bash "$ROOT/foundation-macho/scripts/test_link_ud_guest.sh"; then
+    ok "test_link_ud_guest.sh"
+else
+    die_test "test_link_ud_guest.sh"
+fi
+
+echo "== ud-guest-x86 linker log is a file path, not flattened ld64"
+mkdir -p "$wt/bin"
+link_report=$(phase2_ud_guest_link "$ROOT" "$wt" "${SYS:-$wt/fe/sysroot}" \
+    "$wt/bin/ud_guest" || true)
+if echo "$link_report" | grep -q 'CANNOT_UD_GUEST_UD_GUEST file=ud_guest' \
+    && echo "$link_report" | grep -q "log=$wt/link_ud_guest.log" \
+    && [ -f "$wt/link_ud_guest.log" ] \
+    && grep -q . "$wt/link_ud_guest.log"; then
+    if echo "$link_report" | grep -q 'ld64.lld'; then
+        die_test "CANNOT line still inlines ld64 output: $link_report"
+    else
+        ok "UD_GUEST CANNOT names log= under scratch/ud-guest-x86_64"
+    fi
+else
+    die_test "link log-spill got: $link_report"
 fi
 
 echo "== ud-guest-x86 compiler log is a file path, not inlined swiftc text"

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -145,7 +145,8 @@ phase2_ud_guest_stage_fe() {
         "$fe_out/collections/_RopeModule.swiftmodule" \
         "$ud_w/fe/collections/_RopeModule.swiftmodule" \
         _RopeModule.swiftmodule ROPEMODULE 0 || return 1
-    # link_ud_guest.sh also looks at $W/fe/_RopeModule.o (optional duplicate).
+    # Fallback path for link_ud_guest.sh when collections/ is absent.
+    # The linker takes collections/_RopeModule.o XOR this file, never both.
     phase2_ud_guest_stage_file \
         "$fe_out/collections/_RopeModule.o" \
         "$ud_w/fe/_RopeModule.o" \
@@ -580,25 +581,29 @@ phase2_ud_guest_ensure_cftest() {
 phase2_ud_guest_link() {
     local repo=$1 ud_w=$2 sys=$3 out=$4
     local linker=$repo/$PHASE2_UD_GUEST_LINKER
-    local log=$ud_w/bin/ud_guest.link.log
+    local log=$ud_w/link_ud_guest.log
     local st
     if [ ! -f "$linker" ]; then
         phase2_ud_guest_cannot UD_GUEST ud_guest "missing committed linker $linker"
         return 1
     fi
-    mkdir -p "$(dirname "$out")"
+    mkdir -p "$(dirname "$out")" "$ud_w"
     set +e
     W="$ud_w" SDK="$sys" OUT="$out" LLD_BIN=/usr/lib/llvm-18/bin \
         bash "$linker" >"$log" 2>&1
     st=$?
     set -e
     if [ "$st" -ne 0 ] || [ ! -f "$out" ]; then
+        # Spill to the work-tree root (same rule as the swiftc logs). Do not
+        # flatten ld64 text onto the CANNOT line — the inputs listing alone
+        # buries the diagnostic.
         phase2_ud_guest_cannot UD_GUEST ud_guest \
-            "link_ud_guest.sh exit $st $(phase2_flatten < "$log")"
+            "link_ud_guest.sh exit $st log=$log"
         return 1
     fi
     if ! phase2_is_x86_macho "$out"; then
-        phase2_ud_guest_cannot UD_GUEST ud_guest "linked file is not X86_64 Mach-O: $out"
+        phase2_ud_guest_cannot UD_GUEST ud_guest \
+            "linked file is not X86_64 Mach-O: $out log=$log"
         return 1
     fi
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Operator rerun after PR #53: CF fetched and `libCFTest.dylib` linked, but the final `ud_guest` link failed with no ld64 text anywhere. `phase2_ud_guest_link` flattened `link_ud_guest.sh` stdout onto the CANNOT line; the `== inputs` listing (12 objects) ate the line, so `phase2f.log` never showed the diagnostic, and the log lived under `bin/ud_guest.link.log` rather than next to the other work-tree logs.

## (1) Spill the linker log

`scratch/ud-guest-x86_64/link_ud_guest.log` gets stdout+stderr. `CANNOT_UD_GUEST_UD_GUEST file=ud_guest` names `log=` that path (same rule as the swiftc logs). It does not flatten ld64 onto the CANNOT line.

Measured: `CANNOT_UD_GUEST_UD_GUEST file=ud_guest link_ud_guest.sh exit 1 log=…/link_ud_guest.log` — clang/ld64 lines are only in that file.

## (2) Why the link died

`phase2_ud_guest_stage_fe` always stages **both** `fe/collections/_RopeModule.o` and `fe/_RopeModule.o` (same object). `link_ud_guest.sh` put every existing path on the line, so ld64 sees every Rope export twice.

The script also invoked bare `clang` (`/usr/bin/clang` → Swift clang-17). This tree’s Darwin links are **clang-18 + ld64.lld-18** (`build_cftest_harness.sh`, `machorun` `DARWIN_CLANG`). Guest executables use `-nostdlib` so the Linux driver does not pull host crt.

Fixes, still the same committed linker:

- Prefer `clang-18`
- `-nostdlib`
- Take `collections/_RopeModule.o` **xor** `fe/_RopeModule.o`, never both

Dummy x86 fixture (both rope copies on disk, same `_rope_dup`): inputs list one rope, no `duplicate symbol`, `MH_MAGIC_64 X86_64` binary with the expected `-l` loads (`test_link_ud_guest.sh` 9/9).

## Operator command (x86_64 box)

```bash
bash x86_stage_inputs_phase2.sh
```

Expected: `ENV_PREPARE ud-guest-x86 cold-built bin=…/scratch/ud-guest-x86_64/bin/ud_guest` plus `bin/ud_guest.otool.txt`. If the link still fails, the CANNOT line names `log=scratch/ud-guest-x86_64/link_ud_guest.log` with the ld64 lines.

Rung a smoke 14/14, or the first runtime wall: Apple cache-layout overlays copy-map but lack fixup info until from-source overlays land.

## Tests

- `bash foundation-macho/scripts/test_link_ud_guest.sh` — 9/9
- `bash scripts/x86/test_phase2.sh` — new log= / rope / clang-18 teeth pass. Pre-existing `fail=8` on this VM is missing x86 sysroot / libobjc.tbd / mrroot, not this link.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cede442a-3f9a-443b-aa2b-f42bcba0da41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cede442a-3f9a-443b-aa2b-f42bcba0da41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

