### PR TITLE
Stage x86_64 libCFTest and refuse dyld-cache overlay extracts

### DIFF
--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -259,6 +259,14 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    `Sources/CoreFoundation`. A failed fetch/compile/link is
    `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib`. Will not invent a stub
    dylib. `UD_CFTEST_DYLIB=` still stages a provided x86 dylib.
+   After a successful link, before `run_ud_guest.sh`, phase2 copies
+   `scratch/ud-guest-x86_64/lib/libCFTest.dylib` into
+   `scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib` (the arm64
+   analogue is `build_cftest_harness.sh` copying into `$W/root` when that
+   directory exists; `full/scripts/build_full.sh` does **not** stage
+   libCFTest). Prints `ENV_PREPARE libCFTest-run-root … path=… sha256=…`.
+   Never copies onto the CoreFoundation.framework slot (byte-identical
+   copy there is the duplicate-image refusal in `run_ud_guest.sh`).
    `link_ud_guest.sh` stays the only ud_guest linker. Any other
    missing piece is `CANNOT_UD_GUEST_<FILE> file=<basename>`. On success the
    binary is exported as `UD_GUEST_BIN` for rung a, with
@@ -298,10 +306,17 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
     from `mrroot-base-x86`), and the **twelve** overlay dylibs
     (`phase2_twelve_overlay_names`: nine FE + `libswift_Concurrency.dylib` /
     `libswiftObjectiveC.dylib` / `libswiftObservation.dylib`) in both
-    `mrroot-x86_64` and `mrroot_fe-x86_64`. ObjectiveC /
+    `mrroot-x86_64` and `mrroot_fe-x86_64`, then **restages the same twelve
+    into the run root** `scratch/mrroot_full-x86_64` (always overwrite from
+    artifacts; a dest that is already an x86 Mach-O is not kept — that skip
+    is how `libswiftObjectiveC` stayed the Apple dyld-cache extract while
+    Darwin / `_errno` / `_Concurrency` came from artifacts). ObjectiveC /
     `_DarwinFoundation*` / `_errno` come from
-    `swiftcore-macho/artifacts/swift-macosx/x86_64` (in-tree shells;
-    Apple dyld-cache copies have no `LC_DYLD_INFO`). Host ELF files
+    `swiftcore-macho/artifacts/swift-macosx/x86_64` (in-tree shells).
+    A dyld-cache extract (no `LC_DYLD_INFO`, no `LC_DYLD_CHAINED_FIXUPS`)
+    is `CANNOT_STAGE_CACHE_EXTRACT name=… src=…`, not staged. End of
+    staging prints one `OVERLAY_PROVENANCE name=… srcdir=… sha256=… fixups=dyld_info|chained`
+    line per overlay (`llvm-objdump --macho --private-headers`). Host ELF files
     are the same closed set as `mrroot-host-x86`. Incomplete layout is
     `CANNOT_X86_MRROOT_LAYOUT missing=…` (leaf names). Not a PR3
     `CURSOR_ENV_CANNOT_*` marker. Rungs b/c wait on `LAYOUT_OK`; rung a does
@@ -319,4 +334,6 @@ extracted from the dyld shared cache. Those binaries carry **no**
 stripped. They cannot be loaded. `_DarwinFoundation1/2/3`, `_errno`, and
 `ObjectiveC` are built from in-tree `.swiftinterface` / re-export shells
 and `overlays/ObjectiveC.swift` (`overlay_build_xcode_shells`) and staged
