### PR TITLE
Link Darwin overlays to compiler-rt os_version_check.<arch>.o

### DIFF
--- a/swiftcore-macho/compiler-rt/LICENSE.TXT
+++ b/swiftcore-macho/compiler-rt/LICENSE.TXT
@@ -1,0 +1,311 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+
+The compiler_rt library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+
+==============================================================================
+
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2019 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+
+Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/swiftcore-macho/compiler-rt/SOURCE.txt
+++ b/swiftcore-macho/compiler-rt/SOURCE.txt
@@ -1,0 +1,33 @@
+Vendored compiler-rt os_version_check.c
+=======================================
+
+File:  compiler-rt/lib/builtins/os_version_check.c
+Repo:  https://github.com/llvm/llvm-project
+Tag:   llvmorg-18.1.8
+Commit: 76caf4176cd7877ad5952737d56da6f515ee4602
+URL:   https://github.com/llvm/llvm-project/blob/76caf4176cd7877ad5952737d56da6f515ee4602/compiler-rt/lib/builtins/os_version_check.c
+
+This is the compiler-rt that ships with Ubuntu clang 18.1.3 (the Darwin
+cross clang on the operator box). Apple ships the same TU in
+libclang_rt.osx.a. Linux clang's resource dir has no Darwin builtins
+archive, so overlay links must pass a compiled object.
+
+__isPlatformOrVariantPlatformVersionAtLeast is not in llvmorg-18.1.8; it
+was added on llvm-project main after that tag. The sibling is copied into
+the same TU so both clang availability hooks resolve from one object.
+
+Local patch (not upstream): crt_os_version_once_f replaces
+dispatch_once_f. gen_tbd libSystem.tbd does not export dispatch_once_f
+(Apple puts it in libdispatch). Overlay links are NOUNDEFS, so pulling
+the real symbol would fail the link. Compile still #include's
+<dispatch/dispatch.h> so a sysroot without that header fails loudly.
+
+Runtime when SystemVersion.plist / CoreFoundation is absent (machorun):
+the TU dlopens CoreFoundation and fopen's
+/System/Library/CoreServices/SystemVersion.plist. fopen failure returns
+without writing GlobalMajor/Minor/Subminor, which stay BSS zero. The
+weak_import _availability_version_check is NULL, so
+__isPlatformVersionAtLeast falls through to __isOSVersionAtLeast against
+(0,0,0). It does not crash. @available checks then return false under
+machorun until a plist (or dyld's _availability_version_check) is
+provided. That is Apple's fallback, not a second always-yes shim.

--- a/swiftcore-macho/compiler-rt/os_version_check.c
+++ b/swiftcore-macho/compiler-rt/os_version_check.c
@@ -9,32 +9,25 @@
 // This file implements the function __isOSVersionAtLeast, used by
 // Objective-C's @available
 //
-// Vendored from llvm-project compiler-rt builtins at llvmorg-18.1.8 (the
-// Ubuntu clang 18.1.3 toolchain). Apple ships this in libclang_rt.osx.a.
-// This Linux Darwin-cross clang has no Darwin compiler-rt in its resource
-// dir, so overlay links fail with undefined __isPlatformVersionAtLeast.
+// Vendored from llvm-project compiler-rt builtins at llvmorg-18.1.8
+// (commit 76caf4176cd7877ad5952737d56da6f515ee4602). See SOURCE.txt and
+// LICENSE.TXT in this directory. Apple ships this TU in libclang_rt.osx.a.
+// Linux clang has no Darwin compiler-rt in its resource dir, so Darwin
+// overlay links (NOUNDEFS) fail with undefined __isPlatformVersionAtLeast
+// unless this object is on the link line.
 //
-// Route (b) — export these from gen_tbd libSystem — is closed:
-// machorun/docs/UNIMPLEMENTED.md (the libSystem definition was added then
-// reverted; gen_tbd CHECK 4 already sees them in libswiftcompat).
-// machorun/darwin/src has no implementation. host-bound-allowed.txt does
-// not list them (glibc has no such symbol).
+// libswiftCore's Mach-O link (link_macho_dylib.sh) uses
+// -undefined dynamic_lookup, so the same symbol can stay undefined there.
+// Overlay ninja links do not. libswiftcompat defines the symbol for the
+// ELF compat dylib; that is not a Darwin overlay link input (CHECK 4
+// already refuses exporting it from gen_tbd libSystem).
 //
-// __isPlatformOrVariantPlatformVersionAtLeast is not in llvmorg-18.1.8; it
-// was added on llvm-project main. Copied below so both clang availability
-// hooks are satisfied from one x86_64-apple-macos archive.
+// __isPlatformOrVariantPlatformVersionAtLeast is not in llvmorg-18.1.8;
+// copied from llvm-project main into this TU.
 //
-// Runtime agrees with libswiftcompat (swiftcompat.c): every check returns
-// yes because we emulate a full deployment target. The strong
-// _availability_version_check in this TU makes compiler-rt take the new-API
-// path and return 1. Vanilla compiler-rt would dlopen CoreFoundation, fail
-// to parse SystemVersion.plist under machorun, leave GlobalMajor=0, and
-// hide @available APIs. Not a CHECK 5 host-bind.
-//
-// dispatch_once_f is not in gen_tbd libSystem.tbd (it lives in libdispatch
-// on Apple). This TU uses a local once so overlay NOUNDEFS links do not
-// grow that undefined. Remaining libc symbols (fopen, malloc, …) are in
-// the tbd and are only used on the unused plist fallback path.
+// When SystemVersion.plist is absent (machorun), fopen fails, globals stay
+// (0,0,0), and every __isOSVersionAtLeast check against a real macOS
+// version returns 0. No crash. See SOURCE.txt.
 //
 //===----------------------------------------------------------------------===//
 
@@ -42,25 +35,28 @@
 
 #include <TargetConditionals.h>
 #include <assert.h>
+#include <dispatch/dispatch.h>
+#include <dlfcn.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <dlfcn.h>
 
 /* gen_tbd libSystem.tbd does not export dispatch_once_f (Apple puts it in
- * libdispatch via libSystem). A local once keeps this TU self-contained so
- * overlay NOUNDEFS links do not grow a new undefined. Semantics match
- * dispatch_once for a single-threaded init of the always-yes checker. */
-typedef intptr_t dispatch_once_t;
-static void dispatch_once_f(dispatch_once_t *predicate, void *context,
-                            void (*function)(void *)) {
+ * libdispatch). Overlay NOUNDEFS links must not grow that undefined. The
+ * compile still includes <dispatch/dispatch.h> so a sysroot without it
+ * fails here. Darwin's once.h macros dispatch_once_f to _dispatch_once_f;
+ * undef that so the local once is what this TU calls. */
+static void crt_os_version_once_f(dispatch_once_t *predicate, void *context,
+                                  void (*function)(void *)) {
   if (*predicate == 0) {
     function(context);
     *predicate = ~((dispatch_once_t)0);
   }
 }
+#undef dispatch_once_f
+#define dispatch_once_f crt_os_version_once_f
 
 // These three variables hold the host's OS version.
 static int32_t GlobalMajor, GlobalMinor, GlobalSubminor;
@@ -127,15 +123,9 @@ typedef Boolean (*CFStringGetCStringFuncTy)(CFStringRef, char *, CFIndex,
                                             CFStringEncoding);
 typedef void (*CFReleaseFuncTy)(CFTypeRef);
 
-/* Strong always-yes: matches libswiftcompat, not a glibc host-bind.
- * Replaces the upstream weak_import so Darwin overlay dylibs do not depend
- * on dyld finding this in another image (overlays do not -lswiftcompat). */
+extern __attribute__((weak_import))
 bool _availability_version_check(uint32_t count,
-                                 dyld_build_version_t versions[]) {
-  (void)count;
-  (void)versions;
-  return true;
-}
+                                 dyld_build_version_t versions[]);
 
 static void _initializeAvailabilityCheck(bool LoadPlist) {
   if (AvailabilityVersionCheck && !LoadPlist) {
@@ -144,9 +134,12 @@ static void _initializeAvailabilityCheck(bool LoadPlist) {
     return;
   }
 
-  // Strong local _availability_version_check (always-yes, matching
-  // libswiftcompat). Upstream tests a weak_import pointer here.
-  AvailabilityVersionCheck = &_availability_version_check;
+  // Use the new API if it's is available. Weak-import: NULL under machorun
+  // when dyld does not provide it. Then the plist path runs; fopen of
+  // SystemVersion.plist fails, GlobalMajor/Minor/Subminor stay 0, and
+  // __isOSVersionAtLeast returns 0. No crash.
+  if (_availability_version_check)
+    AvailabilityVersionCheck = &_availability_version_check;
 
   if (AvailabilityVersionCheck && !LoadPlist) {
     // New API is supported and we're not being asked to load the plist,
@@ -331,7 +324,7 @@ int32_t __isPlatformVersionAtLeast(uint32_t Platform, uint32_t Major,
 
 #define PLATFORM_MACOS 1
 
-/* From llvm-project main (post-18.1.8). Darwin clang may emit this sibling. */
+/* From llvm-project main (post llvmorg-18.1.8). Darwin clang may emit this. */
 int32_t __isPlatformOrVariantPlatformVersionAtLeast(
     uint32_t Platform, uint32_t Major, uint32_t Minor, uint32_t Subminor,
     uint32_t Platform2, uint32_t Major2, uint32_t Minor2, uint32_t Subminor2) {
@@ -349,7 +342,6 @@ int32_t __isPlatformOrVariantPlatformVersionAtLeast(
       {Platform2, ConstructVersion(Major2, Minor2, Subminor2)}};
   return AvailabilityVersionCheck(2, Versions);
 }
-
 
 #elif __ANDROID__
 

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -208,15 +208,50 @@ resource dir, and gen_tbd `libSystem.tbd` does not export them. Route
 not list them (glibc has no such symbol; not a CHECK 5 host-bind), and
 `UNIMPLEMENTED.md` records that a libSystem definition was added then
 reverted because gen_tbd CHECK 4 already sees them in `libswiftcompat`.
+`libswiftCore`'s Mach-O link (`link_macho_dylib.sh`) still uses
+`dynamic_lookup`, so the arm64 core (and an x86 core linked that way)
+can leave the symbol undefined at link; overlay ninja links cannot.
+
 `scripts/build_compiler_rt_osx.sh` compiles the vendored
-`compiler-rt/os_version_check.c` (pinned `llvmorg-18.1.8`, variant from
-llvm-project main) for `x86_64-apple-macos` and Darwin links pass
-`$W/build/libclang_rt.osx.a` (archive search, not `-force_load`). Each Darwin link prints
-`clangxx_darwin_link: compiler_rt=<archive>`. Runtime agrees with
-`libswiftcompat` (`swiftcompat.c`: every check is “yes” because we
-emulate a full deployment target) via a strong `_availability_version_check`
-in that TU — not vanilla compiler-rt's CoreFoundation plist fallback
-(which would return 0 under machorun).
+`compiler-rt/os_version_check.c` (pinned `llvmorg-18.1.8`
+`76caf4176cd7877ad5952737d56da6f515ee4602`, LICENSE.TXT + SOURCE.txt;
+variant hook from llvm-project main) for
+`${SWIFTCORE_DARWIN_ARCH}-apple-macos` with the overlay Darwin driver
+argv (`-target`, `-isysroot`). The compile **fails loudly** if the
+sysroot lacks `<dispatch/dispatch.h>`, `<dlfcn.h>`, or CoreFoundation
+headers. The result is
+`$W/build/compiler-rt/os_version_check.<arch>.o` (x86_64 **and** arm64),
+passed as a **static object** on every Darwin overlay link
+(`clangxx_darwin_link.py` and `build_sdk_overlays.sh` `link_overlay`).
+Not archive search: a `.a` without a Mach-O index, or archive search
+without `-force_load`, dropped the member on the seven ninja overlays
+after PR #56. Each Darwin link prints
+`clangxx_darwin_link: compiler_rt=<object>`.
+
+Vanilla compiler-rt dlopens CoreFoundation and `fopen`s
+`/System/Library/CoreServices/SystemVersion.plist`. Under machorun that
+plist is absent: `fopen` fails, `GlobalMajor/Minor/Subminor` stay BSS
+`(0,0,0)`, the weak-import `_availability_version_check` is NULL, and
+every `@available` check against a real macOS version returns **0**. It
+does **not** crash. (A previous always-yes `_availability_version_check`
+in this TU was withdrawn so the object matches Apple.) machorun note:
+do not treat `(0,0,0)` as “all APIs present”; ship a SystemVersion.plist
+or dyld’s checker if guests need `@available` to succeed. A local
+`crt_os_version_once_f` stands in for `dispatch_once_f` because gen_tbd
+`libSystem.tbd` does not export it.
+
+The five PR #56 shells (`_DarwinFoundation1/2/3`, `_errno`,
+`ObjectiveC`) are `@_exported import` re-exports with no availability
+checks, so they never referenced the symbol and linked without the
+object. The seven ninja overlays (`Darwin`, `_Concurrency`,
+`_StringProcessing`, `_RegexParser`, `_Builtin_float`, `Observation`,
+and `Synchronization` via Darwin) emit `__isPlatformVersionAtLeast`.
+The object is added **uniformly** to all twelve.
+
+`scripts/test_os_version_check.sh` links a tiny x86_64-macos object that
+references the symbol against the new `.o` with `ld64.lld` and checks
+`llvm-nm` no longer reports it undefined.
+
 `-target …-unknown-linux-gnu` is ELF:
 `--ld-path=`**ld.lld**, keep `-soname`. Each shared link prints
 `clangxx_darwin_link: -o <path> decision={darwin|elf} linker={ld64.lld|ld.lld}`.
@@ -244,7 +279,7 @@ are **not** CMake targets on Linux (`stdlib/public/CMakeLists.txt:359`).
 for the ninja graph, then `overlay_build_xcode_shells` compiles them with
 the Darwin overlay argv (`-autolink-force-load`, not `-parse-stdlib`) and
 links with `clangxx_darwin_link.py` (sysroot `libc++.tbd`,
-`libclang_rt.osx.a` for `__isPlatformVersionAtLeast`, no
+`os_version_check.<arch>.o` for `__isPlatformVersionAtLeast`, no
 `/usr/lib/llvm-18/lib`). Scoreboard becomes `built` when the dylibs land.
 Empty `SWIFT_LIPO` used to make ninja run
 `cmake -E env -create` (Ubuntu cmake 3.28: `unknown option '-create'`),
@@ -270,13 +305,20 @@ attempts the other in-tree overlays), `scripts/test_clangxx_darwin_link.sh`,
 ninja graph), `scripts/test_overlay_posix.sh`, `scripts/test_overlay_darwin.sh`,
 `scripts/test_overlay_sysroot_stamp.sh` (stale MacOSX.sdk is displaced, not
 overwritten; `.tbd` stubs copied into the fresh dest; listed header ABSENT
+is `CANNOT_OVERLAY_SYSROOT_HEADER`), `scripts/test_sdk_overlays.sh`,
+`scripts/test_os_version_check.sh` (ld64.lld + llvm-nm: `__isPlatformVersionAtLeast`
+undefined in a tiny x86_64 object, defined after linking `os_version_check.x86_64.o`).
 is `CANNOT_OVERLAY_SYSROOT_HEADER` not stamp MATCH; modulemap `header "…"`
 closure via Darwin Clang overlay maps /
 `CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER` (`header@map`; libc++ `c++/v1` does
 not refuse); refuse-before-cmake;
 ninja `-sdk`/`-isysroot`; Darwin dylib `-soname` ninja line vs rewritten
 `-install_name` (apple `-target` `.so` is Darwin/ld64.lld, not ELF);
-Darwin-dep vs `first_error`), `scripts/test_sdk_overlays.sh`, `scripts/test_darwin_overlay_syntax.sh`, `scripts/test_probe_machorun.sh`.
+Darwin-dep vs `first_error`), `scripts/test_sdk_overlays.sh`,
+`scripts/test_os_version_check.sh` (ld64.lld + llvm-nm:
+`__isPlatformVersionAtLeast` undefined in a tiny x86_64 object, defined
+after linking `os_version_check.x86_64.o`),
+`scripts/test_darwin_overlay_syntax.sh`, `scripts/test_probe_machorun.sh`.
 
 ### Darwin-target `dispatch` (patch 8)
 

