### PR TITLE
Build full Darwin compiler-rt builtins; re-export DarwinFoundation shells from libswiftDarwin

### DIFF
--- a/scripts/x86/test_gen_swift_tbd.sh
+++ b/scripts/x86/test_gen_swift_tbd.sh
@@ -69,6 +69,68 @@ while IFS= read -r name; do
     n_checked=$((n_checked + 1))
 done < <({ printf 'libswiftCore.dylib\n'; phase2_twelve_overlay_names; })
 
+# Synthetic Darwin with Apple's four LC_REEXPORT_DYLIB: gen_swift_tbd must
+# record them under reexported-libraries. Committed artifacts may still lack
+# re-exports until the operator rebuilds; this tooth does not wait on that.
+echo
+echo "=== synthetic Darwin LC_REEXPORT_DYLIB round-trip ==="
+clang_c=$(command -v clang-18 || command -v clang)
+echo 'void _swift_reexport_stub(void) {}' | "$clang_c" -target x86_64-apple-macosx13.0 -c -o "$WORK/stub.o" -x c -
+for n in libswift_Builtin_float libswift_DarwinFoundation1 \
+         libswift_DarwinFoundation2 libswift_DarwinFoundation3; do
+    /usr/lib/llvm-18/bin/ld64.lld -arch x86_64 -dylib \
+        -platform_version macos 13.0.0 13.0.0 \
+        -install_name /usr/lib/swift/${n}.dylib \
+        -o "$WORK/${n}.dylib" "$WORK/stub.o"
+done
+echo 'int darwin_overlay(void) { return 1; }' | "$clang_c" -target x86_64-apple-macosx13.0 -c -o "$WORK/Darwin.o" -x c -
+/usr/lib/llvm-18/bin/ld64.lld -arch x86_64 -dylib \
+    -platform_version macos 13.0.0 13.0.0 \
+    -install_name /usr/lib/swift/libswiftDarwin.dylib \
+    -reexport_library "$WORK/libswift_Builtin_float.dylib" \
+    -reexport_library "$WORK/libswift_DarwinFoundation1.dylib" \
+    -reexport_library "$WORK/libswift_DarwinFoundation2.dylib" \
+    -reexport_library "$WORK/libswift_DarwinFoundation3.dylib" \
+    -o "$WORK/libswiftDarwin.reexport.dylib" "$WORK/Darwin.o"
+dest=$WORK/libswiftDarwin.reexport.tbd
+if bash "$GEN" "$WORK/libswiftDarwin.reexport.dylib" "$dest"; then
+    ok "emit tbd from Darwin with four LC_REEXPORT_DYLIB"
+else
+    die_test "emit failed for synthetic Darwin reexport dylib"
+fi
+if grep -q 'reexported-libraries:' "$dest"; then
+    ok "libswiftDarwin.tbd has reexported-libraries"
+else
+    die_test "synthetic Darwin tbd missing reexported-libraries"
+fi
+for n in libswift_Builtin_float.dylib libswift_DarwinFoundation1.dylib \
+         libswift_DarwinFoundation2.dylib libswift_DarwinFoundation3.dylib; do
+    grep -q "/usr/lib/swift/$n" "$dest" \
+        && ok "tbd reexports /usr/lib/swift/$n" \
+        || die_test "tbd missing reexport $n"
+done
+# Live artifact Darwin (pre-rebuild) is allowed to lack re-exports; if it
+# already has them, require exactly those four.
+art=$ROOT/swiftcore-macho/artifacts/swift-macosx/x86_64/libswiftDarwin.dylib
+if [ -f "$art" ]; then
+    rx=$(llvm-otool-18 -l "$art" 2>/dev/null \
+        | awk '/LC_REEXPORT_DYLIB/{f=1} f&&/^ *name /{print $2; f=0}' | sort -u)
+    if [ -z "$rx" ]; then
+        ok "artifact libswiftDarwin has no LC_REEXPORT yet (operator rebuild adds the four)"
+    else
+        want=$(printf '%s\n' \
+            /usr/lib/swift/libswift_Builtin_float.dylib \
+            /usr/lib/swift/libswift_DarwinFoundation1.dylib \
+            /usr/lib/swift/libswift_DarwinFoundation2.dylib \
+            /usr/lib/swift/libswift_DarwinFoundation3.dylib | sort -u)
+        if [ "$rx" = "$want" ]; then
+            ok "artifact libswiftDarwin has exactly four LC_REEXPORT_DYLIB"
+        else
+            die_test "artifact libswiftDarwin LC_REEXPORT drifted: $rx"
+        fi
+    fi
+fi
+
 [ "$n_want" -eq 13 ] \
     && ok "round-trip inventory is libswiftCore + twelve overlays" \
     || die_test "inventory count=$n_want want 13 (Core + twelve)"

--- a/swiftcore-macho/docs/X86_64.md
+++ b/swiftcore-macho/docs/X86_64.md
@@ -200,23 +200,53 @@ link prints `clangxx_darwin_link: cxx_runtime=<tbd>`. Overlay links are
 NOUNDEFS (no `-undefined dynamic_lookup`), so clang's availability
 lowering (`__isPlatformVersionAtLeast` /
 `__isPlatformOrVariantPlatformVersionAtLeast`) must resolve at **link**.
-Those live in compiler-rt builtins (`libclang_rt.osx.a`,
-`os_version_check.c`); this Linux clang has no Darwin compiler-rt in its
-resource dir, and gen_tbd `libSystem.tbd` does not export them. Route
-(b) — adding them to machorun libSystem / the tbd — is closed:
-`machorun/darwin/src` has no definition, `host-bound-allowed.txt` does
-not list them (glibc has no such symbol; not a CHECK 5 host-bind), and
-`UNIMPLEMENTED.md` records that a libSystem definition was added then
-reverted because gen_tbd CHECK 4 already sees them in `libswiftcompat`.
-`scripts/build_compiler_rt_osx.sh` compiles the vendored
-`compiler-rt/os_version_check.c` (pinned `llvmorg-18.1.8`, variant from
-llvm-project main) for `x86_64-apple-macos` and Darwin links pass
-`$W/build/libclang_rt.osx.a` (archive search, not `-force_load`). Each Darwin link prints
-`clangxx_darwin_link: compiler_rt=<archive>`. Runtime agrees with
-`libswiftcompat` (`swiftcompat.c`: every check is “yes” because we
-emulate a full deployment target) via a strong `_availability_version_check`
-in that TU — not vanilla compiler-rt's CoreFoundation plist fallback
-(which would return 0 under machorun).
+Those live in compiler-rt builtins (`libclang_rt.osx.a`). This Linux clang
+has no Darwin compiler-rt in its resource dir, and gen_tbd `libSystem.tbd`
+does not export them. Route (b) — adding them to machorun libSystem / the
+tbd — is closed: `machorun/darwin/src` has no definition,
+`host-bound-allowed.txt` does not list them (glibc has no such symbol; not
+a CHECK 5 host-bind), and `UNIMPLEMENTED.md` records that a libSystem
+definition was added then reverted because gen_tbd CHECK 4 already sees
+them in `libswiftcompat`. Vendoring builtins one file per failure is the
+wrong shape: Apple's `libclang_rt.osx.a` is the whole generic C builtins
+library and ld64 archive-searches whatever members the overlays reference
+(`__divti3`, `__udivti3`, `__floattidf`, `__isPlatformVersionAtLeast`, …).
+`scripts/build_compiler_rt_osx.sh` fetches pinned llvm-project compiler-rt
+**llvmorg-18.1.8** (`3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff`; tarball
+sha256 `e054e99a9c9240720616e927cb52363abbc8b4f1ef0286bad3df79ec8fdf892f`)
+into `scratch/` (do not commit the sources) and compiles `lib/builtins/*.c`
+plus the x86_64 `.S`/`.c` files Apple includes for that arch. Files that
+need a Darwin kernel header the sysroot lacks are skipped and printed
+(`compiler-rt excluded:`). In-tree `compiler-rt/os_version_check.c` keeps
+the PR #60 override (always-yes `_availability_version_check`, local
+`dispatch_once_f`). The archive is indexed with `llvm-ar` (Mach-O TOC).
+Each Darwin link prints `clangxx_darwin_link: compiler_rt=<archive>`
+(archive search, not `-force_load`) and a one-line
+`compiler-rt darwin builtins: members=N arch=x86_64 sha256=…`.
+`scripts/test_compiler_rt_osx.sh` links a tiny x86_64-macos object that
+references `__divti3`, `__udivti3`, `__floattidf`,
+`__isPlatformVersionAtLeast` against the archive; `llvm-nm -u` reports
+none of them undefined.
+
+**libswiftDarwin re-exports the four shells.** Apple's x86_64
+`libswiftDarwin.dylib` carries `LC_REEXPORT_DYLIB` of
+`/usr/lib/swift/libswift_Builtin_float.dylib`,
+`libswift_DarwinFoundation1.dylib`, `libswift_DarwinFoundation2.dylib`,
+`libswift_DarwinFoundation3.dylib` (154 own exports + those four
+re-exports). Apple's `libswiftDarwin.tbd` lists them under
+`reexported-libraries`, so a consumer that references
+`__swift_FORCE_LOAD_$_swift_DarwinFoundation1` (every Darwin importer —
+the shells are built `-autolink-force-load`) records the bind against
+libswiftDarwin and never records DarwinFoundation1 itself. Our overlay
+link recipe now passes `-Xlinker -reexport_library` of those four when
+linking `libswiftDarwin` (`clangxx_darwin_link.py`; no other overlay).
+`overlay_build_xcode_shells` runs **before** the Darwin ninja target, and
+`overlay_candidate_targets` ninja's `swift_Builtin_float` before
+`swiftDarwin`. `scripts/x86/gen_swift_tbd.sh` already records
+`reexported-libraries` from `LC_REEXPORT_DYLIB`. machorun already follows
+`LC_REEXPORT_DYLIB` for two-level binds (libSystem umbrellas); no loader
+change. Do not `-undefined dynamic_lookup`, do not export builtins from
+gen_tbd libSystem, do not touch `libswiftcompat`.
 `-target …-unknown-linux-gnu` is ELF:
 `--ld-path=`**ld.lld**, keep `-soname`. Each shared link prints
 `clangxx_darwin_link: -o <path> decision={darwin|elf} linker={ld64.lld|ld.lld}`.