-in `swiftcore-macho/artifacts/swift-macosx/x86_64`.
+in `swiftcore-macho/artifacts/swift-macosx/x86_64`. Staging into a run
+root refuses a cache extract (`CANNOT_STAGE_CACHE_EXTRACT`) rather than
+falling back to `scratch/apple-x86-overlays`.

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -857,8 +857,9 @@ phase2_fe_overlay_names() {
 # Durable x86 overlay set: nine FE + the three build_full / widget-gate loads
 # (expected_swiftui_loads: _Concurrency, ObjectiveC, Observation). Each needs
 # an x86 .tbd under sysroot usr/lib/swift and the dylib in both mrroot-x86_64
-# and mrroot_fe-x86_64. Sources: cross-built artifacts first, then
-# scratch/apple-x86-overlays (ObjectiveC / _DarwinFoundation* / _errno).
+# and mrroot_fe-x86_64. Sources: cross-built artifacts first. A dyld-cache
+# extract in scratch/apple-x86-overlays is named by CANNOT_STAGE_CACHE_EXTRACT,
+# not copied.
 phase2_twelve_overlay_names() {
     phase2_fe_overlay_names
     printf '%s\n' \
@@ -868,10 +869,12 @@ phase2_twelve_overlay_names() {
 }
 
 # scratch/apple-x86-overlays used to hold Apple dyld-cache extracts. Those
-# copies have no LC_DYLD_INFO / LC_DYLD_CHAINED_FIXUPS and cannot be loaded.
-# The five SDK overlays are now built from in-tree interfaces / ObjectiveC.swift
-# and staged in swiftcore-macho/artifacts/swift-macosx/x86_64. Keep the
-# directory last in the search only as a stale fallback.
+# copies have no LC_DYLD_INFO / LC_DYLD_CHAINED_FIXUPS and cannot be loaded
+# (machorun PR #55, MR_EXIT_DSC_NO_FIXUPS / exit 74). The five SDK overlays
+# are now built from in-tree interfaces / ObjectiveC.swift and staged in
+# swiftcore-macho/artifacts/swift-macosx/x86_64. Keep the Apple directory in
+# the search only so a cache-extract can be NAMED in
+# CANNOT_STAGE_CACHE_EXTRACT src=… — never copy it into a run root.
 phase2_x86_overlay_search_dirs() {
     printf '%s\n' \
         "${W:?}/swiftcore-macho/artifacts/swift-macosx/x86_64" \
@@ -880,8 +883,48 @@ phase2_x86_overlay_search_dirs() {
         "${HOME}/work/build/lib/swift/macosx"
 }
 
-# Print the first x86 Mach-O overlay path for $1, or return 1.
-phase2_find_x86_overlay() {
+# llvm-objdump --macho --private-headers (the reader provenance lines cite).
+phase2_macho_private_headers() {
+    local f=$1
+    if command -v llvm-objdump-18 >/dev/null 2>&1; then
+        llvm-objdump-18 --macho --private-headers "$f" 2>/dev/null
+    else
+        llvm-objdump --macho --private-headers "$f" 2>/dev/null
+    fi
+}
+
+# dyld_info (LC_DYLD_INFO / LC_DYLD_INFO_ONLY), chained, or empty.
+phase2_macho_fixups() {
+    local hdr
+    hdr=$(phase2_macho_private_headers "$1")
+    if printf '%s\n' "$hdr" | grep -q 'LC_DYLD_CHAINED_FIXUPS'; then
+        printf 'chained\n'
+    elif printf '%s\n' "$hdr" | grep -q 'LC_DYLD_INFO'; then
+        printf 'dyld_info\n'
+    else
+        printf '\n'
+    fi
+}
+
+# x86 Mach-O with neither LC_DYLD_INFO nor LC_DYLD_CHAINED_FIXUPS: a dyld
+# shared-cache extract (only LC_DYLD_EXPORTS_TRIE). Staging one into a run
+# root is a guaranteed later machorun failure.
+phase2_is_cache_extract() {
+    local f=$1
+    [ -f "$f" ] || return 1
+    phase2_is_x86_macho "$f" || return 1
+    [ -z "$(phase2_macho_fixups "$f")" ]
+}
+
+phase2_is_loadable_x86_overlay() {
+    local f=$1
+    phase2_is_x86_macho "$f" || return 1
+    phase2_is_cache_extract "$f" && return 1
+    return 0
+}
+
+# First x86 Mach-O for $1 in search order, including cache extracts.
+phase2_find_any_x86_overlay() {
     local name=$1 dir
     while IFS= read -r dir; do
         [ -n "$dir" ] || continue
@@ -893,21 +936,137 @@ phase2_find_x86_overlay() {
     return 1
 }
 
+# First LOADABLE x86 overlay (has LC_DYLD_INFO or LC_DYLD_CHAINED_FIXUPS).
+# Artifacts first. Cache extracts are skipped, not staged.
+phase2_find_x86_overlay() {
+    local name=$1 dir
+    while IFS= read -r dir; do
+        [ -n "$dir" ] || continue
+        if [ -f "$dir/$name" ] && phase2_is_loadable_x86_overlay "$dir/$name"; then
+            printf '%s\n' "$dir/$name"
+            return 0
+        fi
+    done < <(phase2_x86_overlay_search_dirs)
+    return 1
+}
+
+# Copy loadable overlay $2 into directory $1. Sets PHASE2_OVERLAY_SRC.
+#   0 copied from a loadable source
+#   1 missing
+#   2 only a dyld-cache extract exists (PHASE2_OVERLAY_SRC is that path)
+# Always overwrites. A dest that already holds an Apple extract is the
+# ObjectiveC provenance bug: phase2_fill_x86_base_swift_dylibs used to
+# `continue` when dest was any x86 Mach-O, so libswiftObjectiveC stayed the
+# cache extract while Darwin/errno (FE, always cp -f) and Concurrency
+# (absent from dest, so copied from artifacts) came from
+# swiftcore-macho/artifacts/swift-macosx/x86_64. build_full.sh then copied
+# BASE's ObjectiveC into scratch/mrroot_full-x86_64.
+phase2_copy_loadable_overlay() {
+    local dest_swift=$1 name=$2
+    local src extract dest
+    PHASE2_OVERLAY_SRC=
+    mkdir -p "$dest_swift"
+    dest=$dest_swift/$name
+    src=$(phase2_find_x86_overlay "$name" || true)
+    if [ -n "$src" ]; then
+        if phase2_is_cache_extract "$src"; then
+            PHASE2_OVERLAY_SRC=$src
+            return 2
+        fi
+        cp -f "$src" "$dest"
+        PHASE2_OVERLAY_SRC=$src
+        return 0
+    fi
+    extract=$(phase2_find_any_x86_overlay "$name" || true)
+    if [ -n "$extract" ] && phase2_is_cache_extract "$extract"; then
+        PHASE2_OVERLAY_SRC=$extract
+        if [ -f "$dest" ] && phase2_is_cache_extract "$dest"; then
+            rm -f "$dest"
+        fi
+        return 2
+    fi
+    if [ -f "$dest" ] && phase2_is_cache_extract "$dest"; then
+        rm -f "$dest"
+    fi
+    return 1
+}
+
+phase2_print_overlay_provenance() {
+    local name=$1 src=$2 dest=$3
+    local srcdir sha fix
+    srcdir=$(cd "$(dirname "$src")" && pwd)
+    sha=$(sha256sum "$dest" | awk '{print substr($1,1,12)}')
+    fix=$(phase2_macho_fixups "$dest")
+    printf 'OVERLAY_PROVENANCE name=%s srcdir=%s sha256=%s fixups=%s\n' \
+        "$name" "$srcdir" "$sha" "$fix"
+}
+
+# Stage the twelve overlays into a run root ($1/darwin/usr/lib/swift).
+# Always prefers artifacts. Refuses a cache extract with
+#   CANNOT_STAGE_CACHE_EXTRACT name=… src=…
+# At the end: one OVERLAY_PROVENANCE line per staged overlay.
+phase2_stage_x86_run_root_overlays() {
+    local dest=$1
+    local swift=$dest/darwin/usr/lib/swift
+    local name rc fail=0
+    local -a staged_names=() staged_srcs=() refused=()
+    mkdir -p "$swift"
+    while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        rc=0
+        phase2_copy_loadable_overlay "$swift" "$name" || rc=$?
+        case "$rc" in
+            0)
+                staged_names+=("$name")
+                staged_srcs+=("$PHASE2_OVERLAY_SRC")
+                ;;
+            2)
+                refused+=("$name|$PHASE2_OVERLAY_SRC")
+                fail=1
+                ;;
+        esac
+    done < <(phase2_twelve_overlay_names)
+    local i
+    if [ "${#staged_names[@]}" -gt 0 ]; then
+        for i in "${!staged_names[@]}"; do
+            phase2_print_overlay_provenance \
+                "${staged_names[$i]}" \
+                "${staged_srcs[$i]}" \
+                "$swift/${staged_names[$i]}"
+        done
+    fi
+    if [ "${#refused[@]}" -gt 0 ]; then
+        for i in "${refused[@]}"; do
+            printf 'CANNOT_STAGE_CACHE_EXTRACT name=%s src=%s\n' \
+                "${i%%|*}" "${i#*|}"
+        done
+    fi
+    return "$fail"
+}
+
 # Stage FE overlays into $1/darwin/usr/lib/swift/. Prints OK or MISSING=a,b,c.
 # Missing overlays are a named CANNOT_X86_OVERLAYS_NOT_BUILT, not the macOS
-# CoreSimulator marker.
+# CoreSimulator marker. Cache extracts are not staged; stderr names
+# CANNOT_STAGE_CACHE_EXTRACT and the name is listed in MISSING=.
 phase2_stage_x86_fe_overlays() {
     local dest=$1
     local swift=$dest/darwin/usr/lib/swift
     mkdir -p "$swift"
-    local missing=() name src
+    local missing=() name rc
     while IFS= read -r name; do
         [ -n "$name" ] || continue
-        if src=$(phase2_find_x86_overlay "$name"); then
-            cp -f "$src" "$swift/$name"
-        else
-            missing+=("$name")
-        fi
+        rc=0
+        phase2_copy_loadable_overlay "$swift" "$name" || rc=$?
+        case "$rc" in
+            0) ;;
+            2)
+                echo "CANNOT_STAGE_CACHE_EXTRACT name=$name src=$PHASE2_OVERLAY_SRC" >&2
+                missing+=("$name")
+                ;;
+            *)
+                missing+=("$name")
+                ;;
+        esac
     done < <(phase2_twelve_overlay_names)
     if [ "${#missing[@]}" -eq 0 ]; then
         printf 'OK\n'
@@ -1219,22 +1378,25 @@ phase2_fill_x86_libswiftcompat() {
     fi
 }
 
-# Stage BASE swift runtime dylibs that exist as x86 Mach-O in the overlay
-# search dirs (stdlib cross-build / operator Apple overlays). Never copy arm64.
+# Stage BASE swift runtime dylibs from the overlay search. Always overwrite
+# from a loadable source (artifacts first). Never keep a dest that is only
+# x86 Mach-O — that is how libswiftObjectiveC stayed the Apple cache extract
+# while the other four overlays came from artifacts. Never copy arm64.
+# Cache extracts are refused, not copied.
 phase2_fill_x86_base_swift_dylibs() {
     local dest=$1
     local swift=$dest/darwin/usr/lib/swift
-    local name src
+    local name rc
     mkdir -p "$swift"
     while IFS= read -r name; do
         [ -n "$name" ] || continue
-        if phase2_is_x86_macho "$swift/$name"; then
-            continue
-        fi
-        rm -f "$swift/$name"
-        if src=$(phase2_find_x86_overlay "$name"); then
-            cp -f "$src" "$swift/$name"
-        fi
+        rc=0
+        phase2_copy_loadable_overlay "$swift" "$name" || rc=$?
+        case "$rc" in
+            2)
+                echo "CANNOT_STAGE_CACHE_EXTRACT name=$name src=$PHASE2_OVERLAY_SRC" >&2
+                ;;
+        esac
     done < <(phase2_twelve_overlay_names)
 }
 