--- a/swiftcore-macho/scripts/build_compiler_rt_osx.sh
+++ b/swiftcore-macho/scripts/build_compiler_rt_osx.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
-# Build a Darwin-target compiler-rt builtins archive with os_version_check.c
-# (Apple's libclang_rt.osx.a piece that defines __isPlatformVersionAtLeast).
+# Compile compiler-rt os_version_check.c as a Darwin-target static object
+# (Apple ships this TU in libclang_rt.osx.a). Linked into every Darwin overlay
+# as an object, not a dylib export.
 #
-# Usage: build_compiler_rt_osx.sh [output.a]
+# Usage: build_compiler_rt_osx.sh [output.o]
 # Env: SWIFTCORE_SDKROOT or SWIFTCORE_DARWIN_SDK, SWIFTCORE_DARWIN_ARCH,
 #      DARWIN_MIN, clang on PATH (or CC / DARWIN_CLANG).
+#
+# Arch-parametric: default output is
+#   $W/build/compiler-rt/os_version_check.${SWIFTCORE_DARWIN_ARCH}.o
+# Fails loudly if the sysroot lacks <dispatch/dispatch.h>, <dlfcn.h>, or
+# CoreFoundation headers the TU wants.
 set -euo pipefail
 _here=$(cd "$(dirname "$0")" && pwd)
 _root=$(cd "$_here/../.." && pwd)