@@ -244,7 +274,8 @@ are **not** CMake targets on Linux (`stdlib/public/CMakeLists.txt:359`).
 for the ninja graph, then `overlay_build_xcode_shells` compiles them with
 the Darwin overlay argv (`-autolink-force-load`, not `-parse-stdlib`) and
 links with `clangxx_darwin_link.py` (sysroot `libc++.tbd`,
-`libclang_rt.osx.a` for `__isPlatformVersionAtLeast`, no
+`libclang_rt.osx.a` for compiler-rt builtins (`__isPlatformVersionAtLeast`,
+`__divti3`, …), no
 `/usr/lib/llvm-18/lib`). Scoreboard becomes `built` when the dylibs land.
 Empty `SWIFT_LIPO` used to make ninja run
 `cmake -E env -create` (Ubuntu cmake 3.28: `unknown option '-create'`),
@@ -260,7 +291,7 @@ if asked to merge slices).
 | `_Concurrency` | **yes** — staged Mach-O x86_64 | `CANNOT_FETCH_LIBDISPATCH_SOURCE` if checkout missing. Missing CMake `dispatch` node was host-vs-target; patch 8 skips that LINK_LIBRARIES append when `SWIFT_PRIMARY_VARIANT_SDK` ∈ `SWIFT_DARWIN_PLATFORMS`. |
 | `_StringProcessing` / `Synchronization` / `_RegexParser` | **yes** — staged | `CANNOT_FETCH_STRING_PROCESSING_SOURCE`; `CANNOT_OVERLAY_TARGET_ABSENT` if the ninja target is missing |
 | Observation | **yes** — staged | `CANNOT_OVERLAY_TARGET_ABSENT` if cmake did not create it |
-| `swiftDarwin` | sysroot has Apple POSIX overlay headers **and** a Clang `Darwin` module. Staging is **input-keyed** (`.overlay-sysroot-inputs`, recipe `overlay-darwin.4`): recipe + sha of overlay-darwin `math.h` / `MacTypes.h` / `ConditionalMacros.h` / modulemap recipe + machorun `sys/proc.h`. Required *staged* headers (`math.h`, `sys/proc.h`, `MacTypes.h`, `ConditionalMacros.h`, `Darwin.modulemap`) must be on disk — input-sha MATCH is not presence (`CANNOT_OVERLAY_SYSROOT_HEADER`). Every `header "…"` in the Darwin Clang overlay maps (`usr/include/module.modulemap` + `Darwin*.modulemap`) must resolve under `usr/include` **before cmake** (`overlay_sysroot_modulemap_missing_entries`, using `phase2_modulemap_quoted_headers`). `usr/include/c++/v1/module.modulemap` (libc++ `algorithm`, `any`, …) is **outside** that closure: overlay ninja compiles pass `-sdk` only (no `-fmodule-map-file` for libc++), and the swiftinterfaces import Darwin/Swift/SwiftShims not `std`. `full/foundation/stage_fe_sysroot.sh` does not stage libc++ into the FE sysroot. Each leftover name is printed as `header=… map=…` / `CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER missing=complex.h@usr/include/DarwinFoundation1.modulemap`. Missing Darwin names are filled from the FE sysroot / `full/sdk-gaps` (complex.h) / machorun / overlay-darwin pins. A pre-existing `$W/sdk/MacOSX.sdk` whose stamp mismatches is **displaced** (`MacOSX.sdk.stale-<utc>`), never `rm -rf`'d, and restaged into a fresh `MacOSX.sdk.overlay-<id>`. `.tbd` stubs are copied into that dest from the still-live tree / machorun `gen_tbd` **before** displacement; empty `usr/lib/*.tbd` is `CANNOT_OVERLAY_SYSROOT_TBDS tree=… realpath=… searched=…`. `configure.sh` prints each required header's sha **before ninja** and refuses `CANNOT_OVERLAY_SYSROOT_MATH_H` / `PROC_H` if `math.h` lacks `fmaxl` or `sys/proc.h` lacks `extern_proc`. Darwin.o `-sdk` / `-isysroot` comes from `ninja -t commands`. The Darwin dylib link is printed as `overlay_link: ninja` plus `overlay_link: rewritten` (no `-soname`). FE sysroot `math.h` without `fmaxl` or missing CarbonHeaders files are repaired from the pins. | ninja failure is `OVERLAY swiftDarwin-macosx-* FAILED first_error=…`. Synchronization **depends on** `libswiftDarwin.so` (`FAILED dep=swiftDarwin`). `_Concurrency` / `_StringProcessing` / `_Builtin_float` do **not**; a failure there prints their own `first_error`. |
+| `swiftDarwin` | sysroot has Apple POSIX overlay headers **and** a Clang `Darwin` module. Staging is **input-keyed** (`.overlay-sysroot-inputs`, recipe `overlay-darwin.4`): recipe + sha of overlay-darwin `math.h` / `MacTypes.h` / `ConditionalMacros.h` / modulemap recipe + machorun `sys/proc.h`. Required *staged* headers (`math.h`, `sys/proc.h`, `MacTypes.h`, `ConditionalMacros.h`, `Darwin.modulemap`) must be on disk — input-sha MATCH is not presence (`CANNOT_OVERLAY_SYSROOT_HEADER`). Every `header "…"` in the Darwin Clang overlay maps (`usr/include/module.modulemap` + `Darwin*.modulemap`) must resolve under `usr/include` **before cmake** (`overlay_sysroot_modulemap_missing_entries`, using `phase2_modulemap_quoted_headers`). `usr/include/c++/v1/module.modulemap` (libc++ `algorithm`, `any`, …) is **outside** that closure: overlay ninja compiles pass `-sdk` only (no `-fmodule-map-file` for libc++), and the swiftinterfaces import Darwin/Swift/SwiftShims not `std`. `full/foundation/stage_fe_sysroot.sh` does not stage libc++ into the FE sysroot. Each leftover name is printed as `header=… map=…` / `CANNOT_OVERLAY_SYSROOT_MODULEMAP_HEADER missing=complex.h@usr/include/DarwinFoundation1.modulemap`. Missing Darwin names are filled from the FE sysroot / `full/sdk-gaps` (complex.h) / machorun / overlay-darwin pins. A pre-existing `$W/sdk/MacOSX.sdk` whose stamp mismatches is **displaced** (`MacOSX.sdk.stale-<utc>`), never `rm -rf`'d, and restaged into a fresh `MacOSX.sdk.overlay-<id>`. `.tbd` stubs are copied into that dest from the still-live tree / machorun `gen_tbd` **before** displacement; empty `usr/lib/*.tbd` is `CANNOT_OVERLAY_SYSROOT_TBDS tree=… realpath=… searched=…`. `configure.sh` prints each required header's sha **before ninja** and refuses `CANNOT_OVERLAY_SYSROOT_MATH_H` / `PROC_H` if `math.h` lacks `fmaxl` or `sys/proc.h` lacks `extern_proc`. Darwin.o `-sdk` / `-isysroot` comes from `ninja -t commands`. The Darwin dylib link is printed as `overlay_link: ninja` plus `overlay_link: rewritten` (no `-soname`). FE sysroot `math.h` without `fmaxl` or missing CarbonHeaders files are repaired from the pins. Linked with `-reexport_library` of `_Builtin_float` + `_DarwinFoundation{1,2,3}` so `LC_REEXPORT_DYLIB` matches Apple (gen_swift_tbd then emits `reexported-libraries`). | ninja failure is `OVERLAY swiftDarwin-macosx-* FAILED first_error=…`. Synchronization **depends on** `libswiftDarwin.so` (`FAILED dep=swiftDarwin`). `_Concurrency` / `_StringProcessing` / `_Builtin_float` do **not**; a failure there prints their own `first_error`. |
 | `_DarwinFoundation1/2/3`, `_errno`, `swiftObjectiveC` | **yes** — `overlay_build_xcode_shells` (not ninja). Sysroot `.swiftinterface` if present, else in-tree `@_exported import` shells + `overlays/ObjectiveC.swift`. Linked with the Darwin driver (`LC_DYLD_INFO`; no `/usr/lib/llvm-18/lib`). | `FAILED first_error=…` from `build_sdk_overlays.sh`. Select still prints `CANNOT_STAGE_XCODE_DARWIN_OVERLAYS` before the side recipe (not a ninja target). |
 
 Ninja rc tests: `scripts/test_ninja_rc.sh` (gold is `CANNOT_LINKER_GOLD_REJECTED`, not allowed), `scripts/test_overlay_targets.sh`,
@@ -276,7 +307,7 @@ closure via Darwin Clang overlay maps /
 not refuse); refuse-before-cmake;
 ninja `-sdk`/`-isysroot`; Darwin dylib `-soname` ninja line vs rewritten
 `-install_name` (apple `-target` `.so` is Darwin/ld64.lld, not ELF);
-Darwin-dep vs `first_error`), `scripts/test_sdk_overlays.sh`, `scripts/test_darwin_overlay_syntax.sh`, `scripts/test_probe_machorun.sh`.
+Darwin-dep vs `first_error`), `scripts/test_sdk_overlays.sh`, `scripts/test_darwin_overlay_syntax.sh`, `scripts/test_probe_machorun.sh`, `scripts/test_compiler_rt_osx.sh`, `scripts/test_clangxx_darwin_link.sh`.
 
 ### Darwin-target `dispatch` (patch 8)
 
