### PR TITLE
Resolve focus-widget contract pins through guest_gate_inventories

### DIFF
--- a/scripts/env/contract.py
+++ b/scripts/env/contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import re
 from pathlib import Path
@@ -84,6 +85,85 @@ def _perl_spec(text: str, key: str, field: str) -> str:
     if not match:
         raise ContractError(f"pinned_inputs.pl {key} is missing {field}")
     return match.group(1)
+
+
+# env/contract.json hosts.ec2-aarch64.role is execution-authority (arch
+# aarch64/arm64); proof_split.execution is arm64-ec2-authority. Attestation
+# pin values are that host's, even when this process is running on x86_64.
+FOCUS_WIDGET_ATTESTATION_ARCH = "arm64"
+
+
+def load_guest_gate_inventories(root: Path) -> Any:
+    relative = "full/swiftui/guest_gate_inventories.py"
+    path = root / relative
+    if not path.is_file() or path.is_symlink():
+        raise ContractError(f"lock is missing or a symlink: {relative}")
+    spec = importlib.util.spec_from_file_location("guest_gate_inventories", path)
+    if spec is None or spec.loader is None:
+        raise ContractError(f"cannot load {relative}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _inventory_assignment(gate: str, key: str) -> tuple[str, str] | None:
+    """Parse `KEY=$(guest_gate_inventory widget <kind> <field>)` from the gate."""
+    match = re.search(
+        rf"^{re.escape(key)}=\$\(guest_gate_inventory widget (\S+) (\S+)\)\s*$",
+        gate,
+        re.MULTILINE,
+    )
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _resolve_widget_inventory(
+    inventories: Any, kind: str, field: str, *, arch: str = FOCUS_WIDGET_ATTESTATION_ARCH
+) -> str:
+    try:
+        raw = inventories.emit(arch, "widget", kind, field, {})
+    except (KeyError, ValueError) as exc:
+        raise ContractError(
+            f"guest_gate_inventories {arch} widget {kind} {field} is not resolvable"
+        ) from exc
+    return str(raw).rstrip("\n")
+
+
+def check_focus_widget_attestation_pins(
+    pins: dict[str, Any],
+    gate: str,
+    inventories: Any,
+) -> tuple[int, int]:
+    """Return (literal_count, inventory_count). Raise ContractError on drift.
+
+    A pin agrees if the gate still contains the literal `KEY=VALUE`, or if it
+    assigns `KEY=$(guest_gate_inventory widget <kind> <field>)` and that lookup
+    resolves on the attestation arch to exactly VALUE.
+    """
+    literal_n = 0
+    inventory_n = 0
+    for key, value in pins.items():
+        if key == "notes":
+            continue
+        token = f"{key}={value}"
+        if token in gate:
+            literal_n += 1
+            continue
+        assignment = _inventory_assignment(gate, key)
+        if assignment is not None:
+            kind, field = assignment
+            try:
+                resolved = _resolve_widget_inventory(inventories, kind, field)
+            except ContractError as exc:
+                raise ContractError(
+                    f"focus-widget pin {token} is missing from the gate"
+                ) from exc
+            if resolved == str(value):
+                inventory_n += 1
+                continue
+        raise ContractError(f"focus-widget pin {token} is missing from the gate")
+    return literal_n, inventory_n
 
 
 def validate_against_locks(root: Path | None = None) -> list[str]:
@@ -179,17 +259,15 @@ def validate_against_locks(root: Path | None = None) -> list[str]:
 
     widget = contract["focus_widget_attestation_pins"]
     gate = _read(root, "full/swiftui/build_focus_widget_guest.sh")
-    compared = 0
-    for key, value in widget.items():
-        if key == "notes":
-            continue
-        token = f"{key}={value}"
-        if token not in gate:
-            raise ContractError(f"focus-widget pin {token} is missing from the gate")
-        compared += 1
+    inventories = load_guest_gate_inventories(root)
+    literal_n, inventory_n = check_focus_widget_attestation_pins(
+        widget, gate, inventories
+    )
+    compared = literal_n + inventory_n
     notes.append(
-        f"focus_widget_attestation_pins {compared}/{compared} agree with "
-        "full/swiftui/build_focus_widget_guest.sh"
+        f"focus_widget_attestation_pins {compared}/{compared} agree "
+        f"({literal_n} literal, {inventory_n} via guest_gate_inventories "
+        f"{FOCUS_WIDGET_ATTESTATION_ARCH})"
     )
 
     every_row = 0

--- a/scripts/env/test_contract.py
+++ b/scripts/env/test_contract.py
@@ -11,7 +11,15 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from env.contract import checkouts_by_id, demanded_by, load_contract, validate_against_locks
+from env.contract import (
+    ContractError,
+    check_focus_widget_attestation_pins,
+    checkouts_by_id,
+    demanded_by,
+    load_contract,
+    load_guest_gate_inventories,
+    validate_against_locks,
+)
 from env.markers import (
     CANNOT_PREFIX,
     MARKERS,
@@ -88,8 +96,41 @@ class ContractLockTests(unittest.TestCase):
         notes = validate_against_locks(ROOT)
         pin_notes = [n for n in notes if n.startswith("focus_widget_attestation_pins ")]
         self.assertEqual(len(pin_notes), 1)
-        self.assertIn("25/25", pin_notes[0])
+        self.assertEqual(
+            pin_notes[0],
+            "focus_widget_attestation_pins 25/25 agree "
+            "(23 literal, 2 via guest_gate_inventories arm64)",
+        )
         print(pin_notes[0])
+
+    def test_inventory_lookup_pin_resolves_and_agrees(self) -> None:
+        inventories = load_guest_gate_inventories(ROOT)
+        gate = (
+            "EXPECTED_PACKAGE_FILE_COUNT="
+            "$(guest_gate_inventory widget package file_count)\n"
+        )
+        literal_n, inventory_n = check_focus_widget_attestation_pins(
+            {"EXPECTED_PACKAGE_FILE_COUNT": 101},
+            gate,
+            inventories,
+        )
+        self.assertEqual((literal_n, inventory_n), (0, 1))
+
+    def test_changed_inventory_value_fails_naming_the_key(self) -> None:
+        inventories = load_guest_gate_inventories(ROOT)
+        original = inventories.WIDGET_PACKAGE_FILE_COUNT
+        gate = (
+            "EXPECTED_PACKAGE_FILE_COUNT="
+            "$(guest_gate_inventory widget package file_count)\n"
+        )
+        pins = {"EXPECTED_PACKAGE_FILE_COUNT": 101}
+        inventories.WIDGET_PACKAGE_FILE_COUNT = original + 1
+        try:
+            with self.assertRaises(ContractError) as ctx:
+                check_focus_widget_attestation_pins(pins, gate, inventories)
+        finally:
+            inventories.WIDGET_PACKAGE_FILE_COUNT = original
+        self.assertIn("EXPECTED_PACKAGE_FILE_COUNT", str(ctx.exception))
 
 
 class MarkerRegistryTests(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Broken on main

`python3 scripts/env/test_contract.py` has failed on main since PR #54 (`c1d7f342` "Make widget/onboarding gate inventories resolve per ARCH"):

```
env.contract.ContractError: focus-widget pin EXPECTED_PACKAGE_FILE_COUNT=101 is missing from the gate
FAILED (errors=2)
```

`scripts/env/contract.py` `validate_against_locks` required the literal `KEY=VALUE` text in `full/swiftui/build_focus_widget_guest.sh`. PR #54 replaced two of those literals with lookups:

```
EXPECTED_PACKAGE_FILE_COUNT=$(guest_gate_inventory widget package file_count)
EXPECTED_PACKAGE_DIRECTORY_COUNT=$(guest_gate_inventory widget package directory_count)
```

so the lock no longer saw them. This test is on the pin-advance path (`scripts/test_vendor_tree.sh` + `python3 scripts/env/test_contract.py`) and was blocking PR #55.

## Resolution rule

For every pin in `focus_widget_attestation_pins` (skipping `notes`):

1. The gate still contains the literal `KEY=VALUE` (unchanged behaviour), **or**
2. The gate assigns `KEY=$(guest_gate_inventory widget <kind> <field>)` — kind and field are parsed from that assignment, not hard-coded — and `full/swiftui/guest_gate_inventories.py` resolves that lookup for **arm64** to exactly `VALUE`.

Arm64 is the authority: `env/contract.json` `hosts.ec2-aarch64.role` is `execution-authority` and `proof_split.execution` is `arm64-ec2-authority`. A pin that is neither literal nor resolvable still raises `ContractError` naming the key.

No pin VALUE in `env/contract.json` was changed. The two inventory pins still resolve to `101` and `12`. `machorun/` and `uikit/` are untouched.

## Notes line

Before (main, unreachable because the lock raised):

```
focus_widget_attestation_pins 25/25 agree with full/swiftui/build_focus_widget_guest.sh
```

After:

```
focus_widget_attestation_pins 25/25 agree (23 literal, 2 via guest_gate_inventories arm64)
```

## Tests (this VM)

```
python3 scripts/env/test_contract.py            # 10 tests OK (8 existing + 2 new)
bash scripts/test_vendor_tree.sh                # already passing: 5/5
python3 full/swiftui/test_focus_widget_guest.py  # 35 tests OK (unchanged)
```

New contract tests: a `$(guest_gate_inventory …)` pin that resolves correctly passes; monkeypatching `WIDGET_PACKAGE_FILE_COUNT` fails with `EXPECTED_PACKAGE_FILE_COUNT` in the `ContractError`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d45e7e9-7bc7-42b3-a945-83110171a9eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d45e7e9-7bc7-42b3-a945-83110171a9eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