+# Do not source guest_arch.inc: that script requires swiftc. Arch is env-only.
 : "${SWIFTCORE_DARWIN_ARCH:=x86_64}"
 : "${DARWIN_MIN:=macosx13.0}"
 min_ver="${DARWIN_MIN#macosx}"
 sdk="${SWIFTCORE_SDKROOT:-${SWIFTCORE_DARWIN_SDK:-${SWIFTCORE_WORK:-$HOME/work}/sdk/MacOSX.sdk}}"
-out="${1:-${SWIFTCORE_COMPILER_RT_OSX:-${SWIFTCORE_WORK:-$HOME/work}/build/libclang_rt.osx.a}}"
 src_dir="$_root/swiftcore-macho/compiler-rt"
 if [[ -n "${DARWIN_CLANG:-}" ]]; then
   cc="$DARWIN_CLANG"
@@ -33,8 +39,30 @@ if [[ ! -f "$src_dir/os_version_check.c" ]]; then
   exit 1
 fi
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+need_header() {
+  local rel=$1
+  local p
+  for p in \
+    "$sdk/usr/include/$rel" \
+    "$sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/${rel#CoreFoundation/}"
+  do
+    if [[ -f "$p" ]]; then
+      echo "build_compiler_rt_osx.sh: header <$rel> -> $p"
+      return 0
+    fi
+  done
+  echo "build_compiler_rt_osx.sh: sysroot $sdk lacks <$rel>" >&2
+  echo "build_compiler_rt_osx.sh: os_version_check.c wants dispatch, dlfcn, CoreFoundation" >&2
+  exit 1
+}
+need_header "dispatch/dispatch.h"
+need_header "dlfcn.h"
+need_header "CoreFoundation/CoreFoundation.h"
+
+work="${SWIFTCORE_WORK:-${W:-$HOME/work}}"
+bdir="${B:-$work/build}"
+out="${1:-${SWIFTCORE_COMPILER_RT_OSX:-$bdir/compiler-rt/os_version_check.${SWIFTCORE_DARWIN_ARCH}.o}}"
+# Same Darwin driver argv the overlays use: -target <arch>-apple-macos, -isysroot.
 target="${SWIFTCORE_DARWIN_ARCH}-apple-macos${min_ver}"
 
 cflags=(
@@ -44,39 +72,30 @@ cflags=(
   -fPIC
   -O2
   -fno-stack-protector
-  -fvisibility=hidden
   -Wno-deprecated-declarations
+  -Wno-macro-redefined
 )
 
-"$cc" "${cflags[@]}" -c "$src_dir/os_version_check.c" \
-  -o "$tmpdir/os_version_check.o"
-
 mkdir -p "$(dirname "$out")"
-rm -f "$out"
-# GNU ar writes no Mach-O table of contents; ld64.lld then says
-# "archive has no index; run ranlib to add one". llvm-ar indexes Mach-O.
-ar_bin=""
-for cand in /usr/lib/llvm-18/bin/llvm-ar llvm-ar-18 llvm-ar; do
-  if [[ -x "$cand" ]] || command -v "$cand" >/dev/null 2>&1; then
-    ar_bin=$cand
-    break
-  fi
-done
-if [[ -z "$ar_bin" ]]; then
-  echo "build_compiler_rt_osx.sh: need llvm-ar (GNU ar has no Darwin index)" >&2
-  exit 1
-fi
-"$ar_bin" rcs "$out" "$tmpdir/os_version_check.o"
-# Confirm the Darwin availability hooks landed; llvm-nm understands Mach-O.
+echo "build_compiler_rt_osx.sh: $cc ${cflags[*]} -c $src_dir/os_version_check.c -o $out"
+"$cc" "${cflags[@]}" -c "$src_dir/os_version_check.c" -o "$out"
+
 nm_bin=""
-for cand in /usr/lib/llvm-18/bin/llvm-nm llvm-nm nm; do
+for cand in /usr/lib/llvm-18/bin/llvm-nm llvm-nm-18 llvm-nm; do
   if command -v "$cand" >/dev/null 2>&1 || [[ -x "$cand" ]]; then
     nm_bin=$cand
     break
   fi
 done
-if [[ -n "$nm_bin" ]]; then
-  "$nm_bin" "$out" 2>/dev/null | grep -E 'isPlatformVersionAtLeast|isPlatformOrVariantPlatformVersionAtLeast|_availability_version_check' \
-    | sed 's/^/  compiler-rt nm: /' || true
+if [[ -z "$nm_bin" ]]; then
+  echo "build_compiler_rt_osx.sh: need llvm-nm to confirm the availability object" >&2
+  exit 1
 fi
-echo "compiler-rt darwin builtins: $out"
+if ! "$nm_bin" "$out" 2>/dev/null | grep -q 'isPlatformVersionAtLeast'; then
+  echo "build_compiler_rt_osx.sh: $out missing isPlatformVersionAtLeast" >&2
+  "$nm_bin" "$out" >&2 || true
+  exit 1
+fi
+"$nm_bin" "$out" 2>/dev/null | grep -E 'isPlatformVersionAtLeast|isPlatformOrVariantPlatformVersionAtLeast' \
+  | sed 's/^/  compiler-rt nm: /' || true
+echo "compiler-rt darwin availability object: $out"

--- a/swiftcore-macho/scripts/build_sdk_overlays.sh
+++ b/swiftcore-macho/scripts/build_sdk_overlays.sh
@@ -6,7 +6,7 @@
 # Not ninja targets (stdlib/public/CMakeLists.txt:359). Compile with the
 # Darwin overlay argv shape (no -parse-stdlib; -autolink-force-load) and
 # link with the Darwin clang++ shim so ld64.lld gets sysroot libc++.tbd,
-# never /usr/lib/llvm-18/lib, plus libclang_rt.osx.a for availability checks.
+# never /usr/lib/llvm-18/lib, plus os_version_check.<arch>.o for availability.
 #
 # Prefer a sysroot .swiftinterface when present (scratch/sysroot_fe4[-x86_64]
 # usr/lib/swift/<module>.swiftmodule/<triple>.swiftinterface). Otherwise
@@ -40,11 +40,13 @@ fi
 mkdir -p "$work" "$out_lib" "$out_mod" "$work/modcache"
 
 # Overlay links are NOUNDEFS; clang's __isPlatformVersionAtLeast lives in
-# compiler-rt builtins, not gen_tbd libSystem.
+# compiler-rt builtins, not gen_tbd libSystem. Link the static object
+# (Apple's libclang_rt.osx.a member) into every overlay, including the
+# five @_exported-import shells that do not reference the symbol.
 if [ -d "$SDK" ] && [ "${SWIFTCORE_NINJA_HARNESS:-0}" != 1 ]; then
   export SWIFTCORE_SDKROOT="$SDK"
   export SWIFTCORE_WORK="$W"
-  export SWIFTCORE_COMPILER_RT_OSX="${SWIFTCORE_COMPILER_RT_OSX:-$B/libclang_rt.osx.a}"
+  export SWIFTCORE_COMPILER_RT_OSX="${SWIFTCORE_COMPILER_RT_OSX:-$B/compiler-rt/os_version_check.${ARCH}.o}"
   bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$SWIFTCORE_COMPILER_RT_OSX"
 fi
 
@@ -163,7 +165,8 @@ link_overlay() {
   local dylib=$out_lib/${lib}.dylib
   local so=$out_lib/${lib}.so
   local err=$work/${lib}.link.err
-  echo "sdk_overlay: link $lib install_name=/usr/lib/swift/${lib}.dylib"
+  local builtin="${SWIFTCORE_COMPILER_RT_OSX:-$BUILD_DIR/compiler-rt/os_version_check.${ARCH}.o}"
+  echo "sdk_overlay: link $lib install_name=/usr/lib/swift/${lib}.dylib builtin=$builtin"
   set +e
   "${CLANGXX[@]}" \
     -target "$target" \
@@ -174,6 +177,7 @@ link_overlay() {
     -Wl,-install_name,/usr/lib/swift/${lib}.dylib \
     -o "$dylib" \
     "$obj" \
+    "$builtin" \
     -L "$out_lib" \
     -lswiftCore \
     -lSystem \
@@ -190,7 +194,7 @@ link_overlay() {
     echo "sdk_overlay: REFUSING Darwin link still mentions /usr/lib/llvm-18/lib" >&2
     return 2
   fi
-  grep -E 'cxx_runtime=' "$err" || true
+  grep -E 'cxx_runtime=|compiler_rt=' "$err" || true
   cp -f "$dylib" "$so"
   echo "sdk_overlay: linked $dylib"
 }

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -105,7 +105,7 @@ ensure_compiler_rt_osx() {
     echo "build_stdlib: skip compiler-rt osx (no SDK at $sdk)"
     return 0
   fi
-  local out="${SWIFTCORE_COMPILER_RT_OSX:-$W/build/libclang_rt.osx.a}"
+  local out="${SWIFTCORE_COMPILER_RT_OSX:-$W/build/compiler-rt/os_version_check.${SWIFTCORE_DARWIN_ARCH}.o}"
   export SWIFTCORE_SDKROOT="$sdk"
   export SWIFTCORE_WORK="$W"
   export SWIFTCORE_COMPILER_RT_OSX="$out"

--- a/swiftcore-macho/scripts/clangxx_darwin_link.py
+++ b/swiftcore-macho/scripts/clangxx_darwin_link.py
@@ -15,9 +15,10 @@ Apple triple → exec the real clang++ with the original argv plus
 `-L/usr/lib/llvm-18/lib`; drop that on Darwin links and pass
 `-nostdlib++` plus the sysroot `usr/lib/libc++.tbd` / `libc++abi.tbd`
 so ld64 never opens the host ELF `libc++.so`. Print
-`cxx_runtime=<tbd>`. Pass `libclang_rt.osx.a` (compiler-rt
-`os_version_check.c` for `__isPlatformVersionAtLeast`) and print
-`compiler_rt=<archive>`. Linux/unknown-linux-gnu → ld.lld, keep `-soname`.
+`cxx_runtime=<tbd>`. Pass the Darwin compiler-rt availability object
+(`os_version_check.<arch>.o` from `os_version_check.c`, Apple's
+`libclang_rt.osx.a` piece for `__isPlatformVersionAtLeast`) and print
+`compiler_rt=<object>`. Linux/unknown-linux-gnu → ld.lld, keep `-soname`.
 `-soname` is rewritten to `-install_name` only so ld64 never sees the GNU
 flag; nothing else is rewritten (PR #40's -dynamiclib/-nostdlib pass
 dropped -platform_version/-arch).
@@ -369,32 +370,43 @@ def darwin_cxx_runtime_path(argv: list[str]) -> str:
     return tbds[0] if tbds else "ABSENT"
 
 
-def darwin_compiler_rt_osx_path() -> str:
-    """x86_64-apple-macos compiler-rt builtins archive (os_version_check.c)."""
+def _darwin_arch_from_argv(argv: list[str]) -> str:
+    """Slice from -target (x86_64 or arm64). Env is the fallback."""
+    t = (_target(argv) or "").lower()
+    if t.startswith("arm64") or t.startswith("aarch64"):
+        return "arm64"
+    if t.startswith("x86_64"):
+        return "x86_64"
+    env = os.environ.get("SWIFTCORE_DARWIN_ARCH", "x86_64")
+    return "arm64" if env in ("arm64", "aarch64") else "x86_64"
+
+
+def darwin_compiler_rt_osx_path(argv: list[str] | None = None) -> str:
+    """Arch-parametric Darwin compiler-rt availability object (.o, not .a)."""
     env = os.environ.get("SWIFTCORE_COMPILER_RT_OSX")
     if env:
         return env
+    arch = _darwin_arch_from_argv(argv or [])
     work = os.environ.get("SWIFTCORE_WORK") or os.path.join(
         os.path.expanduser("~"), "work"
     )
-    return os.path.join(work, "build", "libclang_rt.osx.a")
+    return os.path.join(work, "build", "compiler-rt", f"os_version_check.{arch}.o")
 
 
 def darwin_compiler_rt_link_flags(argv: list[str]) -> list[str]:
-    """Pass Darwin compiler-rt builtins so availability checks resolve.
+    """Pass the availability .o so __isPlatformVersionAtLeast resolves.
 
-    Linux clang has no libclang_rt.osx.a in its resource dir. Overlay links
-    are NOUNDEFS (no -undefined dynamic_lookup), so clang's
-    __isPlatformVersionAtLeast must come from this archive — not libSystem
-    (gen_tbd CHECK 4 vs libswiftcompat) and not a glibc host-bind.
+    Linux clang has no libclang_rt.osx.a. Overlay links are NOUNDEFS, so
+    the compiler-rt TU must be a static object on the link — Apple's
+    shape, not a dylib export (gen_tbd CHECK 4 vs libswiftcompat).
 
-    Do not -force_load: that would pull the member into every Darwin dylib
-    (including ones that never emit an availability check) and surface any
-    leftover undefineds from the TU. Regular archive search is enough when
-    the object refs the symbol.
+    A .o is always linked (the five @_exported-import shells do not
+    reference the symbol; the seven ninja overlays do). Do not wrap it
+    in an archive: GNU ar writes no Mach-O index, and archive search
+    dropped the member on the operator overlay links.
     """
-    path = darwin_compiler_rt_osx_path()
-    if any("libclang_rt.osx.a" in a for a in argv):
+    path = darwin_compiler_rt_osx_path(argv)
+    if any("os_version_check" in a and a.endswith(".o") for a in argv):
         return []
     return [path]
 
@@ -495,7 +507,7 @@ def log_link(
             f"clangxx_darwin_link: cxx_runtime={darwin_cxx_runtime_path(original)}\n"
         )
         sys.stderr.write(
-            f"clangxx_darwin_link: compiler_rt={darwin_compiler_rt_osx_path()}\n"
+            f"clangxx_darwin_link: compiler_rt={darwin_compiler_rt_osx_path(original)}\n"
         )
     elif rewritten is not None:
         sys.stderr.write("clangxx_darwin_link: rewritten argv: " + shlex.join(rewritten) + "\n")

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -190,7 +190,7 @@ write_clang_shim() {
     printf 'export LD64_LLD=%q\n' "${LD64_LLD:-}"
     printf 'export TC=%q\n' "${TC}"
     printf 'export SWIFTCORE_WORK=%q\n' "${W}"
-    printf 'export SWIFTCORE_COMPILER_RT_OSX=%q\n' "${W}/build/libclang_rt.osx.a"
+    printf 'export SWIFTCORE_COMPILER_RT_OSX=%q\n' "${W}/build/compiler-rt/os_version_check.${SWIFTCORE_DARWIN_ARCH}.o"
     printf 'exec %q %q "$@"\n' "$pyexe" "$SCRIPT_DIR/clangxx_darwin_link.py"
   } > "$dest"
   chmod +x "$dest"
@@ -318,6 +318,6 @@ python3 "$SCRIPT_DIR/lipo_single_arch.py" --rewrite-ninja "$B"
 if [ -d "$SDK" ]; then
   export SWIFTCORE_SDKROOT="$SDK"
   export SWIFTCORE_WORK="$W"
-  export SWIFTCORE_COMPILER_RT_OSX="$B/libclang_rt.osx.a"
+  export SWIFTCORE_COMPILER_RT_OSX="$B/compiler-rt/os_version_check.${SWIFTCORE_DARWIN_ARCH}.o"
   bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$SWIFTCORE_COMPILER_RT_OSX"
 fi

--- a/swiftcore-macho/scripts/guest_arch.inc
+++ b/swiftcore-macho/scripts/guest_arch.inc
@@ -112,3 +112,17 @@ STRING_PROCESSING_PIN_COMMIT=91177e6225c63e885872b83d48e254b1270fa15a
 LIBDISPATCH_PIN_COMMIT=2df91f94651f2d924d7506c9d14685929386d779
 STRING_PROCESSING_REPO=https://github.com/swiftlang/swift-experimental-string-processing.git
 LIBDISPATCH_REPO=https://github.com/swiftlang/swift-corelibs-libdispatch.git
+
+# Darwin compiler-rt availability object (arch-parametric). Apple puts this
+# TU in libclang_rt.osx.a; we link os_version_check.${arch}.o into each overlay.
+# SWIFTCORE_COMPILER_RT_OSX, if set, is the concrete path (configure shim).
+swiftcore_compiler_rt_object() {
+    local arch=${1:-${SWIFTCORE_DARWIN_ARCH:?}}
+    if [ -n "${SWIFTCORE_COMPILER_RT_OSX:-}" ]; then
+        printf '%s\n' "$SWIFTCORE_COMPILER_RT_OSX"
+        return 0
+    fi
+    local work=${SWIFTCORE_WORK:-${W:-$HOME/work}}
+    local bdir=${B:-$work/build}
+    printf '%s\n' "$bdir/compiler-rt/os_version_check.${arch}.o"
+}

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -430,8 +430,11 @@ else:
         print("overlay_link: missing cxx_runtime= sysroot libc++.tbd")
         sys.exit(1)
     crt = next((l for l in err.splitlines() if l.startswith("clangxx_darwin_link: compiler_rt=")), "")
-    if "libclang_rt.osx.a" not in crt or "libclang_rt.osx.a" not in executed:
-        print("overlay_link: missing compiler_rt= libclang_rt.osx.a")
+    if "os_version_check" not in crt or ".o" not in crt:
+        print("overlay_link: missing compiler_rt= os_version_check object")
+        sys.exit(1)
+    if "os_version_check" not in executed:
+        print("overlay_link: missing os_version_check.o on Darwin driver argv")
         sys.exit(1)
     if "-platform_version" in executed.split() or (
         "-arch" in executed.split() and "ld64" not in executed

--- a/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
+++ b/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
@@ -67,17 +67,17 @@ printf '%s\n' "$got" | grep -F -- '/root/work/sdk/MacOSX.sdk/usr/lib/libc++.tbd'
   && echo "  OK  sysroot libc++.tbd on the Darwin link" \
   || { echo "  FAIL missing sysroot libc++.tbd"; fail=1; }
 printf '%s\n' "$got" | grep -F -- '-Wl,-force_load,' >/dev/null \
-  && { echo "  FAIL Darwin force-loads compiler-rt (pulls the TU into every dylib)"; fail=1; } \
+  && { echo "  FAIL Darwin force-loads compiler-rt (pulls leftover undefineds)"; fail=1; } \
   || echo "  OK  did not -force_load compiler-rt"
-printf '%s\n' "$got" | grep -F -- 'libclang_rt.osx.a' >/dev/null \
-  && echo "  OK  Darwin compiler-rt builtins archive on the link" \
-  || { echo "  FAIL missing libclang_rt.osx.a"; fail=1; }
+printf '%s\n' "$got" | grep -E 'os_version_check\.(x86_64|arm64)\.o' >/dev/null \
+  && echo "  OK  Darwin compiler-rt availability object on the link" \
+  || { echo "  FAIL missing os_version_check.<arch>.o"; fail=1; }
 grep -q 'clangxx_darwin_link: cxx_runtime=/root/work/sdk/MacOSX.sdk/usr/lib/libc++.tbd' "$tmp/link.err" \
   && echo "  OK  printed cxx_runtime= sysroot tbd" \
   || { echo "  FAIL missing cxx_runtime line"; fail=1; }
 grep -q 'clangxx_darwin_link: compiler_rt=' "$tmp/link.err" \
-  && grep -q 'libclang_rt.osx.a' "$tmp/link.err" \
-  && echo "  OK  printed compiler_rt= builtins archive" \
+  && grep -q 'os_version_check' "$tmp/link.err" \
+  && echo "  OK  printed compiler_rt= availability object" \
   || { echo "  FAIL missing compiler_rt line"; fail=1; }
 printf '%s\n' "$got" | grep -F -- '-fuse-ld=lld' >/dev/null \
   && echo "  OK  kept -fuse-ld=lld (Darwin maps lld → ld64.lld + -platform_version)" \
@@ -121,9 +121,9 @@ printf '%s\n' "$got" | grep -F -- "--ld-path=${LD_LLD}" >/dev/null \
 printf '%s\n' "$got" | grep -F -- 'ld64.lld' >/dev/null \
   && { echo "  FAIL linux-target .so selected ld64.lld"; fail=1; } \
   || echo "  OK  did not select ld64.lld"
-printf '%s\n' "$got" | grep -F -- 'libclang_rt.osx.a' >/dev/null \
-  && { echo "  FAIL ELF link force-loaded Darwin compiler-rt"; fail=1; } \
-  || echo "  OK  ELF link has no Darwin compiler-rt archive"
+printf '%s\n' "$got" | grep -E 'os_version_check\.(x86_64|arm64)\.o|libclang_rt.osx.a' >/dev/null \
+  && { echo "  FAIL ELF link passed Darwin compiler-rt object"; fail=1; } \
+  || echo "  OK  ELF link has no Darwin compiler-rt object"
 assert_decision libswiftCore.so elf ld.lld
 
 echo
@@ -349,32 +349,37 @@ EOF
 fi
 
 echo
-echo "=== Darwin availability check resolves from compiler-rt builtins archive ==="
+echo "=== Darwin availability check resolves from compiler-rt object ==="
 sdk=""
-for d in /home/ubuntu/work/sdk/MacOSX.sdk /root/work/sdk/MacOSX.sdk; do
-  if [ -f "$d/usr/lib/libc++.tbd" ]; then sdk=$d; break; fi
+for d in \
+  "${SWIFTCORE_SDKROOT:-}" \
+  /home/ubuntu/work/sdk/MacOSX.sdk \
+  /root/work/sdk/MacOSX.sdk \
+  "${W:-$HOME/work}/sdk/MacOSX.sdk"
+do
+  [ -n "$d" ] && [ -f "$d/usr/lib/libc++.tbd" ] && { sdk=$d; break; }
 done
-rt_a=""
+rt_o=""
 work=${SWIFTCORE_WORK:-$HOME/work}
 if [ -n "$sdk" ]; then
-  rt_a=$work/build/libclang_rt.osx.a
-  SWIFTCORE_SDKROOT="$sdk" SWIFTCORE_WORK="$work" \
-    SWIFTCORE_COMPILER_RT_OSX="$rt_a" \
-    bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$rt_a"
+  rt_o=$work/build/compiler-rt/os_version_check.x86_64.o
+  SWIFTCORE_SDKROOT="$sdk" SWIFTCORE_WORK="$work" SWIFTCORE_DARWIN_ARCH=x86_64 \
+    SWIFTCORE_COMPILER_RT_OSX="$rt_o" \
+    bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$rt_o"
 fi
 if [ -z "$sdk" ]; then
-  echo "  FAIL no sysroot for availability Darwin link"; fail=1
-elif [ ! -f "$rt_a" ]; then
-  echo "  FAIL compiler-rt archive missing at $rt_a"; fail=1
+  echo "  skip live availability Darwin link (no sysroot libc++.tbd)"
+elif [ ! -f "$rt_o" ]; then
+  echo "  FAIL compiler-rt object missing at $rt_o"; fail=1
 else
-  /usr/lib/llvm-18/bin/llvm-nm "$rt_a" 2>/dev/null \
+  /usr/lib/llvm-18/bin/llvm-nm "$rt_o" 2>/dev/null \
     | grep -q 'isPlatformVersionAtLeast' \
-    && echo "  OK  archive defines isPlatformVersionAtLeast" \
-    || { echo "  FAIL archive missing isPlatformVersionAtLeast"; fail=1; }
-  /usr/lib/llvm-18/bin/llvm-nm "$rt_a" 2>/dev/null \
+    && echo "  OK  object defines isPlatformVersionAtLeast" \
+    || { echo "  FAIL object missing isPlatformVersionAtLeast"; fail=1; }
+  /usr/lib/llvm-18/bin/llvm-nm "$rt_o" 2>/dev/null \
     | grep -q 'isPlatformOrVariantPlatformVersionAtLeast' \
-    && echo "  OK  archive defines isPlatformOrVariantPlatformVersionAtLeast" \
-    || { echo "  FAIL archive missing variant hook"; fail=1; }
+    && echo "  OK  object defines isPlatformOrVariantPlatformVersionAtLeast" \
+    || { echo "  FAIL object missing variant hook"; fail=1; }
   cat > "$tmp/avail.c" <<'EOF'
 /* Deployment target is macosx13.0; 14.0 must go through the runtime hook. */
 int probe(void) {
@@ -406,7 +411,7 @@ EOF
     set +e
     SWIFTCORE_REAL_CLANGXX="$clang_real" \
       SWIFTCORE_WORK="$work" \
-      SWIFTCORE_COMPILER_RT_OSX="$rt_a" \
+      SWIFTCORE_COMPILER_RT_OSX="$rt_o" \
       python3 "$py" \
       -target x86_64-apple-macosx13.0 -isysroot "$sdk" \
       -B/usr/lib/llvm-18/bin -L/usr/lib/llvm-18/lib \
@@ -420,9 +425,9 @@ EOF
     grep -q "undefined symbol:.*isPlatformVersionAtLeast" "$tmp/avail.link.err" \
       && { echo "  FAIL still undefined isPlatformVersionAtLeast"; fail=1; } \
       || echo "  OK  no undefined isPlatformVersionAtLeast"
-    grep -q "compiler_rt=$rt_a" "$tmp/avail.link.err" \
-      && echo "  OK  link printed compiler_rt=$rt_a" \
-      || { echo "  FAIL compiler_rt not the builtins archive"; fail=1; }
+    grep -q "compiler_rt=$rt_o" "$tmp/avail.link.err" \
+      && echo "  OK  link printed compiler_rt=$rt_o" \
+      || { echo "  FAIL compiler_rt not the availability object"; fail=1; }
     grep -q 'unhandled file type' "$tmp/avail.link.err" \
       && { echo "  FAIL still passed ELF libc++.so to ld64"; fail=1; } \
       || echo "  OK  no ELF libc++.so unhandled file type"
@@ -433,7 +438,7 @@ EOF
         || echo "  OK  dylib has no undefined isPlatformVersionAtLeast"
       /usr/lib/llvm-18/bin/llvm-nm "$tmp/libavail.dylib" 2>/dev/null \
         | grep -q 'isPlatformVersionAtLeast' \
-        && echo "  OK  dylib defines isPlatformVersionAtLeast (from archive)" \
+        && echo "  OK  dylib defines isPlatformVersionAtLeast (from object)" \
         || { echo "  FAIL dylib missing isPlatformVersionAtLeast"; fail=1; }
     fi
   fi

--- a/swiftcore-macho/scripts/test_os_version_check.sh
+++ b/swiftcore-macho/scripts/test_os_version_check.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# Prove Darwin overlay availability: a tiny x86_64-macos object that
+# references __isPlatformVersionAtLeast is undefined until linked against
+# the compiler-rt os_version_check.<arch>.o, then llvm-nm no longer reports
+# it undefined. Next to test_sdk_overlays.sh.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+NM=${NM:-/usr/lib/llvm-18/bin/llvm-nm}
+[ -x "$NM" ] || NM=$(command -v llvm-nm-18 || command -v llvm-nm)
+LD64=${LD64_LLD:-/usr/lib/llvm-18/bin/ld64.lld}
+[ -x "$LD64" ] || LD64=$(command -v ld64.lld-18 || command -v ld64.lld)
+CC=$(command -v clang-18 || command -v clang)
+
+find_complete_sdk() {
+  local d
+  for d in \
+    "${SWIFTCORE_SDKROOT:-}" \
+    "${SWIFTCORE_DARWIN_SDK:-}" \
+    "${W:-$HOME/work}/sdk/MacOSX.sdk" \
+    /root/work/sdk/MacOSX.sdk \
+    /home/ubuntu/work/sdk/MacOSX.sdk
+  do
+    [ -n "$d" ] || continue
+    if [ -f "$d/usr/include/dispatch/dispatch.h" ] \
+        && [ -f "$d/usr/include/dlfcn.h" ] \
+        && { [ -f "$d/usr/include/CoreFoundation/CoreFoundation.h" ] \
+          || [ -f "$d/System/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h" ]; } \
+        && [ -f "$d/usr/include/i386/types.h" ]; then
+      printf '%s\n' "$d"
+      return 0
+    fi
+  done
+  return 1
+}
+
+assemble_union_sdk() {
+  local dest=$1
+  local inc_src cf_src
+  inc_src=""
+  for d in "$ROOT/machorun/sdk" /workspace/machorun/sdk; do
+    if [ -f "$d/usr/include/i386/types.h" ] && [ -f "$d/usr/include/dispatch/dispatch.h" ]; then
+      inc_src=$d
+      break
+    fi
+  done
+  cf_src=""
+  for d in "$ROOT/scratch/sysroot_fe4" /workspace/scratch/sysroot_fe4; do
+    if [ -f "$d/usr/include/CoreFoundation/CoreFoundation.h" ]; then
+      cf_src=$d
+      break
+    fi
+  done
+  if [ -z "$inc_src" ] || [ -z "$cf_src" ]; then
+    echo "cannot assemble union SDK (need machorun i386+dispatch and fe4 CoreFoundation)" >&2
+    return 1
+  fi
+  mkdir -p "$dest/usr"
+  cp -a "$inc_src/usr/include" "$dest/usr/include"
+  if [ ! -f "$dest/usr/include/CoreFoundation/CoreFoundation.h" ]; then
+    cp -a "$cf_src/usr/include/CoreFoundation" "$dest/usr/include/"
+  fi
+  printf '%s\n' "$dest"
+}
+
+echo "=== missing sysroot headers fail loudly ==="
+empty=$tmp/empty-sdk
+mkdir -p "$empty/usr/include"
+set +e
+out=$(SWIFTCORE_SDKROOT="$empty" SWIFTCORE_DARWIN_ARCH=x86_64 \
+  bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$tmp/should-not-exist.o" 2>&1)
+st=$?
+set -e
+printf '%s\n' "$out" | tail -8
+[ "$st" -ne 0 ] && echo "  OK  missing headers rc=$st" \
+  || { echo "  FAIL compiled without dispatch/dlfcn/CF headers"; fail=1; }
+printf '%s\n' "$out" | grep -q 'lacks <dispatch/dispatch.h>' \
+  && echo "  OK  named missing <dispatch/dispatch.h>" \
+  || { echo "  FAIL did not name dispatch.h"; fail=1; }
+[ ! -f "$tmp/should-not-exist.o" ] && echo "  OK  no object on header failure" \
+  || { echo "  FAIL wrote object despite missing headers"; fail=1; }
+
+sdk=$(find_complete_sdk) || sdk=""
+if [ -z "$sdk" ]; then
+  echo "no full MacOSX.sdk; assembling a header union for this VM"
+  sdk=$(assemble_union_sdk "$tmp/MacOSX.sdk") || sdk=""
+fi
+if [ -z "$sdk" ]; then
+  echo "FAIL no Darwin sysroot with <dispatch/dispatch.h>, <dlfcn.h>, CoreFoundation, i386/types.h"
+  exit 1
+fi
+echo "sdk=$sdk"
+echo "ld64=$LD64"
+echo "nm=$NM"
+
+echo
+echo "=== compile os_version_check.c for x86_64-apple-macos ==="
+rt_o=$tmp/os_version_check.x86_64.o
+set +e
+build_out=$(SWIFTCORE_SDKROOT="$sdk" SWIFTCORE_DARWIN_ARCH=x86_64 \
+  SWIFTCORE_WORK="$tmp/work" \
+  bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$rt_o" 2>&1)
+st=$?
+set -e
+printf '%s\n' "$build_out"
+[ "$st" -eq 0 ] && [ -f "$rt_o" ] && echo "  OK  x86_64 object rc=0" \
+  || { echo "  FAIL compile availability object rc=$st"; fail=1; }
+printf '%s\n' "$build_out" | grep -q 'header <dispatch/dispatch.h>' \
+  && echo "  OK  found dispatch.h" || { echo "  FAIL no dispatch.h probe"; fail=1; }
+printf '%s\n' "$build_out" | grep -q 'header <dlfcn.h>' \
+  && echo "  OK  found dlfcn.h" || { echo "  FAIL no dlfcn.h probe"; fail=1; }
+printf '%s\n' "$build_out" | grep -q 'header <CoreFoundation/CoreFoundation.h>' \
+  && echo "  OK  found CoreFoundation.h" || { echo "  FAIL no CF header probe"; fail=1; }
+
+echo
+echo "=== arch-parametric: arm64 object (even if this host is x86_64) ==="
+rt_arm=$tmp/os_version_check.arm64.o
+set +e
+arm_out=$(SWIFTCORE_SDKROOT="$sdk" SWIFTCORE_DARWIN_ARCH=arm64 \
+  bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$rt_arm" 2>&1)
+arm_st=$?
+set -e
+printf '%s\n' "$arm_out" | tail -6
+[ "$arm_st" -eq 0 ] && [ -f "$rt_arm" ] && echo "  OK  arm64 object rc=0" \
+  || { echo "  FAIL arm64 availability object rc=$arm_st"; fail=1; }
+if [ -f "$rt_arm" ]; then
+  "$NM" "$rt_arm" 2>/dev/null | grep -q 'isPlatformVersionAtLeast' \
+    && echo "  OK  arm64 object defines isPlatformVersionAtLeast" \
+    || { echo "  FAIL arm64 object missing symbol"; fail=1; }
+fi
+
+echo
+echo "=== tiny x86_64-macos object references __isPlatformVersionAtLeast ==="
+cat > "$tmp/ref.c" <<'EOF'
+#include <stdint.h>
+int32_t __isPlatformVersionAtLeast(uint32_t, uint32_t, uint32_t, uint32_t);
+int probe(void) {
+  return __isPlatformVersionAtLeast(1, 14, 0, 0);
+}
+EOF
+set +e
+"$CC" -c -target x86_64-apple-macosx13.0 -isysroot "$sdk" \
+  -o "$tmp/ref.o" "$tmp/ref.c" 2>"$tmp/ref.err"
+c_st=$?
+set -e
+if [ "$c_st" -ne 0 ]; then
+  echo "  FAIL compile ref.c rc=$c_st"; cat "$tmp/ref.err"; fail=1
+else
+  echo "--- llvm-nm ref.o (before link) ---"
+  "$NM" "$tmp/ref.o" | tee "$tmp/ref.nm"
+  if "$NM" "$tmp/ref.o" | grep -E 'isPlatformVersionAtLeast' | grep -q ' U '; then
+    echo "  OK  ref.o has undefined isPlatformVersionAtLeast"
+  else
+    echo "  FAIL ref.o does not show undefined isPlatformVersionAtLeast"
+    fail=1
+  fi
+fi
+
+echo
+echo "=== ld64.lld: ref.o + os_version_check.x86_64.o ==="
+if [ ! -f "$rt_o" ] || [ ! -f "$tmp/ref.o" ]; then
+  echo "  FAIL missing inputs for ld64.lld"; fail=1
+else
+  set +e
+  "$LD64" -arch x86_64 -dylib \
+    -platform_version macos 13.0 13.0 \
+    -undefined dynamic_lookup \
+    -o "$tmp/libavail.dylib" \
+    "$tmp/ref.o" "$rt_o" \
+    >"$tmp/ld64.out" 2>"$tmp/ld64.err"
+  l_st=$?
+  set -e
+  cat "$tmp/ld64.out" "$tmp/ld64.err" || true
+  [ "$l_st" -eq 0 ] && echo "  OK  ld64.lld rc=0" \
+    || { echo "  FAIL ld64.lld rc=$l_st"; fail=1; }
+  if grep -q "undefined symbol:.*isPlatformVersionAtLeast" "$tmp/ld64.err"; then
+    echo "  FAIL ld64.lld still undefined isPlatformVersionAtLeast"
+    fail=1
+  else
+    echo "  OK  ld64.lld did not report undefined isPlatformVersionAtLeast"
+  fi
+  if [ -f "$tmp/libavail.dylib" ]; then
+    echo "--- llvm-nm libavail.dylib (after link) ---"
+    "$NM" "$tmp/libavail.dylib" | grep -E 'isPlatformVersionAtLeast|isPlatformOrVariant' \
+      | tee "$tmp/dylib.nm" || true
+    if "$NM" "$tmp/libavail.dylib" | grep -E 'isPlatformVersionAtLeast' | grep -q ' U '; then
+      echo "  FAIL dylib still has undefined isPlatformVersionAtLeast"
+      fail=1
+    else
+      echo "  OK  llvm-nm no longer reports isPlatformVersionAtLeast undefined"
+    fi
+    if "$NM" "$tmp/libavail.dylib" | grep -q 'isPlatformVersionAtLeast'; then
+      echo "  OK  dylib defines isPlatformVersionAtLeast from the builtin object"
+    else
+      echo "  FAIL dylib missing isPlatformVersionAtLeast"
+      fail=1
+    fi
+  fi
+fi
+
+echo
+echo "=== clangxx_darwin_link argv includes the object (x86_64 and arm64) ==="
+py=$SCRIPT_DIR/clangxx_darwin_link.py
+got=$(SWIFTCORE_CLANGXX_PRINT_REWRITTEN=1 \
+  SWIFTCORE_COMPILER_RT_OSX="$rt_o" \
+  python3 "$py" -target x86_64-apple-macosx13.0 -isysroot "$sdk" \
+  -shared -o libswiftDarwin.so Darwin.o 2>"$tmp/shim.err")
+printf '%s\n' "$got" | grep -F -- "$rt_o" >/dev/null \
+  && echo "  OK  x86_64 Darwin driver argv has the object" \
+  || { echo "  FAIL x86_64 argv missing object"; echo "$got"; fail=1; }
+got_arm=$(SWIFTCORE_CLANGXX_PRINT_REWRITTEN=1 \
+  SWIFTCORE_COMPILER_RT_OSX="$rt_arm" \
+  python3 "$py" -target arm64-apple-macosx13.0 -isysroot "$sdk" \
+  -shared -o libswiftDarwin.so Darwin.o 2>"$tmp/shim.arm.err")
+printf '%s\n' "$got_arm" | grep -F -- "$rt_arm" >/dev/null \
+  && echo "  OK  arm64 Darwin driver argv has the object" \
+  || { echo "  FAIL arm64 argv missing object"; echo "$got_arm"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- os_version_check.<arch>.o resolves __isPlatformVersionAtLeast for ld64.lld"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
+++ b/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
@@ -477,9 +477,9 @@ printf '%s\n' "$out" | grep -q 'clangxx_darwin_link: cxx_runtime=/root/work/sdk/
   && echo "  OK  cxx_runtime= sysroot libc++.tbd" \
   || { echo "  FAIL missing cxx_runtime tbd"; fail=1; }
 printf '%s\n' "$out" | grep -q 'clangxx_darwin_link: compiler_rt=' \
-  && printf '%s\n' "$out" | grep 'overlay_link: driver argv' | grep -q 'libclang_rt.osx.a' \
-  && echo "  OK  driver argv passes compiler-rt builtins" \
-  || { echo "  FAIL missing compiler_rt / libclang_rt.osx.a on Darwin link"; fail=1; }
+  && printf '%s\n' "$out" | grep 'overlay_link: driver argv' | grep -q 'os_version_check' \
+  && echo "  OK  driver argv passes compiler-rt availability object" \
+  || { echo "  FAIL missing compiler_rt / os_version_check.o on Darwin link"; fail=1; }
 
 echo
 echo "=== cmake : && clang++ && : wrapper is stripped before rewrite ==="

--- a/swiftcore-macho/scripts/test_sdk_overlays.sh
+++ b/swiftcore-macho/scripts/test_sdk_overlays.sh
@@ -41,6 +41,9 @@ if [ -f "$SDK/usr/include/Darwin.modulemap" ] \
     && echo "  OK  cxx_runtime printed" || { echo "  FAIL missing cxx_runtime"; fail=1; }
   printf '%s\n' "$out" | grep -q 'compiler_rt=' \
     && echo "  OK  compiler_rt printed" || { echo "  FAIL missing compiler_rt"; fail=1; }
+  printf '%s\n' "$out" | grep -q 'os_version_check' \
+    && echo "  OK  availability object on overlay link" \
+    || { echo "  FAIL missing os_version_check.o on overlay link"; fail=1; }
   printf '%s\n' "$out" | grep -q '/usr/lib/llvm-18/lib' \
     && { echo "  FAIL Darwin link still has /usr/lib/llvm-18/lib"; fail=1; } \
     || echo "  OK  no host llvm-18/lib on Darwin links"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR #56 scoreboard (x86_64 box i-0a2e25f3895c819b3)

```
clangxx_darwin_link: cxx_runtime=/root/work/sdk/MacOSX.sdk/usr/lib/libc++.tbd
OVERLAY swift_Concurrency-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __isPlatformVersionAtLeast
OVERLAY swiftSynchronization-macosx-x86_64 FAILED dep=swiftDarwin
OVERLAY swift_StringProcessing-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __isPlatformVersionAtLeast
OVERLAY swift_Builtin_float-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __isPlatformVersionAtLeast
OVERLAY swift_RegexParser-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __isPlatformVersionAtLeast
OVERLAY swiftObservation-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __isPlatformVersionAtLeast
OVERLAY swiftDarwin-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __isPlatformVersionAtLeast
OVERLAY swift_DarwinFoundation1-macosx-x86_64 built
OVERLAY swift_DarwinFoundation2-macosx-x86_64 built
OVERLAY swift_DarwinFoundation3-macosx-x86_64 built
OVERLAY swift_errno-macosx-x86_64 built
OVERLAY swiftObjectiveC-macosx-x86_64 built
overlay: FAILED rc=1
```

The five shells are `@_exported import` re-exports (`overlays/_DarwinFoundation{1,2,3}.swift`, `_errno.swift`, `ObjectiveC.swift`) with no `@available` / `if #available`, so clang never emits `__isPlatformVersionAtLeast`. Their link inputs are the shell `.o` + `-lswiftCore -lSystem -lobjc` + sysroot `libc++.tbd`. The seven ninja overlays (`Darwin`, `_Concurrency`, `_StringProcessing`, `_RegexParser`, `_Builtin_float`, `Observation`, and `Synchronization` via Darwin) compile real stdlib sources that do availability lowering; overlay links are NOUNDEFS (no `-undefined dynamic_lookup`). `libswiftCore` still uses `link_macho_dylib.sh` `dynamic_lookup`, which is how the arm64 core / earlier x86 core links survived. `libswiftcompat` defines the symbol for the ELF compat dylib; gen_tbd CHECK 4 already refuses exporting it from libSystem. The Linux clang driver never adds Darwin `libclang_rt.osx.a`. The symbol is absent from every sysroot `.tbd` and from Apple's libSystem — it is a static compiler-rt builtin.

## Mechanism

Reuse the in-tree compiler-rt TU (`swiftcore-macho/compiler-rt/os_version_check.c`), not a second dylib export. Compile it the way Apple does — as a **static object** linked into each overlay:

- `scripts/build_compiler_rt_osx.sh` emits `$W/build/compiler-rt/os_version_check.${ARCH}.o` (`x86_64` and `arm64`) with the overlay Darwin driver argv (`-target ${ARCH}-apple-macos`, `-isysroot $SYS`).
- Fails loudly if the sysroot lacks `<dispatch/dispatch.h>`, `<dlfcn.h>`, or CoreFoundation headers.
- `clangxx_darwin_link.py` appends the `.o` on every Darwin shared link (ninja overlays).
- `build_sdk_overlays.sh` `link_overlay` passes the same `.o` next to the shell object (five shells unchanged except this uniform builtin).
- A `.o` is always linked. Archive search / GNU `ar` (no Mach-O index) dropped the member on the seven overlays after PR #56.

`crt_os_version_once_f` stands in for `dispatch_once_f` because gen_tbd `libSystem.tbd` does not export it (Apple puts it in libdispatch). Compile still `#include`s `<dispatch/dispatch.h>`.

## compiler-rt source pin

| | |
|---|---|
| file | `compiler-rt/lib/builtins/os_version_check.c` |
| tag | `llvmorg-18.1.8` (Ubuntu clang 18.1.3) |
| commit | `76caf4176cd7877ad5952737d56da6f515ee4602` |
| license | `swiftcore-macho/compiler-rt/LICENSE.TXT` (Apache-2.0 WITH LLVM-exception) |
| pin record | `swiftcore-macho/compiler-rt/SOURCE.txt` |

`__isPlatformOrVariantPlatformVersionAtLeast` is not in 18.1.8; copied from llvm-project main into the same TU.

## Runtime under machorun (plist absent)

Vanilla compiler-rt dlopens CoreFoundation and `fopen`s `/System/Library/CoreServices/SystemVersion.plist`. If that plist is absent: `fopen` fails, `GlobalMajor/Minor/Subminor` stay BSS **`(0,0,0)`**, the weak-import `_availability_version_check` is NULL, and every `@available` check against a real macOS version returns **0**. It does **not** crash. machorun note: `(0,0,0)` is not “all APIs present”; ship a SystemVersion.plist or dyld’s checker if guests need `@available` to succeed. (An earlier always-yes `_availability_version_check` in this TU was withdrawn so the object matches Apple.)

## nm proof (`scripts/test_os_version_check.sh`)

ld64.lld 18.1.3 on this VM:

```
--- llvm-nm ref.o (before link) ---
                 U ___isPlatformVersionAtLeast

=== ld64.lld: ref.o + os_version_check.x86_64.o ===
  OK  ld64.lld rc=0

--- llvm-nm libavail.dylib (after link) ---
0000000000000700 T ___isPlatformOrVariantPlatformVersionAtLeast
0000000000000640 T ___isPlatformVersionAtLeast
  OK  llvm-nm no longer reports isPlatformVersionAtLeast undefined
```

Missing-header compile fails with `sysroot … lacks <dispatch/dispatch.h>`. Arm64 object is built on the x86 host as well.

## Operator command

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

Expected scoreboard: all twelve overlays **built**.

```
OVERLAY swift_Concurrency-macosx-x86_64 built
OVERLAY swiftSynchronization-macosx-x86_64 built
OVERLAY swift_StringProcessing-macosx-x86_64 built
OVERLAY swift_Builtin_float-macosx-x86_64 built
OVERLAY swift_RegexParser-macosx-x86_64 built
OVERLAY swiftObservation-macosx-x86_64 built
OVERLAY swiftDarwin-macosx-x86_64 built
OVERLAY swift_DarwinFoundation1-macosx-x86_64 built
OVERLAY swift_DarwinFoundation2-macosx-x86_64 built
OVERLAY swift_DarwinFoundation3-macosx-x86_64 built
OVERLAY swift_errno-macosx-x86_64 built
OVERLAY swiftObjectiveC-macosx-x86_64 built
```

Does not touch `machorun/` or `uikit/`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edee8312-86af-48a6-bbb4-0254b84b99b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edee8312-86af-48a6-bbb4-0254b84b99b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