@@ -314,19 +345,27 @@ target aborted before Synchronization / `_StringProcessing` / `_Builtin_float`
 / Darwin. It now attempts every name in `OVERLAY_NINJA_TARGETS`, then prints:
 
 ```
-OVERLAY swift_Concurrency-macosx-x86_64 FAILED
-OVERLAY swiftSynchronization-macosx-x86_64 built
-OVERLAY swift_StringProcessing-macosx-x86_64 built
 OVERLAY swift_Builtin_float-macosx-x86_64 built
+OVERLAY swiftDarwin-macosx-x86_64 built
+OVERLAY swift_Concurrency-macosx-x86_64 built
+OVERLAY swift_StringProcessing-macosx-x86_64 built
 OVERLAY swift_RegexParser-macosx-x86_64 built
 OVERLAY swiftObservation-macosx-x86_64 built
-OVERLAY swiftDarwin-macosx-x86_64 FAILED
+OVERLAY swiftSynchronization-macosx-x86_64 built
 OVERLAY swift_DarwinFoundation1-macosx-x86_64 built
 OVERLAY swift_DarwinFoundation2-macosx-x86_64 built
 OVERLAY swift_DarwinFoundation3-macosx-x86_64 built
 OVERLAY swift_errno-macosx-x86_64 built
 OVERLAY swiftObjectiveC-macosx-x86_64 built
 ```
+
+Post-PR #60 operator scoreboard died on `undefined symbol: __divti3` (availability
+was already resolved). After the generic compiler-rt archive, the operator
+command is expected to print all twelve `built` and `compiler_rt=` naming
+`$W/build/libclang_rt.osx.a`. `libswiftDarwin` must carry exactly four
+`LC_REEXPORT_DYLIB` (the shells above); `gen_swift_tbd` then emits
+`reexported-libraries` so the widget guest does not record
+`libswift_DarwinFoundation1.dylib` as a direct load.
 
 plus `ls` of `lib/swift/macosx/` (dylibs and ELF `.so`). Overall rc stays
 non-zero if any overlay FAILED or a required target was `CANNOT_*`.

--- a/swiftcore-macho/scripts/build_compiler_rt_osx.sh
+++ b/swiftcore-macho/scripts/build_compiler_rt_osx.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# Build a Darwin-target compiler-rt builtins archive with os_version_check.c
-# (Apple's libclang_rt.osx.a piece that defines __isPlatformVersionAtLeast).
+# Build Apple's-shape Darwin compiler-rt builtins archive (libclang_rt.osx.a).
+#
+# Generic C builtins + the x86_64 (or arm64) .c/.S files Apple includes for
+# that arch, from a pinned llvm-project compiler-rt (llvmorg-18.1.8). One
+# file per missing symbol is the wrong shape: ld64 archive-searches the
+# whole library (__divti3, __udivti3, __floattidf, atomics, …).
+#
+# os_version_check.c is the in-tree override (always-yes
+# _availability_version_check, local dispatch_once_f) — not upstream.
 #
 # Usage: build_compiler_rt_osx.sh [output.a]
 # Env: SWIFTCORE_SDKROOT or SWIFTCORE_DARWIN_SDK, SWIFTCORE_DARWIN_ARCH,
@@ -8,12 +15,19 @@
 set -euo pipefail
 _here=$(cd "$(dirname "$0")" && pwd)
 _root=$(cd "$_here/../.." && pwd)
+# Pins duplicated from guest_arch.inc so this script does not require swiftc.
+LLVM_PROJECT_PIN_TAG=llvmorg-18.1.8
+LLVM_PROJECT_PIN_COMMIT=3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff
+COMPILER_RT_SRC_TAR_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/compiler-rt-18.1.8.src.tar.xz
+COMPILER_RT_SRC_TAR_SHA256=e054e99a9c9240720616e927cb52363abbc8b4f1ef0286bad3df79ec8fdf892f
 : "${SWIFTCORE_DARWIN_ARCH:=x86_64}"
 : "${DARWIN_MIN:=macosx13.0}"
 min_ver="${DARWIN_MIN#macosx}"
 sdk="${SWIFTCORE_SDKROOT:-${SWIFTCORE_DARWIN_SDK:-${SWIFTCORE_WORK:-$HOME/work}/sdk/MacOSX.sdk}}"
 out="${1:-${SWIFTCORE_COMPILER_RT_OSX:-${SWIFTCORE_WORK:-$HOME/work}/build/libclang_rt.osx.a}}"
-src_dir="$_root/swiftcore-macho/compiler-rt"
+override="$_root/swiftcore-macho/compiler-rt/os_version_check.c"
+W=${SWIFTCORE_WORK:-${W:-$HOME/work}}
+
 if [[ -n "${DARWIN_CLANG:-}" ]]; then
   cc="$DARWIN_CLANG"
 elif [[ -n "${CC:-}" ]]; then
@@ -28,33 +42,56 @@ if [[ ! -d "$sdk" ]]; then
   echo "build_compiler_rt_osx.sh: no SDK at $sdk" >&2
   exit 1
 fi
-if [[ ! -f "$src_dir/os_version_check.c" ]]; then
-  echo "build_compiler_rt_osx.sh: missing $src_dir/os_version_check.c" >&2
+if [[ ! -f "$override" ]]; then
+  echo "build_compiler_rt_osx.sh: missing $override" >&2
   exit 1
 fi
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
-target="${SWIFTCORE_DARWIN_ARCH}-apple-macos${min_ver}"
+# --- fetch pinned compiler-rt into scratch/ (do not commit sources) ---
+_fetch_compiler_rt() {
+  local scratch tar dest got
+  scratch="${SWIFTCORE_LLVM_SRC:-}"
+  if [[ -z "$scratch" ]]; then
+    for d in \
+      "$W/scratch/llvm-project/compiler-rt/lib/builtins" \
+      "$_root/scratch/llvm-project/compiler-rt/lib/builtins" \
+      "$W/scratch/compiler-rt-18.1.8.src/lib/builtins" \
+      "$_root/scratch/compiler-rt-18.1.8.src/lib/builtins"
+    do
+      if [[ -f "$d/divti3.c" && -f "$d/CMakeLists.txt" ]]; then
+        printf '%s\n' "$d"
+        return 0
+      fi
+    done
+    scratch="$W/scratch"
+  fi
+  mkdir -p "$scratch"
+  dest="$scratch/compiler-rt-18.1.8.src"
+  if [[ -f "$dest/lib/builtins/divti3.c" ]]; then
+    printf '%s\n' "$dest/lib/builtins"
+    return 0
+  fi
+  tar="$scratch/compiler-rt-18.1.8.src.tar.xz"
+  if [[ ! -f "$tar" ]]; then
+    echo "build_compiler_rt_osx.sh: fetching $COMPILER_RT_SRC_TAR_URL" >&2
+    curl -fsSL -o "$tar" "$COMPILER_RT_SRC_TAR_URL"
+  fi
+  got=$(sha256sum "$tar" | awk '{print $1}')
+  if [[ "$got" != "$COMPILER_RT_SRC_TAR_SHA256" ]]; then
+    echo "build_compiler_rt_osx.sh: tarball sha256 $got != pin $COMPILER_RT_SRC_TAR_SHA256" >&2
+    exit 2
+  fi
+  tar -xJf "$tar" -C "$scratch"
+  if [[ ! -f "$dest/lib/builtins/divti3.c" ]]; then
+    echo "build_compiler_rt_osx.sh: extract missing lib/builtins/divti3.c" >&2
+    exit 2
+  fi
+  echo "build_compiler_rt_osx.sh: compiler-rt $LLVM_PROJECT_PIN_TAG commit=$LLVM_PROJECT_PIN_COMMIT tar_sha256=$COMPILER_RT_SRC_TAR_SHA256" >&2
+  printf '%s\n' "$dest/lib/builtins"
+}
 
-cflags=(
-  -target "$target"
-  -isysroot "$sdk"
-  -std=c11
-  -fPIC
-  -O2
-  -fno-stack-protector
-  -fvisibility=hidden
-  -Wno-deprecated-declarations
-)
+builtins=$(_fetch_compiler_rt)
 
-"$cc" "${cflags[@]}" -c "$src_dir/os_version_check.c" \
-  -o "$tmpdir/os_version_check.o"
-
-mkdir -p "$(dirname "$out")"
-rm -f "$out"
-# GNU ar writes no Mach-O table of contents; ld64.lld then says
-# "archive has no index; run ranlib to add one". llvm-ar indexes Mach-O.
 ar_bin=""
 for cand in /usr/lib/llvm-18/bin/llvm-ar llvm-ar-18 llvm-ar; do
   if [[ -x "$cand" ]] || command -v "$cand" >/dev/null 2>&1; then
@@ -66,17 +103,191 @@ if [[ -z "$ar_bin" ]]; then
   echo "build_compiler_rt_osx.sh: need llvm-ar (GNU ar has no Darwin index)" >&2
   exit 1
 fi