@@ -1252,9 +1414,18 @@ phase2_stage_x86_mrroot_layout() {
     while IFS= read -r rel; do
         [ -n "$rel" ] || continue
         leaf=$(phase2_layout_leaf "$rel")
-        if ! phase2_is_x86_macho "$dest/$rel"; then
-            missing+=("$leaf")
-        fi
+        case "$rel" in
+            darwin/usr/lib/swift/*)
+                if ! phase2_is_loadable_x86_overlay "$dest/$rel"; then
+                    missing+=("$leaf")
+                fi
+                ;;
+            *)
+                if ! phase2_is_x86_macho "$dest/$rel"; then
+                    missing+=("$leaf")
+                fi
+                ;;
+        esac
     done < <(phase2_base_layout_macho_names)
 
     while IFS= read -r name; do
@@ -1266,10 +1437,10 @@ phase2_stage_x86_mrroot_layout() {
 
     while IFS= read -r name; do
         [ -n "$name" ] || continue
-        if ! phase2_is_x86_macho "$dest/darwin/usr/lib/swift/$name"; then
+        if ! phase2_is_loadable_x86_overlay "$dest/darwin/usr/lib/swift/$name"; then
             missing+=("$name")
         fi
-        if ! phase2_is_x86_macho "$fe/darwin/usr/lib/swift/$name"; then
+        if ! phase2_is_loadable_x86_overlay "$fe/darwin/usr/lib/swift/$name"; then
             missing+=("$name")
         fi
     done < <(phase2_twelve_overlay_names)

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -869,6 +869,28 @@ else
     fi
 fi
 
+# 6b2. Loadable overlays into the run root. build_full.sh copies swift
+# dylibs from BASE/FE; that is how libswiftObjectiveC arrived as the Apple
+# extract (BASE fill skipped an existing x86 Mach-O). Always restage from
+# artifacts when present; refuse a dyld-cache extract (no LC_DYLD_INFO /
+# LC_DYLD_CHAINED_FIXUPS) with CANNOT_STAGE_CACHE_EXTRACT. One
+# OVERLAY_PROVENANCE line per staged overlay (name, srcdir, sha256 prefix,
+# fixups=dyld_info|chained from llvm-objdump --macho --private-headers).
+echo "==== mrroot_full-x86_64 overlays (artifacts first; refuse cache extracts) ===="
+if [ -d "$MRROOT" ]; then
+    overlay_full_report=$(phase2_stage_x86_run_root_overlays "$MRROOT" || true)
+    printf '%s\n' "$overlay_full_report"
+    if printf '%s\n' "$overlay_full_report" | grep -q '^CANNOT_STAGE_CACHE_EXTRACT'; then
+        cannot mrroot-overlays-x86 STAGE_CACHE_EXTRACT \
+            "$(printf '%s\n' "$overlay_full_report" | grep '^CANNOT_STAGE_CACHE_EXTRACT' | tr '\n' ' ' | phase2_flatten)"
+    else
+        note mrroot-overlays-x86 satisfied
+    fi
+else
+    cannot mrroot-overlays-x86 STAGE_CACHE_EXTRACT \
+        "no $MRROOT to stage overlays into (mrroot-x86 did not produce a dest)"
+fi
+
 # ---------------------------------------------------------------------------
 # 6c. Guest-visible /w layout (FocusWidgetGuestMain.swift fonts)
 echo "==== /w layout (guest-visible fonts path) ===="
@@ -922,6 +944,31 @@ case "$ud_report" in
         cannot ud-guest-x86 UD_GUEST_UNKNOWN "ud-guest-x86 produced: ${ud_report:-empty}"
         ;;
 esac
+
+# Stage libCFTest into the run root after link, before run. Arm64
+# build_cftest_harness.sh copies into $W/root; x86 W is the ud-guest work
+# tree, so this is the analogue for scratch/mrroot_full-x86_64. Not a
+# build_full.sh step (that script never stages libCFTest).
+echo "==== libCFTest into run root (after link, before run_ud_guest.sh) ===="
+if [ "$UD_GUEST_ITEM_OK" -eq 1 ] && [ -d "$MRROOT" ]; then
+    cftest_src=${UD_GUEST_W:-$W/scratch/ud-guest-x86_64}/lib/libCFTest.dylib
+    cftest_report=$(phase2_stage_cftest_into_run_root "$cftest_src" "$MRROOT" || true)
+    case "$cftest_report" in
+        status=satisfied\ path=*)
+            note libCFTest-run-root satisfied "${cftest_report#status=satisfied }"
+            ;;
+        status=cold-built\ path=*)
+            note libCFTest-run-root cold-built "${cftest_report#status=cold-built }"
+            ;;
+        *)
+            cannot libCFTest-run-root CFTEST_STAGE \
+                "${cftest_report:-empty}. arm64 stages via build_cftest_harness.sh into \$W/root; x86 stages scratch/ud-guest-x86_64/lib/libCFTest.dylib into $MRROOT/darwin/usr/lib/libCFTest.dylib (not the CoreFoundation.framework slot)."
+            ;;
+    esac
+elif [ "$UD_GUEST_ITEM_OK" -eq 1 ]; then
+    cannot libCFTest-run-root CFTEST_STAGE \
+        "ud_guest linked but no run root at $MRROOT to stage libCFTest.dylib into"
+fi
 
 # ---------------------------------------------------------------------------
 # 7. Rungs. Reuse committed gates. Never invent new denominators.

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -1072,6 +1072,16 @@ expect_grep 'CANNOT_X86_OVERLAYS_NOT_BUILT' "$PREPARE" "widget env-prepare overl
 expect_grep 'try_generate_tbd' "$PREPARE" "tbd-stubs tries gen_tbd instead of host=x86_64"
 expect_not_grep 'CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS' "$PHASE2" \
     "phase2 overlay staging does not use the macOS CoreSimulator marker"
+expect_grep 'phase2_find_x86_overlay' "$COMMON" "overlay search helper"
+expect_grep 'phase2_is_cache_extract' "$COMMON" "cache-extract detector"
+expect_grep 'phase2_stage_x86_run_root_overlays' "$COMMON" "run-root overlay stager"
+expect_grep 'CANNOT_STAGE_CACHE_EXTRACT' "$COMMON" "cache-extract refusal marker"
+expect_grep 'OVERLAY_PROVENANCE' "$COMMON" "overlay provenance line"
+expect_grep 'llvm-objdump' "$COMMON" "provenance reads llvm-objdump private-headers"
+expect_grep 'phase2_stage_x86_run_root_overlays' "$PHASE2" \
+    "phase2 restages overlays into the run root"
+expect_not_grep 'if phase2_is_x86_macho "$swift/$name"; then' "$COMMON" \
+    "BASE fill no longer keeps an existing x86 Mach-O (ObjectiveC Apple-extract skip)"
 for overlay in libswiftDarwin.dylib libswiftSynchronization.dylib \
     libswift_Builtin_float.dylib libswift_DarwinFoundation1.dylib \
     libswift_DarwinFoundation2.dylib libswift_DarwinFoundation3.dylib \
@@ -1420,14 +1430,19 @@ if [ -d "$SYS/usr/lib" ]; then
         die_test "libswift_Concurrency.dylib was not staged as x86 Mach-O"
     fi
     if [ -f "$STUB_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib" ]; then
-        if phase2_is_x86_macho \
+        if phase2_is_loadable_x86_overlay \
             "$STUB_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib"; then
-            ok "layout staged x86 libswiftObjectiveC.dylib when overlay search found it"
+            art=$ROOT/swiftcore-macho/artifacts/swift-macosx/x86_64/libswiftObjectiveC.dylib
+            if cmp -s "$STUB_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib" "$art"; then
+                ok "layout stages loadable libswiftObjectiveC.dylib from artifacts"
+            else
+                die_test "staged libswiftObjectiveC.dylib does not match artifacts"
+            fi
         else
-            die_test "libswiftObjectiveC.dylib present but not x86 Mach-O"
+            die_test "libswiftObjectiveC.dylib present but is a cache extract"
         fi
     else
-        ok "libswiftObjectiveC.dylib absent (Apple-SDK overlay; named in MISSING=)"
+        die_test "libswiftObjectiveC.dylib absent (artifacts has a from-source build)"
     fi
     rm -rf "$STUB_DEST"
 else
@@ -1519,6 +1534,17 @@ expect_grep 'scratch/ud-guest-x86_64' "$UDINC" "work tree is suffixed"
 expect_grep 'refusing unsuffixed/arm64 ud-guest work tree' "$UDINC" \
     "unsuffixed work tree is a named CANNOT"
 expect_grep 'export UD_GUEST_BIN' "$PHASE2" "successful link exports UD_GUEST_BIN for rung a"
+expect_grep 'phase2_stage_cftest_into_run_root' "$UDINC" \
+    "libCFTest is staged into the run root after link"
+expect_grep 'phase2_stage_cftest_into_run_root' "$PHASE2" \
+    "phase2 stages libCFTest after ud-guest link, before rung a"
+expect_grep 'libCFTest-run-root' "$PHASE2" "ENV_PREPARE item names libCFTest-run-root"
+expect_grep 'darwin/usr/lib/libCFTest.dylib' "$PHASE2" \
+    "libCFTest stage names the run-root path"
+expect_grep 'CoreFoundation slot is a byte-identical copy' "$UDINC" \
+    "run-root stager refuses a duplicate CF framework slot"
+expect_grep 'build_full.sh does not stage libCFTest' "$UDINC" \
+    "libCFTest staging is not routed through build_full.sh"
 expect_grep 'CANNOT_UD_GUEST_' "$UDINC" "refusal markers use CANNOT_UD_GUEST_"
 expect_grep 'LIBCFTEST libCFTest.dylib' "$UDINC" "CF hole names file=libCFTest.dylib"
 expect_grep 'USERDEFAULTSGUEST UserDefaultsGuest.o' "$UDINC" "port hole names file=UserDefaultsGuest.o"
@@ -1718,6 +1744,48 @@ if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
     else
         die_test "UD_CFTEST_DYLIB resolution got: '$cfok'"
     fi
+    echo "== libCFTest stage into the run root (after link, before run)"
+    CFROOT=$(mktemp -d /tmp/phase2-cftest-root.XXXXXX)
+    cstage=$(phase2_stage_cftest_into_run_root "$UDWORK/libCFTest.dylib" "$CFROOT" || true)
+    case "$cstage" in
+        status=cold-built\ path=*sha256=*)
+            dest=${cstage#*path=}
+            dest=${dest%% *}
+            sha=${cstage##*sha256=}
+            want=$(sha256sum "$CFROOT/darwin/usr/lib/libCFTest.dylib" | awk '{print $1}')
+            env_line=$(phase2_prepare libCFTest-run-root "cold-built path=$dest sha256=$sha")
+            if [ "$dest" = "$CFROOT/darwin/usr/lib/libCFTest.dylib" ] \
+                && [ "$sha" = "$want" ] \
+                && [ -f "$CFROOT/darwin/usr/lib/libCFTest.dylib" ] \
+                && phase2_is_x86_macho "$CFROOT/darwin/usr/lib/libCFTest.dylib" \
+                && [ ! -e "$CFROOT/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation" ] \
+                && echo "$env_line" | grep -q "ENV_PREPARE libCFTest-run-root cold-built path=$dest sha256=$sha"
+            then
+                ok "libCFTest stages into run-root darwin/usr/lib (ENV_PREPARE path+sha256; not the CF slot)"
+            else
+                die_test "libCFTest stage dest/sha/ENV_PREPARE mismatch: '$cstage' env='$env_line'"
+            fi
+            ;;
+        *) die_test "libCFTest run-root stage got: '$cstage'" ;;
+    esac
+    again=$(phase2_stage_cftest_into_run_root "$UDWORK/libCFTest.dylib" "$CFROOT" || true)
+    case "$again" in
+        status=satisfied\ path=*sha256=*)
+            ok "libCFTest re-stage of an identical dest is satisfied"
+            ;;
+        *) die_test "identical re-stage got: '$again'" ;;
+    esac
+    mkdir -p "$CFROOT/darwin/System/Library/Frameworks/CoreFoundation.framework"
+    cp -f "$UDWORK/libCFTest.dylib" \
+        "$CFROOT/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+    dup=$(phase2_stage_cftest_into_run_root "$UDWORK/libCFTest.dylib" "$CFROOT" || true)
+    case "$dup" in
+        CANNOT_UD_GUEST_LIBCFTEST\ file=libCFTest.dylib*byte-identical*)
+            ok "libCFTest stage refuses a byte-identical CoreFoundation slot"
+            ;;
+        *) die_test "duplicate CF slot got: '$dup'" ;;
+    esac
+    rm -rf "$CFROOT"
     unset UD_CFTEST_DYLIB
 else
     die_test "could not emit an x86 libCFTest.dylib fixture"
@@ -1783,6 +1851,78 @@ else
     die_test "port compile log-spill got: $port_report"
 fi
 rm -rf "$UDWORK"
+
+echo "== overlay provenance from artifacts + cache-extract refusal"
+# shellcheck source=common.inc
+. "$COMMON"
+ART_OC=$ROOT/swiftcore-macho/artifacts/swift-macosx/x86_64/libswiftObjectiveC.dylib
+PACK=$ROOT/machorun/scripts/pack_macho.py
+if [ ! -f "$ART_OC" ]; then
+    die_test "missing from-source $ART_OC"
+elif [ ! -f "$PACK" ]; then
+    die_test "missing $PACK (PR #55 strip-fixups)"
+else
+    saved_w=$W
+    saved_home=$HOME
+    W=$ROOT
+    PROV_DEST=$(mktemp -d /tmp/phase2-overlay-prov.XXXXXX)
+    prov=$(phase2_stage_x86_run_root_overlays "$PROV_DEST" || true)
+    oc_line=$(printf '%s\n' "$prov" | grep 'name=libswiftObjectiveC.dylib' | head -1 || true)
+    art_dir=$ROOT/swiftcore-macho/artifacts/swift-macosx/x86_64
+    art_sha=$(sha256sum "$ART_OC" | awk '{print substr($1,1,12)}')
+    if echo "$oc_line" | grep -q "OVERLAY_PROVENANCE name=libswiftObjectiveC.dylib" \
+        && echo "$oc_line" | grep -q "srcdir=$art_dir" \
+        && echo "$oc_line" | grep -q "sha256=$art_sha" \
+        && echo "$oc_line" | grep -q 'fixups=dyld_info' \
+        && cmp -s "$PROV_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib" "$ART_OC"
+    then
+        ok "OVERLAY_PROVENANCE names artifacts libswiftObjectiveC (sha256 prefix, fixups=dyld_info)"
+    else
+        die_test "ObjectiveC provenance expected artifacts+$art_sha+dyld_info got: '$oc_line'"
+    fi
+    # Stale Apple extract already in the dest must be overwritten, not kept.
+    EXTRACT_W=$(mktemp -d /tmp/phase2-overlay-extract.XXXXXX)
+    mkdir -p "$EXTRACT_W/scratch/apple-x86-overlays" \
+        "$EXTRACT_W/swiftcore-macho/artifacts/swift-macosx/x86_64"
+    python3 "$PACK" strip-fixups "$ART_OC" \
+        -o "$EXTRACT_W/scratch/apple-x86-overlays/libswiftObjectiveC.dylib"
+    if ! phase2_is_cache_extract \
+        "$EXTRACT_W/scratch/apple-x86-overlays/libswiftObjectiveC.dylib"
+    then
+        die_test "strip-fixups fixture is not a cache extract"
+    fi
+    STALE_DEST=$(mktemp -d /tmp/phase2-overlay-stale.XXXXXX)
+    mkdir -p "$STALE_DEST/darwin/usr/lib/swift"
+    cp -f "$EXTRACT_W/scratch/apple-x86-overlays/libswiftObjectiveC.dylib" \
+        "$STALE_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib"
+    W=$ROOT
+    stale_prov=$(phase2_stage_x86_run_root_overlays "$STALE_DEST" || true)
+    if cmp -s "$STALE_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib" "$ART_OC" \
+        && echo "$stale_prov" | grep -q "OVERLAY_PROVENANCE name=libswiftObjectiveC.dylib" \
+        && echo "$stale_prov" | grep -q "srcdir=$art_dir" \
+        && ! echo "$stale_prov" | grep -q '^CANNOT_STAGE_CACHE_EXTRACT'
+    then
+        ok "stale dest cache extract is overwritten from artifacts (not kept)"
+    else
+        die_test "stale overwrite failed: $(sha256sum "$STALE_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib" "$ART_OC"); $stale_prov"
+    fi
+    # Isolated tree: only the cache extract is findable. Must refuse, not stage.
+    W=$EXTRACT_W
+    HOME=$EXTRACT_W
+    REFUSE_DEST=$(mktemp -d /tmp/phase2-overlay-refuse.XXXXXX)
+    refuse=$(phase2_stage_x86_run_root_overlays "$REFUSE_DEST" || true)
+    extract_src=$EXTRACT_W/scratch/apple-x86-overlays/libswiftObjectiveC.dylib
+    if echo "$refuse" | grep -q "CANNOT_STAGE_CACHE_EXTRACT name=libswiftObjectiveC.dylib src=$extract_src" \
+        && [ ! -f "$REFUSE_DEST/darwin/usr/lib/swift/libswiftObjectiveC.dylib" ]
+    then
+        ok "cache extract is CANNOT_STAGE_CACHE_EXTRACT name=… src=… (not staged)"
+    else
+        die_test "cache-extract refusal got: '$refuse' dest=$(ls -l "$REFUSE_DEST/darwin/usr/lib/swift" 2>/dev/null)"
+    fi
+    W=$saved_w
+    HOME=$saved_home
+    rm -rf "$PROV_DEST" "$STALE_DEST" "$REFUSE_DEST" "$EXTRACT_W"
+fi
 
 echo "== gen_swift_tbd.sh round-trip (libswiftCore + overlays)"
 if bash "$ROOT/scripts/x86/test_gen_swift_tbd.sh"; then

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -5,6 +5,9 @@
 #   objects in $W/scratch/ud-guest-x86_64/fe  (never scratch/ud-guest)
 #   libCFTest.dylib from build_cfobjc.sh + build_cftest_harness.sh
 #     (never a stub dylib; link_ud_guest.sh stays the only ud_guest linker)
+#   after link, before run: stage that dylib into
+#     scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib
+#     (arm64 analogue: build_cftest_harness.sh -> $W/root; not build_full.sh)
 #   libswiftcompat.dylib in that tree's lib/
 #   link via foundation-macho/scripts/link_ud_guest.sh  (no second linker)
 #   binary at $W/scratch/ud-guest-x86_64/bin/ud_guest, handed to rung a as
@@ -635,6 +638,47 @@ phase2_ud_guest_check_loads() {
         return 1
     fi
     return 0
+}
+
+# Stage libCFTest.dylib into a named run root, after link, before run.
+# Arm64: build_cftest_harness.sh copies $W/lib/libCFTest.dylib into
+# $W/root/darwin/usr/lib/ when that directory exists (/work/root). x86 W is
+# scratch/ud-guest-x86_64; the run root is scratch/mrroot_full-x86_64.
+# full/scripts/build_full.sh does not stage libCFTest (ARCH does not change
+# that). Never copy onto the CoreFoundation.framework slot: a byte-identical
+# copy there is the duplicate-image refusal in run_ud_guest.sh.
+# Prints: status=cold-built|satisfied path=… sha256=…
+phase2_stage_cftest_into_run_root() {
+    local src=$1 dest_root=$2
+    local dest=$dest_root/darwin/usr/lib/libCFTest.dylib
+    local cf_slot=$dest_root/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
+    local sha a b already=0
+    if [ ! -f "$src" ] || ! phase2_is_x86_macho "$src"; then
+        printf 'CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib reason=no x86 Mach-O to stage into run root src=%s\n' \
+            "${src:-empty}"
+        return 1
+    fi
+    mkdir -p "$(dirname "$dest")"
+    if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+        already=1
+    else
+        cp -f "$src" "$dest"
+    fi
+    sha=$(sha256sum "$dest" | awk '{print $1}')
+    if [ -f "$cf_slot" ]; then
+        a=$(md5sum "$cf_slot" | awk '{print $1}')
+        b=$(md5sum "$dest" | awk '{print $1}')
+        if [ "$a" = "$b" ]; then
+            printf 'CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib reason=CoreFoundation slot is a byte-identical copy of libCFTest.dylib (duplicate-image refusal) path=%s\n' \
+                "$cf_slot"
+            return 1
+        fi
+    fi
+    if [ "$already" -eq 1 ]; then
+        printf 'status=satisfied path=%s sha256=%s\n' "$dest" "$sha"
+    else
+        printf 'status=cold-built path=%s sha256=%s\n' "$dest" "$sha"
+    fi
 }
 
 # Main producer. Prints one line:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Operator measurements (main `78167f8b`, x86 box `i-0a2e25f3895c819b3`, after `bash scripts/x86/phase2.sh`)

### Defect 1 — rung a: libCFTest built, never staged into the run root

`scripts/x86/ud_guest.inc` built `scratch/ud-guest-x86_64/lib/libCFTest.dylib` (1,531,824 bytes) and `link_ud_guest.sh` linked `bin/ud_guest` (12,226,160 bytes, LC_LOAD_DYLIB `/usr/lib/libCFTest.dylib`). Rung a then ran `foundation-macho/scripts/run_ud_guest.sh` with `ROOT=scratch/mrroot_full-x86_64`, which expects `REAL_CF=$ROOT/darwin/usr/lib/libCFTest.dylib`. machorun stopped:

```
machorun: cannot find dylib '/usr/lib/libCFTest.dylib'
  required by: .../scratch/ud-guest-x86_64/bin/ud_guest
  tried: .../scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib
  tried: /usr/lib/libCFTest.dylib
== exit 72
ENV_PREPARE rung-a-ud_guest CANNOT_UD_SMOKE reason=run_ud_guest.sh exit 72
```

`scratch/mrroot_full-x86_64/darwin/usr/lib/` held libSystem.B/.lowheap/.real, libc++.1/.real, libc++abi, libobjc.A, libquartz, libswiftcompat, swift/ — no libCFTest.

Arm64 stages it in `foundation-macho/scripts/build_cftest_harness.sh` (`cp` into `$W/root/darwin/usr/lib/` when that directory exists; `/work/root` in the #87 container). `run_ud_guest.sh` comments and `build_foundation_placeholder.sh` record the duplicate-image refusal: the CoreFoundation.framework slot must **not** be a byte-identical copy of `libCFTest.dylib`. `full/scripts/build_full.sh` does **not** stage libCFTest (routing through it with `ARCH` would not help).

This PR copies `scratch/ud-guest-x86_64/lib/libCFTest.dylib` into `scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib` **after link, before run**, and prints `ENV_PREPARE libCFTest-run-root … path=… sha256=…`. It never copies onto the CoreFoundation.framework slot.

### Defect 2 — rung c: run root held the Apple dyld-cache extract of libswiftObjectiveC

PR #56 built the five SDK overlays from in-tree shells into `swiftcore-macho/artifacts/swift-macosx/x86_64/` and made that directory FIRST in `phase2_x86_overlay_search_dirs`, demoting `scratch/apple-x86-overlays` to a stale fallback. The run root did not follow:

```
scratch/mrroot_full-x86_64/darwin/usr/lib/swift/  (staged 07:25/07:30)
libswiftObjectiveC   mrroot=f1e8be914783 artifacts=a0d04413cfc5 apple=f1e8be914783   <-- Apple extract, LC_DYLD_EXPORTS_TRIE only, no LC_DYLD_INFO
libswiftDarwin       mrroot=0978b970cbc6 artifacts=0978b970cbc6 apple=39dbf71c1415   <-- ok
libswift_errno       mrroot=6c5720b6a879 artifacts=6c5720b6a879 apple=dbdebb87865e   <-- ok
libswift_Concurrency mrroot=7440d8620700 artifacts=7440d8620700 apple=51cc30b254fe   <-- ok
```

(DF1/2/3 sizes 8560/8400/8600 match the artifacts.) The Reminder scene then died on an un-fixed cache pointer inside objc4's load-image pass:

```
machorun: guest died with SIGSEGV at pc 0x200a3535e (fault address 0x200225a3c41)
  pc is in .../mrroot_full-x86_64/darwin/usr/lib/libobjc.A.dylib at image offset 0x2935e
  #2 _sel_registerName+0x64  #3 __objc_flush_caches+0xb4e  #4 _objc_addLoadImageFunc2+0x745
```

**Root cause of ObjectiveC provenance:** `full/scripts/build_full.sh` copies `darwin/usr/lib/swift/*.dylib` (except libswiftCore) from `BASE_RUNTIME_SOURCE` (`scratch/mrroot-x86_64`) into `scratch/mrroot_full-x86_64`, then overwrites the nine FE names from `FE_RUNTIME_SOURCE`. ObjectiveC is a BASE dylib, not an FE overlay.

`phase2_fill_x86_base_swift_dylibs` **skipped** dest files that were already x86 Mach-O. An earlier copy of the Apple extract therefore stayed. Darwin/`_errno` are FE overlays (`phase2_stage_x86_fe_overlays` always `cp -f` from artifacts-first search). `_Concurrency` was missing from BASE, so fill copied it from artifacts. Search order was not the bug; a freshness skip on “any x86 Mach-O” was.

This PR always overwrites from a loadable source (artifacts first), refuses a dyld-cache extract (no `LC_DYLD_INFO` and no `LC_DYLD_CHAINED_FIXUPS`) with `CANNOT_STAGE_CACHE_EXTRACT name=… src=…` (machorun PR #55, exit 74 `MR_EXIT_DSC_NO_FIXUPS`), restages the twelve overlays into the run root, and prints one `OVERLAY_PROVENANCE name=… srcdir=… sha256=… fixups=dyld_info|chained` line per overlay (`llvm-objdump --macho --private-headers`).

Verified here against in-tree artifacts (prefixes match the operator’s artifacts column):

```
OVERLAY_PROVENANCE name=libswiftDarwin.dylib srcdir=.../swift-macosx/x86_64 sha256=0978b970cbc6 fixups=dyld_info
OVERLAY_PROVENANCE name=libswift_errno.dylib srcdir=.../swift-macosx/x86_64 sha256=6c5720b6a879 fixups=dyld_info
OVERLAY_PROVENANCE name=libswift_Concurrency.dylib srcdir=.../swift-macosx/x86_64 sha256=7440d8620700 fixups=dyld_info
OVERLAY_PROVENANCE name=libswiftObjectiveC.dylib srcdir=.../swift-macosx/x86_64 sha256=a0d04413cfc5 fixups=dyld_info
```

## Operator next command

```bash
bash x86_stage_inputs_phase2.sh
```

Expected next lines:

- **rung a** proceeds past `cannot find dylib '/usr/lib/libCFTest.dylib'` (`ENV_PREPARE libCFTest-run-root` names `scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib` and its sha256). The smoke/persist wall after that load is the next report.
- **rung c** loads the from-source `libswiftObjectiveC` (`OVERLAY_PROVENANCE name=libswiftObjectiveC.dylib srcdir=…/swift-macosx/x86_64 sha256=a0d04413cfc5 fixups=dyld_info`) and reports its next wall (no longer the Apple-extract SIGSEGV in `_objc_addLoadImageFunc2`).

Rung success bars are unchanged (14 `check()` / widget+onboarding / `windows=1 turns=3 paced=true`).

## Tests

`bash scripts/x86/test_phase2.sh` teeth for both: libCFTest `ENV_PREPARE` line + path, overlay provenance line, cache-extract refusal via `machorun/scripts/pack_macho.py strip-fixups` (PR #55). Does not edit `machorun/` or `uikit/`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539cb29d-a8db-466a-bfbc-ac1ebfb53c5e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539cb29d-a8db-466a-bfbc-ac1ebfb53c5e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