-"$ar_bin" rcs "$out" "$tmpdir/os_version_check.o"
-# Confirm the Darwin availability hooks landed; llvm-nm understands Mach-O.
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+objdir="$tmpdir/obj"
+mkdir -p "$objdir"
+target="${SWIFTCORE_DARWIN_ARCH}-apple-macos${min_ver}"
+
+cflags=(
+  -target "$target"
+  -isysroot "$sdk"
+  -std=c11
+  -fPIC
+  -fno-builtin
+  -O2
+  -fno-stack-protector
+  -fvisibility=hidden
+  -Wno-deprecated-declarations
+  -Wno-unused-parameter
+  -Wno-atomic-alignment
+  -I "$builtins"
+  -I "$builtins/cpu_model"
+)
+
+asflags=(
+  -target "$target"
+  -isysroot "$sdk"
+  -fPIC
+  -fno-builtin
+  -O2
+  -I "$builtins"
+)
+
+sys_inc="$sdk/usr/include"
+header_in_sysroot() {
+  local h=$1
+  [[ -f "$sys_inc/$h" ]]
+}
+
+# Skip TUs that #include a Darwin kernel/libkern header the sysroot lacks.
+# Compile failures of other kinds are also excluded (printed).
+exclude_reason() {
+  local src=$1
+  local rel=$2
+  # Upstream os_version_check.c is replaced by the in-tree override.
+  if [[ "$(basename "$src")" == os_version_check.c ]]; then
+    printf 'in-tree override (always-yes _availability_version_check)\n'
+    return 0
+  fi
+  # ELF .init_array CRT glue; Mach-O rejects the section attribute.
+  if [[ "$(basename "$src")" == crtbegin.c || "$(basename "$src")" == crtend.c ]]; then
+    printf 'ELF CRT glue (crtbegin/crtend), not Darwin builtins\n'
+    return 0
+  fi
+  local inc
+  inc=$(grep -E '^[[:space:]]*#include[[:space:]]*[<"]' "$src" 2>/dev/null || true)
+  if printf '%s\n' "$inc" | grep -q 'libkern/'; then
+    if ! header_in_sysroot libkern/OSCacheControl.h && ! header_in_sysroot libkern/OSAtomic.h; then
+      printf 'Darwin kernel header libkern/* absent from sysroot\n'
+      return 0
+    fi
+  fi
+  if printf '%s\n' "$inc" | grep -q '<mach/'; then
+    if ! header_in_sysroot mach/mach.h && ! header_in_sysroot mach/vm_prot.h; then
+      printf 'Darwin kernel header mach/* absent from sysroot\n'
+      return 0
+    fi
+  fi
+  if printf '%s\n' "$inc" | grep -q '<Availability.h>'; then
+    if ! header_in_sysroot Availability.h; then
+      printf 'Darwin header Availability.h absent from sysroot\n'
+      return 0
+    fi
+  fi
+  if printf '%s\n' "$inc" | grep -q '<unwind.h>'; then
+    if ! header_in_sysroot unwind.h && ! header_in_sysroot mach-o/unwind.h; then
+      printf 'unwind.h absent from sysroot\n'
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Collect sources: generic C at builtins root + arch-specific .c/.S Apple uses.
+declare -a sources=()
+while IFS= read -r f; do
+  sources+=("$f")
+done < <(find "$builtins" -maxdepth 1 -name '*.c' -print | LC_ALL=C sort)
+
+case "$SWIFTCORE_DARWIN_ARCH" in
+  x86_64)
+    for f in \
+      "$builtins/cpu_model/x86.c" \
+      "$builtins/i386/fp_mode.c" \
+      "$builtins/x86_64/floatdidf.c" \
+      "$builtins/x86_64/floatdisf.c" \
+      "$builtins/x86_64/floatdixf.c" \
+      "$builtins/x86_64/floatundidf.S" \
+      "$builtins/x86_64/floatundisf.S" \
+      "$builtins/x86_64/floatundixf.S"
+    do
+      [[ -f "$f" ]] && sources+=("$f")
+    done
+    ;;
+  arm64)
+    for f in \
+      "$builtins/cpu_model/aarch64.c" \
+      "$builtins/aarch64/fp_mode.c"
+    do
+      [[ -f "$f" ]] && sources+=("$f")
+    done
+    ;;
+  *)
+    echo "build_compiler_rt_osx.sh: arch $SWIFTCORE_DARWIN_ARCH not x86_64|arm64" >&2
+    exit 1
+    ;;
+esac
+
+declare -a objs=()
+declare -a excluded=()
+n_ok=0
+for src in "${sources[@]}"; do
+  rel=${src#"$builtins"/}
+  base=$(basename "$src")
+  stem=${base%.*}
+  # Disambiguate arch subdir members (fp_mode.c vs i386/fp_mode.c).
+  obj_name=$(printf '%s' "$rel" | tr '/.' '__')
+  obj="$objdir/${obj_name}.o"
+  if reason=$(exclude_reason "$src" "$rel"); then
+    excluded+=("$rel ($reason)")
+    continue
+  fi
+  extra=()
+  if [[ "$src" == *.S ]]; then
+    extra=("${asflags[@]}")
+  else
+    extra=("${cflags[@]}")
+  fi
+  err=$tmpdir/$stem.err
+  if ! "$cc" "${extra[@]}" -c "$src" -o "$obj" 2>"$err"; then
+    why=$(tr '\n' ' ' <"$err" | sed 's/  */ /g; s/^ //; s/ $//' | cut -c1-160)
+    excluded+=("$rel (compile failed: ${why:-unknown})")
+    continue
+  fi
+  objs+=("$obj")
+  n_ok=$((n_ok + 1))
+done
+
+# In-tree os_version_check.c override — always compiled, never skipped.
+if ! "$cc" "${cflags[@]}" -c "$override" -o "$objdir/os_version_check.o"; then
+  echo "build_compiler_rt_osx.sh: in-tree os_version_check.c failed" >&2
+  exit 1
+fi
+objs+=("$objdir/os_version_check.o")
+n_ok=$((n_ok + 1))
+
+if [[ ${#objs[@]} -lt 4 ]]; then
+  echo "build_compiler_rt_osx.sh: too few members (${#objs[@]}); refusing empty archive" >&2
+  printf '  excluded: %s\n' "${excluded[@]}" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$out")"
+rm -f "$out"
+"$ar_bin" rcs "$out" "${objs[@]}"
+
+if [[ ${#excluded[@]} -gt 0 ]]; then
+  echo "compiler-rt excluded (${#excluded[@]}):"
+  printf '  %s\n' "${excluded[@]}"
+else
+  echo "compiler-rt excluded: (none)"
+fi
+
+sha=$(sha256sum "$out" | awk '{print $1}')
+# One-line summary: member count, arch, sha256.
+echo "compiler-rt darwin builtins: members=$n_ok arch=$SWIFTCORE_DARWIN_ARCH sha256=$sha $out"
+
 nm_bin=""
-for cand in /usr/lib/llvm-18/bin/llvm-nm llvm-nm nm; do
+for cand in /usr/lib/llvm-18/bin/llvm-nm llvm-nm-18 llvm-nm nm; do
   if command -v "$cand" >/dev/null 2>&1 || [[ -x "$cand" ]]; then
     nm_bin=$cand
     break
   fi
 done
 if [[ -n "$nm_bin" ]]; then
-  "$nm_bin" "$out" 2>/dev/null | grep -E 'isPlatformVersionAtLeast|isPlatformOrVariantPlatformVersionAtLeast|_availability_version_check' \
+  "$nm_bin" "$out" 2>/dev/null \
+    | grep -E ' (__divti3|__udivti3|__floattidf|__isPlatformVersionAtLeast)$' \
     | sed 's/^/  compiler-rt nm: /' || true
 fi
-echo "compiler-rt darwin builtins: $out"

--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -211,6 +211,17 @@ run_stdlib_ninja() {
     if [ "$sel_rc" -ne 0 ]; then
       overlay_rc=$sel_rc
     fi
+    # DarwinFoundation shells before Darwin ninja: libswiftDarwin re-exports
+    # them (Apple's four LC_REEXPORT_DYLIB). Builtin_float is ninja'd first.
+    if [ "${SWIFTCORE_NINJA_HARNESS:-0}" != 1 ]; then
+      set +e
+      overlay_build_xcode_shells "$B" "$SWIFTCORE_DARWIN_ARCH"
+      local shells_st=$?
+      set -e
+      if [ "$shells_st" -ne 0 ] && [ "$overlay_rc" -eq 0 ]; then
+        overlay_rc=$shells_st
+      fi
+    fi
     if [ ${#OVERLAY_NINJA_TARGETS[@]} -gt 0 ]; then
       for t in "${OVERLAY_NINJA_TARGETS[@]}"; do
         step "ninja overlay $t"
@@ -241,11 +252,14 @@ run_stdlib_ninja() {
     fi
     if [ "${SWIFTCORE_NINJA_HARNESS:-0}" != 1 ]; then
       set +e
-      overlay_build_xcode_shells "$B" "$SWIFTCORE_DARWIN_ARCH"
-      local shells_st=$?
+      overlay_ensure_darwin_reexports "$B" "$SWIFTCORE_DARWIN_ARCH"
+      local rx_st=$?
       set -e
-      if [ "$shells_st" -ne 0 ] && [ "$overlay_rc" -eq 0 ]; then
-        overlay_rc=$shells_st
+      if [ "$rx_st" -ne 0 ]; then
+        OVERLAY_STATUS[swiftDarwin-macosx-${SWIFTCORE_DARWIN_ARCH}]="FAILED first_error=CANNOT_DARWIN_REEXPORT"
+        if [ "$overlay_rc" -eq 0 ]; then
+          overlay_rc=$rx_st
+        fi
       fi
     fi
     overlay_print_scoreboard "$SWIFTCORE_DARWIN_ARCH"

--- a/swiftcore-macho/scripts/clangxx_darwin_link.py
+++ b/swiftcore-macho/scripts/clangxx_darwin_link.py
@@ -16,8 +16,9 @@ Apple triple → exec the real clang++ with the original argv plus
 `-nostdlib++` plus the sysroot `usr/lib/libc++.tbd` / `libc++abi.tbd`
 so ld64 never opens the host ELF `libc++.so`. Print
 `cxx_runtime=<tbd>`. Pass `libclang_rt.osx.a` (compiler-rt
-`os_version_check.c` for `__isPlatformVersionAtLeast`) and print
-`compiler_rt=<archive>`. Linux/unknown-linux-gnu → ld.lld, keep `-soname`.
+generic Darwin builtins, including `__isPlatformVersionAtLeast` /
+`__divti3`) and print `compiler_rt=<archive>`. Linux/unknown-linux-gnu
+→ ld.lld, keep `-soname`.
 `-soname` is rewritten to `-install_name` only so ld64 never sees the GNU
 flag; nothing else is rewritten (PR #40's -dynamiclib/-nostdlib pass
 dropped -platform_version/-arch).
@@ -369,8 +370,99 @@ def darwin_cxx_runtime_path(argv: list[str]) -> str:
     return tbds[0] if tbds else "ABSENT"
 
 
+# Apple's libswiftDarwin.dylib LC_REEXPORT_DYLIB set (measured on the
+# x86_64 extract). Only Darwin; no other overlay grows re-exports.
+DARWIN_REEXPORT_SHELLS = (
+    "libswift_Builtin_float",
+    "libswift_DarwinFoundation1",
+    "libswift_DarwinFoundation2",
+    "libswift_DarwinFoundation3",
+)
+
+
+def _is_libswift_darwin_output(path: str | None) -> bool:
+    if not path:
+        return False
+    base = os.path.basename(path)
+    return base in ("libswiftDarwin.dylib", "libswiftDarwin.so")
+
+
+def _search_dirs_for_reexport(argv: list[str], out_path: str | None) -> list[str]:
+    dirs: list[str] = []
+    seen: set[str] = set()
+
+    def add(p: str) -> None:
+        if not p:
+            return
+        n = os.path.normpath(p)
+        if n in seen:
+            return
+        seen.add(n)
+        dirs.append(n)
+
+    if out_path:
+        d = os.path.dirname(os.path.abspath(out_path))
+        add(d)
+        add(os.path.dirname(d))
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        i += 1
+        if a in ("-L", "-Wl,-L") and i < len(argv):
+            add(argv[i])
+            i += 1
+            continue
+        if a.startswith("-L") and len(a) > 2:
+            add(a[2:])
+            continue
+        if a.startswith("-Wl,-L,"):
+            add(a.split(",", 2)[-1])
+    return dirs
+
+
+def find_darwin_reexport_shells(argv: list[str]) -> list[str]:
+    """Absolute paths of the four Darwin re-export shells, or [].
+
+    All four must exist (Apple's LC_REEXPORT_DYLIB set is exactly these).
+    Prefer .dylib over the ninja .so sibling.
+    """
+    if not _is_libswift_darwin_output(_output_path(argv)):
+        return []
+    dirs = _search_dirs_for_reexport(argv, _output_path(argv))
+    found: list[str] = []
+    for name in DARWIN_REEXPORT_SHELLS:
+        hit = ""
+        for d in dirs:
+            for ext in (".dylib", ".so"):
+                cand = os.path.join(d, name + ext)
+                if os.path.isfile(cand):
+                    hit = cand
+                    break
+            if hit:
+                break
+        if not hit:
+            return []
+        found.append(hit)
+    return found
+
+
+def darwin_reexport_link_flags(argv: list[str]) -> list[str]:
+    """-Xlinker -reexport_library for Apple's four Darwin shells.
+
+    Only when linking libswiftDarwin and all four dylibs are on disk.
+    Do not -reexport any other overlay.
+    """
+    paths = find_darwin_reexport_shells(argv)
+    if not paths:
+        return []
+    flags: list[str] = []
+    for p in paths:
+        flags.extend(["-Xlinker", "-reexport_library", "-Xlinker", p])
+    return flags
+
+
 def darwin_compiler_rt_osx_path() -> str:
-    """x86_64-apple-macos compiler-rt builtins archive (os_version_check.c)."""
+    """Darwin-target compiler-rt builtins archive (generic C + os_version_check)."""
     env = os.environ.get("SWIFTCORE_COMPILER_RT_OSX")
     if env:
         return env
@@ -460,6 +552,7 @@ def darwin_driver_argv(argv: list[str]) -> list[str]:
     for t in tbds:
         kept.append(t)
     kept.extend(darwin_compiler_rt_link_flags(kept))
+    kept.extend(darwin_reexport_link_flags(kept))
     # clang ignores argv after -###; keep diagnostics last.
     diag = [a for a in kept if a in ("-###", "-v", "--verbose")]
     if diag:
@@ -497,6 +590,10 @@ def log_link(
         sys.stderr.write(
             f"clangxx_darwin_link: compiler_rt={darwin_compiler_rt_osx_path()}\n"
         )
+        shells = find_darwin_reexport_shells(driver_argv or original)
+        if shells:
+            names = ",".join(os.path.basename(p) for p in shells)
+            sys.stderr.write(f"clangxx_darwin_link: darwin_reexport={names}\n")
     elif rewritten is not None:
         sys.stderr.write("clangxx_darwin_link: rewritten argv: " + shlex.join(rewritten) + "\n")
     sys.stderr.flush()

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -45,7 +45,8 @@ done
 # it from SWIFT_BUILD_DYNAMIC_SDK_OVERLAY (default TRUE on a non-Apple host),
 # so Platform/swiftDarwin *is* in the ninja graph. ObjectiveC /
 # _DarwinFoundation* / _errno are not CMake targets on Linux; build_stdlib.sh
-# compiles them via overlay_build_xcode_shells after the ninja overlay loop.
+# compiles them via overlay_build_xcode_shells *before* the Darwin ninja
+# target so libswiftDarwin can LC_REEXPORT DarwinFoundation{1,2,3}.
 #
 # Phase-2 guests load _Concurrency + _StringProcessing + Synchronization.
 # Overlays therefore also fetch/pass libdispatch (BUILD_LOG §16): CMake with

--- a/swiftcore-macho/scripts/guest_arch.inc
+++ b/swiftcore-macho/scripts/guest_arch.inc
@@ -112,3 +112,12 @@ STRING_PROCESSING_PIN_COMMIT=91177e6225c63e885872b83d48e254b1270fa15a
 LIBDISPATCH_PIN_COMMIT=2df91f94651f2d924d7506c9d14685929386d779
 STRING_PROCESSING_REPO=https://github.com/swiftlang/swift-experimental-string-processing.git
 LIBDISPATCH_REPO=https://github.com/swiftlang/swift-corelibs-libdispatch.git
+# compiler-rt builtins for Darwin overlay links (libclang_rt.osx.a).
+# Same pin as PR #60's os_version_check.c (llvmorg-18.1.8). Sources live in
+# scratch/ — do not commit them. Tarball sha256 is the GitHub release asset
+# compiler-rt-18.1.8.src.tar.xz; commit is llvm-project llvmorg-18.1.8^{}.
+LLVM_PROJECT_PIN_TAG=llvmorg-18.1.8
+LLVM_PROJECT_PIN_COMMIT=3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff
+LLVM_PROJECT_REPO=https://github.com/llvm/llvm-project.git
+COMPILER_RT_SRC_TAR_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/compiler-rt-18.1.8.src.tar.xz
+COMPILER_RT_SRC_TAR_SHA256=e054e99a9c9240720616e927cb52363abbc8b4f1ef0286bad3df79ec8fdf892f

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -12,7 +12,9 @@
 # building any overlays. Instead, we're picking them up from the SDK.").
 # They are not ninja targets. `overlay_build_xcode_shells` compiles them
 # from sysroot .swiftinterface (or in-tree re-export shells) + ObjectiveC.swift
-# with the Darwin driver. Shared-cache Apple dylibs have no LC_DYLD_INFO.
+# with the Darwin driver *before* the Darwin ninja target so libswiftDarwin
+# can LC_REEXPORT DarwinFoundation{1,2,3}. Shared-cache Apple dylibs have no
+# LC_DYLD_INFO.
 
 if [ -n "${SWIFTCORE_OVERLAY_TARGETS_INC:-}" ]; then
     return 0 2>/dev/null || exit 0
@@ -34,14 +36,18 @@ overlay_write_ninja_commands() {
 
 overlay_candidate_targets() {
     local arch=${1:?overlay_candidate_targets: arch}
+    # Builtin_float before Darwin so libswiftDarwin can LC_REEXPORT it.
+    # Darwin before Synchronization (Sync's ninja graph depends on Darwin).
+    # DarwinFoundation shells are not ninja targets; overlay_build_xcode_shells
+    # runs them before this ninja loop.
     printf '%s\n' \
-        "swift_Concurrency-macosx-${arch}" \
-        "swiftSynchronization-macosx-${arch}" \
-        "swift_StringProcessing-macosx-${arch}" \
         "swift_Builtin_float-macosx-${arch}" \
+        "swiftDarwin-macosx-${arch}" \
+        "swift_Concurrency-macosx-${arch}" \
+        "swift_StringProcessing-macosx-${arch}" \
         "swift_RegexParser-macosx-${arch}" \
         "swiftObservation-macosx-${arch}" \
-        "swiftDarwin-macosx-${arch}" \
+        "swiftSynchronization-macosx-${arch}" \
         "swift_DarwinFoundation1-macosx-${arch}" \
         "swift_DarwinFoundation2-macosx-${arch}" \
         "swift_DarwinFoundation3-macosx-${arch}" \
@@ -520,9 +526,130 @@ overlay_copy_so_as_dylib() {
     done
 }
 
+# Apple's libswiftDarwin LC_REEXPORT_DYLIB install names (exactly four).
+overlay_darwin_reexport_install_names() {
+    printf '%s\n' \
+        /usr/lib/swift/libswift_Builtin_float.dylib \
+        /usr/lib/swift/libswift_DarwinFoundation1.dylib \
+        /usr/lib/swift/libswift_DarwinFoundation2.dylib \
+        /usr/lib/swift/libswift_DarwinFoundation3.dylib
+}
+
+overlay_darwin_lc_reexport_names() {
+    local dylib=$1
+    local otool=${OTOOL:-llvm-otool-18}
+    command -v "$otool" >/dev/null 2>&1 || otool=llvm-otool
+    "$otool" -l "$dylib" 2>/dev/null \
+        | awk '/LC_REEXPORT_DYLIB/{f=1} f&&/^ *name /{print $2; f=0}' \
+        | sort -u
+}
+
+# After ninja Darwin + the four shells exist, relink libswiftDarwin so it
+# carries Apple's four LC_REEXPORT_DYLIB entries. clangxx_darwin_link.py
+# injects -reexport_library when those dylibs are on disk; this pass covers
+# the case where ninja first linked Darwin as a Synchronization dep before
+# Builtin_float landed.
+# overlay_ensure_darwin_reexports <build_dir> <arch>
+overlay_ensure_darwin_reexports() {
+    local build_dir=${1:?overlay_ensure_darwin_reexports: build dir}
+    local arch=${2:?overlay_ensure_darwin_reexports: arch}
+    local py cmds_file darwin want have missing
+    if [ "${SWIFTCORE_NINJA_HARNESS:-0}" = 1 ]; then
+        echo "overlay_ensure_darwin_reexports: skip (SWIFTCORE_NINJA_HARNESS=1)"
+        return 0
+    fi
+    darwin=$build_dir/lib/swift/macosx/$arch/libswiftDarwin.dylib
+    [ -f "$darwin" ] || darwin=$build_dir/lib/swift/macosx/$arch/libswiftDarwin.so
+    if [ ! -f "$darwin" ]; then
+        echo "overlay_ensure_darwin_reexports: no libswiftDarwin (ninja Darwin did not land)"
+        return 0
+    fi
+    want=$(overlay_darwin_reexport_install_names | sort -u)
+    have=$(overlay_darwin_lc_reexport_names "$darwin")
+    if [ "$(printf '%s\n' "$have")" = "$(printf '%s\n' "$want")" ]; then
+        echo "overlay_ensure_darwin_reexports: $darwin already has four LC_REEXPORT_DYLIB"
+        printf '%s\n' "$have" | sed 's/^/  reexport /'
+        return 0
+    fi
+    py=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/clangxx_darwin_link.py
+    cmds_file=$(mktemp)
+    overlay_write_ninja_commands "$cmds_file" "$build_dir" \
+        "lib/swift/macosx/${arch}/libswiftDarwin.so"
+    if [ ! -s "$cmds_file" ]; then
+        overlay_write_ninja_commands "$cmds_file" "$build_dir" \
+            "swiftDarwin-macosx-${arch}"
+    fi
+    if [ ! -s "$cmds_file" ]; then
+        echo "CANNOT_DARWIN_REEXPORT reason=no ninja Darwin link command to relink" >&2
+        rm -f "$cmds_file"
+        return 2
+    fi
+    echo "overlay_ensure_darwin_reexports: relink $darwin with -reexport_library of four shells"
+    set +e
+    python3 - "$py" "$cmds_file" <<'PY'
+import os, pathlib, shlex, subprocess, sys
+
+def compiler_args(line):
+    argv = shlex.split(line)
+    if not argv:
+        return []
+    if argv[0] == ":" and len(argv) > 2 and argv[1] == "&&":
+        argv = argv[2:]
+    while len(argv) >= 2 and argv[-2] == "&&" and argv[-1] == ":":
+        argv = argv[:-2]
+    i = 0
+    for j, t in enumerate(argv):
+        base = os.path.basename(t.rstrip("\\"))
+        if base in ("clang++", "clang", "clangxx_darwin_link.py") or t.endswith("/clang++"):
+            i = j
+            break
+    return argv[i + 1 :]
+
+py, cmds_path = sys.argv[1], sys.argv[2]
+text = pathlib.Path(cmds_path).read_text(errors="replace")
+line = None
+for raw in text.splitlines():
+    if "libswiftDarwin.so" in raw and " -o " in raw and (
+        "clang++" in raw or "clang " in raw or "clangxx_darwin_link" in raw
+    ):
+        line = raw
+        break
+if line is None:
+    sys.stderr.write("CANNOT_DARWIN_REEXPORT reason=no clang++ Darwin link line\n")
+    sys.exit(2)
+args = compiler_args(line)
+proc = subprocess.run([sys.executable, py, *args])
+sys.exit(proc.returncode)
+PY
+    local st=$?
+    set -e
+    rm -f "$cmds_file"
+    if [ "$st" -ne 0 ]; then
+        echo "CANNOT_DARWIN_REEXPORT reason=relink rc=$st" >&2
+        return "$st"
+    fi
+    overlay_copy_so_as_dylib "$build_dir" "$arch"
+    overlay_flatten_unarch "$build_dir" "$arch"
+    darwin=$build_dir/lib/swift/macosx/$arch/libswiftDarwin.dylib
+    [ -f "$darwin" ] || darwin=$build_dir/lib/swift/macosx/$arch/libswiftDarwin.so
+    have=$(overlay_darwin_lc_reexport_names "$darwin")
+    missing=$(comm -23 <(printf '%s\n' "$want") <(printf '%s\n' "$have"))
+    if [ -n "$missing" ]; then
+        echo "CANNOT_DARWIN_REEXPORT missing=$(printf '%s' "$missing" | tr '\n' ',')" >&2
+        echo "  have:" >&2
+        printf '%s\n' "$have" | sed 's/^/    /' >&2
+        return 2
+    fi
+    echo "overlay_ensure_darwin_reexports: four LC_REEXPORT_DYLIB on $darwin"
+    printf '%s\n' "$have" | sed 's/^/  reexport /'
+    return 0
+}
+
 # Compile the five non-ninja Apple-SDK overlays with the Darwin driver.
 # overlay_build_xcode_shells <build_dir> <arch>
 # Skipped in SWIFTCORE_NINJA_HARNESS (fake ninja / no Darwin resource-dir).
+# Called *before* the Darwin ninja target so libswiftDarwin can re-export
+# DarwinFoundation{1,2,3}. Builtin_float is a ninja target, built first.
 overlay_build_xcode_shells() {
     local build_dir=${1:?overlay_build_xcode_shells: build dir}
     local arch=${2:?overlay_build_xcode_shells: arch}

--- a/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
+++ b/swiftcore-macho/scripts/test_clangxx_darwin_link.sh
@@ -440,6 +440,64 @@ EOF
 fi
 
 echo
+echo "=== Darwin link re-exports the four Apple shells; other overlays do not ==="
+clang_c=$(command -v clang-18 || command -v clang)
+# shellcheck source=overlay_targets.inc
+. "$SCRIPT_DIR/overlay_targets.inc"
+rxdir=$tmp/reexport
+mkdir -p "$rxdir"
+echo 'void _swift_reexport_stub(void) {}' | "$clang_c" -target x86_64-apple-macosx13.0 -c -o "$tmp/stub.o" -x c -
+for n in libswift_Builtin_float libswift_DarwinFoundation1 \
+         libswift_DarwinFoundation2 libswift_DarwinFoundation3; do
+  /usr/lib/llvm-18/bin/ld64.lld -arch x86_64 -dylib \
+    -platform_version macos 13.0.0 13.0.0 \
+    -install_name /usr/lib/swift/${n}.dylib \
+    -o "$rxdir/${n}.dylib" "$tmp/stub.o"
+done
+echo 'int darwin_overlay(void) { return 0; }' | "$clang_c" -target x86_64-apple-macosx13.0 -c -o "$rxdir/Darwin.o" -x c -
+got=$(rewrite -target x86_64-apple-macosx13.0 -isysroot /sdk \
+  -shared -o "$rxdir/libswiftDarwin.dylib" "$rxdir/Darwin.o" \
+  -L "$rxdir")
+rx_n=$(printf '%s\n' "$got" | tr ' ' '\n' | grep -c -- '-reexport_library' || true)
+[ "$rx_n" -eq 4 ] && echo "  OK  Darwin driver argv has 4 -reexport_library" \
+  || { echo "  FAIL Darwin -reexport_library count=$rx_n want 4"; fail=1; }
+for n in libswift_Builtin_float libswift_DarwinFoundation1 \
+         libswift_DarwinFoundation2 libswift_DarwinFoundation3; do
+  printf '%s\n' "$got" | grep -q "$n" \
+    && echo "  OK  reexports $n" \
+    || { echo "  FAIL missing reexport $n"; fail=1; }
+done
+grep -q 'clangxx_darwin_link: darwin_reexport=' "$tmp/link.err" \
+  && echo "  OK  printed darwin_reexport=" \
+  || { echo "  FAIL missing darwin_reexport line"; fail=1; }
+got=$(rewrite -target x86_64-apple-macosx13.0 -isysroot /sdk \
+  -shared -o "$rxdir/libswiftObjectiveC.dylib" "$rxdir/Darwin.o" \
+  -L "$rxdir")
+printf '%s\n' "$got" | grep -q -- '-reexport_library' \
+  && { echo "  FAIL ObjectiveC link grew -reexport_library"; fail=1; } \
+  || echo "  OK  ObjectiveC link has no -reexport_library"
+# Direct ld64.lld: exactly four LC_REEXPORT_DYLIB (Apple's set).
+/usr/lib/llvm-18/bin/ld64.lld -arch x86_64 -dylib \
+  -platform_version macos 13.0.0 13.0.0 \
+  -install_name /usr/lib/swift/libswiftDarwin.dylib \
+  -reexport_library "$rxdir/libswift_Builtin_float.dylib" \
+  -reexport_library "$rxdir/libswift_DarwinFoundation1.dylib" \
+  -reexport_library "$rxdir/libswift_DarwinFoundation2.dylib" \
+  -reexport_library "$rxdir/libswift_DarwinFoundation3.dylib" \
+  -o "$rxdir/libswiftDarwin.linked.dylib" "$rxdir/Darwin.o"
+have=$(overlay_darwin_lc_reexport_names "$rxdir/libswiftDarwin.linked.dylib")
+want=$(overlay_darwin_reexport_install_names | sort -u)
+if [ "$(printf '%s\n' "$have")" = "$(printf '%s\n' "$want")" ]; then
+  echo "  OK  exactly four LC_REEXPORT_DYLIB on synthetic Darwin"
+  printf '%s\n' "$have" | sed 's/^/    /'
+else
+  echo "  FAIL LC_REEXPORT_DYLIB set:"
+  echo "    have:"; printf '%s\n' "$have" | sed 's/^/      /'
+  echo "    want:"; printf '%s\n' "$want" | sed 's/^/      /'
+  fail=1
+fi
+
+echo
 if [ "$fail" -eq 0 ]; then
   echo "PASS -- apple-target .so → Darwin driver + sysroot libc++ + compiler-rt; linux-gnu .so → ld.lld"
   exit 0

--- a/swiftcore-macho/scripts/test_compiler_rt_osx.sh
+++ b/swiftcore-macho/scripts/test_compiler_rt_osx.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Tooth: Darwin compiler-rt builtins archive resolves __divti3 / __udivti3 /
+# __floattidf / __isPlatformVersionAtLeast under ld64.lld NOUNDEFS.
+# Overlay .o grep is printed when $W/build exists; otherwise the operator
+# ninja overlay log is the proof.
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+NM=${NM:-/usr/lib/llvm-18/bin/llvm-nm}
+LD64=${LD64_LLD:-/usr/lib/llvm-18/bin/ld64.lld}
+OTOOL=${OTOOL:-llvm-otool-18}
+command -v "$OTOOL" >/dev/null 2>&1 || OTOOL=llvm-otool
+clang_c=$(command -v clang-18 || command -v clang)
+
+echo "=== bash -n build_compiler_rt_osx.sh ==="
+bash -n "$SCRIPT_DIR/build_compiler_rt_osx.sh" \
+  && echo "  OK  bash -n" || { echo "  FAIL bash -n"; fail=1; }
+
+echo
+echo "=== build libclang_rt.osx.a (generic C builtins + os_version_check override) ==="
+sdk=""
+for d in \
+  "${SWIFTCORE_SDKROOT:-}" \
+  "${SWIFTCORE_DARWIN_SDK:-}" \
+  "${SWIFTCORE_WORK:-$HOME/work}/sdk/MacOSX.sdk" \
+  /home/ubuntu/work/sdk/MacOSX.sdk \
+  /root/work/sdk/MacOSX.sdk
+do
+  [ -n "$d" ] && [ -d "$d/usr/include" ] && { sdk=$d; break; }
+done
+if [ -z "$sdk" ]; then
+  sdk=$tmp/sdk
+  mkdir -p "$sdk/usr/include" "$sdk/usr/lib"
+  root=$(cd "$SCRIPT_DIR/../.." && pwd)
+  if [ -d "$root/machorun/sdk/usr/include" ]; then
+    cp -a "$root/machorun/sdk/usr/include/." "$sdk/usr/include/"
+  fi
+  if [ -d "$root/machorun/sdk/local" ]; then
+    cp -a "$root/machorun/sdk/local/." "$sdk/usr/include/" 2>/dev/null || true
+  fi
+  [ -f "$sdk/usr/include/TargetConditionals.h" ] \
+    && echo "  OK  mini sysroot from machorun/sdk headers" \
+    || { echo "  FAIL no TargetConditionals.h for compiler-rt"; fail=1; }
+fi
+rt_a=$tmp/libclang_rt.osx.a
+set +e
+out=$(SWIFTCORE_SDKROOT="$sdk" SWIFTCORE_DARWIN_ARCH=x86_64 \
+  SWIFTCORE_LLVM_SRC="${SWIFTCORE_LLVM_SRC:-}" \
+  SWIFTCORE_WORK="${SWIFTCORE_WORK:-$HOME/work}" \
+  bash "$SCRIPT_DIR/build_compiler_rt_osx.sh" "$rt_a" 2>&1)
+st=$?
+set -e
+printf '%s\n' "$out" | tail -20
+[ "$st" -eq 0 ] && echo "  OK  build rc=0" || { echo "  FAIL build rc=$st"; fail=1; }
+printf '%s\n' "$out" | grep -qE 'compiler-rt darwin builtins: members=[0-9]+ arch=x86_64 sha256=' \
+  && echo "  OK  one-line members/arch/sha256 summary" \
+  || { echo "  FAIL missing summary line"; fail=1; }
+members=$(printf '%s\n' "$out" | sed -n 's/.*members=\([0-9][0-9]*\).*/\1/p' | tail -1)
+[ "${members:-0}" -ge 50 ] && echo "  OK  member count $members (>=50, not a single TU)" \
+  || { echo "  FAIL member count $members is still single-file vendoring"; fail=1; }
+printf '%s\n' "$out" | grep -q 'os_version_check.c (in-tree override' \
+  && echo "  OK  excluded upstream os_version_check.c (in-tree override)" \
+  || { echo "  FAIL did not skip upstream os_version_check.c"; fail=1; }
+if [ ! -f "$rt_a" ]; then
+  echo "  FAIL archive missing"; fail=1
+else
+  for s in ___divti3 ___udivti3 ___floattidf ___isPlatformVersionAtLeast; do
+    nmlst=$("$NM" "$rt_a" 2>/dev/null || true)
+    printf '%s\n' "$nmlst" | grep -F -- "$s" >/dev/null \
+      && echo "  OK  archive contains $s" \
+      || { echo "  FAIL archive missing $s"; fail=1; }
+  done
+fi
+
+echo
+echo "=== ld64.lld NOUNDEFS probe: __divti3 __udivti3 __floattidf __isPlatformVersionAtLeast ==="
+if [ ! -f "$rt_a" ]; then
+  echo "  FAIL skip probe (no archive)"; fail=1
+else
+  cat > "$tmp/probe.c" <<'EOF'
+__int128 call_div(__int128 a, __int128 b) { return a / b; }
+unsigned __int128 call_udiv(unsigned __int128 a, unsigned __int128 b) { return a / b; }
+double call_float(__int128 a) { return (double)a; }
+int __isPlatformVersionAtLeast(unsigned, unsigned, unsigned, unsigned);
+int call_plat(void) { return __isPlatformVersionAtLeast(1, 14, 0, 0); }
+EOF
+  # libc symbols pulled by os_version_check.c; stubs keep this probe NOUNDEFS
+  # without -undefined dynamic_lookup and without exporting builtins from libSystem.
+  cat > "$tmp/stubs.c" <<'EOF'
+void *fopen(const char *a, const char *b) { (void)a; (void)b; return 0; }
+int fclose(void *f) { (void)f; return 0; }
+int fseek(void *f, long o, int w) { (void)f; (void)o; (void)w; return 0; }
+long ftell(void *f) { (void)f; return 0; }
+void rewind(void *f) { (void)f; }
+unsigned long fread(void *p, unsigned long s, unsigned long n, void *f) {
+  (void)p; (void)s; (void)n; (void)f; return 0;
+}
+int sscanf(const char *s, const char *fmt, ...) { (void)s; (void)fmt; return 0; }
+char *getenv(const char *n) { (void)n; return 0; }
+void *malloc(unsigned long n) { (void)n; return 0; }
+void free(void *p) { (void)p; }
+void *dlsym(void *h, const char *n) { (void)h; (void)n; return 0; }
+unsigned long strlen(const char *s) { (void)s; return 0; }
+char *strcpy(char *d, const char *s) { (void)s; return d; }
+char *strcat(char *d, const char *s) { (void)s; return d; }
+void __assert_rtn(const char *a, const char *b, int c, const char *d) {
+  (void)a; (void)b; (void)c; (void)d;
+}
+EOF
+  "$clang_c" -target x86_64-apple-macosx13.0 -fno-builtin -c -o "$tmp/probe.o" "$tmp/probe.c"
+  "$clang_c" -target x86_64-apple-macosx13.0 -fno-builtin -c -o "$tmp/stubs.o" "$tmp/stubs.c"
+  "$NM" -u "$tmp/probe.o" | grep -q '__divti3' \
+    && echo "  OK  probe object refs __divti3" \
+    || { echo "  FAIL probe missing __divti3 ref"; fail=1; }
+  set +e
+  "$LD64" -arch x86_64 -dylib -platform_version macos 13.0.0 13.0.0 \
+    -o "$tmp/libprobe.dylib" "$tmp/probe.o" "$rt_a" "$tmp/stubs.o" 2>"$tmp/probe.link.err"
+  lst=$?
+  set -e
+  [ "$lst" -eq 0 ] && echo "  OK  ld64.lld probe link rc=0 (NOUNDEFS)" \
+    || { echo "  FAIL ld64.lld probe rc=$lst"; cat "$tmp/probe.link.err"; fail=1; }
+  grep -q 'undefined dynamic_lookup' "$tmp/probe.link.err" \
+    && { echo "  FAIL probe used -undefined dynamic_lookup"; fail=1; } \
+    || echo "  OK  no -undefined dynamic_lookup"
+  if [ -f "$tmp/libprobe.dylib" ]; then
+    undef=$("$NM" -u "$tmp/libprobe.dylib" 2>/dev/null || true)
+    miss=0
+    for s in __divti3 __udivti3 __floattidf __isPlatformVersionAtLeast; do
+      printf '%s\n' "$undef" | grep -q "$s" \
+        && { echo "  FAIL llvm-nm -u still has $s"; miss=1; fail=1; } \
+        || echo "  OK  llvm-nm -u has no $s"
+    done
+    [ "$miss" -eq 0 ] && echo "  OK  none of the four are undefined"
+  fi
+fi
+
+echo
+echo "=== overlay .o grep (U __divti3 / __float / __fix) ==="
+build=${SWIFTCORE_WORK:-$HOME/work}/build
+if [ -d "$build" ]; then
+  hits=$(find "$build" -name '*.o' -print0 2>/dev/null \
+    | xargs -0 "$NM" -u 2>/dev/null \
+    | grep -E 'U __[a-z]*ti3|U __float|U __fix' | sort -u | head -40 || true)
+  if [ -n "$hits" ]; then
+    echo "$hits"
+    echo "  note: overlay objects still reference compiler-rt helpers; the archive must supply them"
+  else
+    echo "  OK  no U __ti3/__float/__fix in $build overlay objects (or none found)"
+  fi
+else
+  echo "  note: no $build; operator ninja overlay log is the proof (expected: all twelve OVERLAY … built)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "PASS -- compiler-rt darwin builtins archive resolves __divti3/__udivti3/__floattidf/__isPlatformVersionAtLeast"
+  exit 0
+fi
+echo "FAIL"
+exit 1

--- a/swiftcore-macho/scripts/test_sdk_overlays.sh
+++ b/swiftcore-macho/scripts/test_sdk_overlays.sh
@@ -77,6 +77,34 @@ if [ -f "$SDK/usr/include/Darwin.modulemap" ] \
     && echo "  OK  NSObject hash" || { echo "  FAIL missing NSObject hash"; fail=1; }
   echo "$nm_o" | grep -q 'ObjectiveC8SelectorV' \
     && echo "  OK  Selector helpers" || { echo "  FAIL missing Selector"; fail=1; }
+  # The five SDK overlays must not grow Darwin's LC_REEXPORT_DYLIB set.
+  for n in libswift_DarwinFoundation1.dylib libswift_DarwinFoundation2.dylib \
+           libswift_DarwinFoundation3.dylib libswift_errno.dylib \
+           libswiftObjectiveC.dylib; do
+    f=$B/lib/swift/macosx/x86_64/$n
+    [ -f "$f" ] || continue
+    rx=$("$OTOOL" -l "$f" | awk '/LC_REEXPORT_DYLIB/{c++} END{print c+0}')
+    [ "$rx" -eq 0 ] && echo "  OK  $n has 0 LC_REEXPORT_DYLIB" \
+      || { echo "  FAIL $n has $rx LC_REEXPORT_DYLIB (only Darwin re-exports the shells)"; fail=1; }
+  done
+  darwin=$B/lib/swift/macosx/x86_64/libswiftDarwin.dylib
+  [ -f "$darwin" ] || darwin=$B/lib/swift/macosx/x86_64/libswiftDarwin.so
+  if [ -f "$darwin" ]; then
+    # shellcheck source=overlay_targets.inc
+    . "$SCRIPT_DIR/overlay_targets.inc"
+    have=$(overlay_darwin_lc_reexport_names "$darwin")
+    want=$(overlay_darwin_reexport_install_names | sort -u)
+    if [ "$(printf '%s\n' "$have")" = "$(printf '%s\n' "$want")" ]; then
+      echo "  OK  libswiftDarwin has exactly four LC_REEXPORT_DYLIB"
+    else
+      echo "  FAIL libswiftDarwin LC_REEXPORT_DYLIB:"
+      echo "    have:"; printf '%s\n' "$have" | sed 's/^/      /'
+      echo "    want:"; printf '%s\n' "$want" | sed 's/^/      /'
+      fail=1
+    fi
+  else
+    echo "  note: libswiftDarwin not in this live recipe (ninja target; operator overlay loop)"
+  fi
 else
   echo "  skip live recipe (no MacOSX.sdk Darwin map or Swift.swiftmodule)"
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## After PR #60 (overlays3.log)

`__isPlatformVersionAtLeast` is gone. The next missing builtin is `__divti3`. Same operator command (`NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift bash swiftcore-macho/scripts/build_stdlib.sh`):

```
OVERLAY swiftDarwin-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __divti3
OVERLAY swift_Concurrency-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __divti3
OVERLAY swiftSynchronization-macosx-x86_64 FAILED dep=swiftDarwin
OVERLAY swift_StringProcessing-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __divti3
OVERLAY swift_Builtin_float-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __divti3
OVERLAY swift_RegexParser-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __divti3
OVERLAY swiftObservation-macosx-x86_64 FAILED first_error=ld64.lld: error: undefined symbol: __divti3
OVERLAY swift_DarwinFoundation1/2/3, swift_errno, swiftObjectiveC  built
```

Vendoring builtins one file per failure is the wrong shape: Apple's `libclang_rt.osx.a` is the whole generic C builtins library, and ld64 archive-searches whatever members the overlays reference (`__divti3`, `__modti3`, `__udivti3`, `__umodti3`, `__floattidf`, `__fixunsdfti`, `__popcountdi2`, `__clzti2`, atomics, `__isPlatformVersionAtLeast`, …). `cxx_runtime=` / `compiler_rt=` lines already put the archive on the Darwin link.

## compiler-rt builtins archive

`swiftcore-macho/scripts/build_compiler_rt_osx.sh` now fetches pinned **llvm-project llvmorg-18.1.8** into `scratch/` (do not commit sources):

| pin | value |
|---|---|
| tag | `llvmorg-18.1.8` |
| commit | `3b5b5c1ec4a3095ab096dd780e84d7ab81f3d7ff` |
| tarball | `compiler-rt-18.1.8.src.tar.xz` |
| sha256 | `e054e99a9c9240720616e927cb52363abbc8b4f1ef0286bad3df79ec8fdf892f` |

It compiles `lib/builtins/*.c` plus the x86_64 `.S`/`.c` files Apple includes for that arch (`arm64` is a parameter). ELF `crtbegin.c`/`crtend.c` and TUs that need a Darwin kernel header the sysroot lacks are printed on `compiler-rt excluded:`. In-tree `compiler-rt/os_version_check.c` keeps the PR #60 override (always-yes `_availability_version_check`, local `dispatch_once_f`). Archive with `llvm-ar` (Mach-O index).

One-line summary measured on this VM:

```
compiler-rt darwin builtins: members=181 arch=x86_64 sha256=5334976ddb3991ccca4c3717a373d712e32483306dd33eb370086d4765ab1c79
compiler-rt excluded (3): crtbegin.c, crtend.c, upstream os_version_check.c (in-tree override)
```

## nm proof (this VM, ld64.lld NOUNDEFS)

`scripts/test_compiler_rt_osx.sh` compiles a tiny `x86_64-apple-macos` object that references `__divti3`, `__udivti3`, `__floattidf`, `__isPlatformVersionAtLeast`, links it against the archive, and checks `llvm-nm -u`:

```
OK  llvm-nm -u has no __divti3
OK  llvm-nm -u has no __udivti3
OK  llvm-nm -u has no __floattidf
OK  llvm-nm -u has no __isPlatformVersionAtLeast
archive: T ___divti3 / T ___udivti3 / T ___floattidf / T ___isPlatformVersionAtLeast
```

No overlay `.o` tree under `$W/build` on this VM; the operator ninja overlay log is the proof for overlay undefs.

Does **not** weaken overlay NOUNDEFS (no `-undefined dynamic_lookup`), does **not** export builtins from gen_tbd libSystem, does **not** touch `libswiftcompat`.

## libswiftDarwin must re-export the four shells

After PR #59 the x86 widget gate gets past FoundationEssentials and stops at OpenUIKit:

```
focus_widget_guest: libOpenUIKit dylib loads changed
@@ -8,3 +8,4 @@
 /usr/lib/libquartz.dylib
 /usr/lib/swift/libswift_Concurrency.dylib
 /usr/lib/swift/libswiftObjectiveC.dylib
+/usr/lib/swift/libswift_DarwinFoundation1.dylib
```

Apple's x86_64 `libswiftDarwin.dylib` carries `LC_REEXPORT_DYLIB` of `/usr/lib/swift/libswift_Builtin_float.dylib`, `libswift_DarwinFoundation1.dylib`, `libswift_DarwinFoundation2.dylib`, `libswift_DarwinFoundation3.dylib` (154 own exports + those four re-exports). Apple's `libswiftDarwin.tbd` lists them under `reexported-libraries`. A consumer that references `__swift_FORCE_LOAD_$_swift_DarwinFoundation1` (every Darwin importer — the shells are built `-autolink-force-load`) records the bind against libswiftDarwin and never records DarwinFoundation1 itself.

The overlay link recipe now passes `-Xlinker -reexport_library` of those four when linking `libswiftDarwin` only (`clangxx_darwin_link.py`). `overlay_build_xcode_shells` runs **before** the Darwin ninja target; `overlay_candidate_targets` ninja's `swift_Builtin_float` before `swiftDarwin`. `scripts/x86/gen_swift_tbd.sh` already records `reexported-libraries` from `LC_REEXPORT_DYLIB` (verified: synthetic Darwin tbd lists the four). No re-exports on any other overlay.

**machorun already follows `LC_REEXPORT_DYLIB` for two-level binds** (libSystem umbrellas). No loader change.

## Operator command (expected scoreboard)

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

Expected: all twelve overlays `built`, each Darwin link prints `compiler_rt=` naming `$W/build/libclang_rt.osx.a`, `libswiftDarwin.dylib` has exactly those four `LC_REEXPORT_DYLIB`.

```
OVERLAY swift_Builtin_float-macosx-x86_64 built
OVERLAY swiftDarwin-macosx-x86_64 built
OVERLAY swift_Concurrency-macosx-x86_64 built
OVERLAY swift_StringProcessing-macosx-x86_64 built
OVERLAY swift_RegexParser-macosx-x86_64 built
OVERLAY swiftObservation-macosx-x86_64 built
OVERLAY swiftSynchronization-macosx-x86_64 built
OVERLAY swift_DarwinFoundation1-macosx-x86_64 built
OVERLAY swift_DarwinFoundation2-macosx-x86_64 built
OVERLAY swift_DarwinFoundation3-macosx-x86_64 built
OVERLAY swift_errno-macosx-x86_64 built
OVERLAY swiftObjectiveC-macosx-x86_64 built
```

## Tests

- `swiftcore-macho/scripts/test_compiler_rt_osx.sh` — archive member count, nm of the four helpers, ld64.lld NOUNDEFS probe
- `swiftcore-macho/scripts/test_clangxx_darwin_link.sh` — Darwin driver argv has four `-reexport_library`; ObjectiveC has none
- `scripts/x86/test_gen_swift_tbd.sh` — synthetic Darwin tbd `reexported-libraries`
- `test_overlay_targets.sh` / `test_overlay_scoreboard.sh` / `test_ninja_rc.sh`

[compiler-rt archive and Darwin re-export proof log](https://cursor.com/agents/bc-a0740942-3043-43ed-9288-0b6901c27a6c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompiler_rt_and_darwin_reexport_proof.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0740942-3043-43ed-9288-0b6901c27a6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0740942-3043-43ed-9288-0b6901c27a6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

