### PR TITLE
Refuse to reuse a machorun product older than HEAD:machorun

### DIFF
--- a/scripts/env/prepare.py
+++ b/scripts/env/prepare.py
@@ -330,18 +330,88 @@ def verify_absolute_hash(path: Path, expected: str, ident: str) -> Outcome:
     return Outcome("satisfied", ident, f"sha256={expected} reused=1")
 
 
+# Loader stamp: machorun/build/.source-tree, one git tree hash, same identifier
+# as `git rev-parse HEAD:machorun` / the machorun-inrepo attestation.
+#
+# build.sh already writes build/.input-hashes (check_stale.sh --stamp): one
+# content hash per artefact. The loader row hashes `src` + `scripts/build.sh`
+# for *.c/*.h/*.cpp/*.mm/*.m/*.sh, and darwin/objc4/quartz have their own
+# rows. That would have caught a util.c change. It is still the wrong
+# identifier for this gate: the in-repo pin prints HEAD:machorun, and the
+# measured failure was that attestation naming the NEW tree while a binary
+# built from the OLD tree passed every existence check. .input-hashes also
+# misses *.S (tlv_asm.S). Reuse compares the tree the pin already names.
+LOADER_SOURCE_TREE_STAMP = Path("machorun") / "build" / ".source-tree"
+
+
+def source_tree_stamp_path(product: Path) -> Path:
+    """Stamp file next to a built product.
+
+    The loader uses the contracted name machorun/build/.source-tree. Other
+    products (libSystem.B.dylib, libobjc.A.dylib, libquartz.dylib,
+    libSystem.tbd) get a sibling .source-tree.<basename> so a stamp written
+    after rebuilding one cannot make a different artefact look fresh.
+    """
+    if product.name == "machorun":
+        return product.parent / ".source-tree"
+    return product.parent / f".source-tree.{product.name}"
+
+
+def loader_source_tree_stamp(root: Path) -> Path:
+    return root / LOADER_SOURCE_TREE_STAMP
+
+
+def head_machorun_tree(root: Path) -> str:
+    """Git tree of HEAD:machorun, or empty if it cannot be read."""
+    result = _run(["git", "-C", str(root), "rev-parse", "HEAD:machorun"])
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def read_source_tree_stamp(stamp: Path) -> str:
+    if not stamp.is_file() or stamp.is_symlink():
+        return ""
+    return stamp.read_text(encoding="utf-8").strip()
+
+
+def write_source_tree_stamp(stamp: Path, tree: str) -> None:
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text(tree + "\n", encoding="utf-8")
+
+
+def source_tree_mismatch_reason(root: Path, stamp: Path) -> str | None:
+    """None when the stamp matches HEAD:machorun; else no-stamp / source-tree old→new."""
+    live = head_machorun_tree(root)
+    recorded = read_source_tree_stamp(stamp)
+    if not recorded:
+        return "no-stamp"
+    if live and recorded == live:
+        return None
+    return f"source-tree {recorded}→{live or 'unknown'}"
+
+
 def maybe_build_loader(root: Path, verify_only: bool, arch: str) -> Outcome:
     loader = root / "machorun" / "build" / "machorun"
-    if loader.is_file() and os.access(loader, os.X_OK) and not loader.is_symlink():
+    stamp = loader_source_tree_stamp(root)
+    present = loader.is_file() and os.access(loader, os.X_OK) and not loader.is_symlink()
+    reason = source_tree_mismatch_reason(root, stamp)
+    if present and reason is None:
         return Outcome("satisfied", "machorun-loader", f"path={loader} reused=1")
-    if arch not in ("aarch64", "arm64"):
+    if present:
+        # A binary older than HEAD:machorun must not look satisfied. verify_only
+        # reports the reason; otherwise rebuild even on x86_64 — this host
+        # already produced a loader. A missing loader on x86_64 stays cannot.
+        if verify_only:
+            return Outcome("unsatisfied", "machorun-loader", f"reason={reason}")
+    elif arch not in ("aarch64", "arm64"):
         return Outcome(
             "cannot",
             "machorun-loader",
             f"host={arch}",
             marker="CURSOR_ENV_CANNOT_BUILD_LOADER",
         )
-    if verify_only:
+    elif verify_only:
         return Outcome("unsatisfied", "machorun-loader", "missing loader")
     built = _run(["sh", str(root / "machorun" / "scripts" / "build.sh"), "loader"], cwd=root)
     if built.returncode != 0 or not loader.is_file():
@@ -351,7 +421,11 @@ def maybe_build_loader(root: Path, verify_only: bool, arch: str) -> Outcome:
             "machorun-loader",
             tail[-1] if tail else "build.sh loader failed",
         )
-    return Outcome("cold-built", "machorun-loader", f"path={loader}")
+    live = head_machorun_tree(root)
+    if live:
+        write_source_tree_stamp(stamp, live)
+    extra = f" reason={reason}" if reason else ""
+    return Outcome("cold-built", "machorun-loader", f"path={loader}{extra}")
 
 
 def product_outcome(
@@ -398,10 +472,13 @@ def product_outcome(
             return Outcome("unsatisfied", ident, f"missing {','.join(missing)}")
         return Outcome("satisfied", ident, f"files={len(hashes)}/{len(hashes)} reused=1")
     if ident == "tbd-stubs":
-        # gen_tbd is host-independent (nm on dylibs ∪ loader exports). With
-        # FULL_OUT_SUFFIX set, actually try it — never refuse solely because
-        # uname is x86_64. Empty suffix keeps the historical arm64/Linux
-        # cannot so existing tests stay byte-identical.
+        # Presence-only reuse. The x86 operator path (phase2.sh ensure_tbd)
+        # refuses a .tbd older than HEAD:machorun; this row does not
+        # cold-build darwin/objc4/quartz. gen_tbd is host-independent (nm on
+        # dylibs ∪ loader exports). With FULL_OUT_SUFFIX set, actually try
+        # it — never refuse solely because uname is x86_64. Empty suffix
+        # keeps the historical arm64/Linux cannot so existing tests stay
+        # byte-identical.
         if suffix:
             if path.is_dir() and any(path.glob("*.tbd")):
                 return Outcome("satisfied", ident, "tbd present reused=1")
@@ -466,6 +543,9 @@ def product_outcome(
             marker="CURSOR_ENV_CANNOT_BUILD_MODCACHE_SWIFTUI_GUEST",
         )
     if ident == "darwin-userland":
+        # Presence-only: this row does not cold-build. machorun-darwin /
+        # objc4 / quartz reuse-by-existence lives in scripts/x86/phase2.sh
+        # ensure_* and is stamped against HEAD:machorun there.
         probe = path / "libSystem.B.dylib"
         if probe.is_file() and not probe.is_symlink():
             return Outcome("satisfied", ident, f"path={path} reused=1")

--- a/scripts/env/test_prepare.py
+++ b/scripts/env/test_prepare.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import tempfile
 import unittest
+from unittest.mock import patch
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -19,9 +20,12 @@ from prepare import (  # noqa: E402
     expected_cannot_for_host,
     guest_out_suffix,
     host_arch,
+    loader_source_tree_stamp,
+    maybe_build_loader,
     prepare,
     resolve_row_path,
     summarize,
+    write_source_tree_stamp,
 )
 from contract import load_contract  # noqa: E402
 
@@ -239,6 +243,119 @@ class SuffixPathPrepareTests(unittest.TestCase):
             self.assertEqual(len(oc), 1, proc.stdout)
             self.assertNotIn("CURSOR_ENV_CANNOT_BUILD_OPENCOMBINE_EXPORT", oc[0])
             self.assertIn("export-x86_64", oc[0])
+
+
+class LoaderSourceTreeTests(unittest.TestCase):
+    """Reuse a loader only when machorun/build/.source-tree matches HEAD:machorun.
+
+    A binary older than its own source used to pass every gate: existence was
+    the only test, while machorun-inrepo attested the new tree.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="env-prepare-loader.")
+        self.root = Path(self._tmp.name)
+        (self.root / "machorun" / "src").mkdir(parents=True)
+        (self.root / "machorun" / "scripts").mkdir(parents=True)
+        (self.root / "machorun" / "src" / "util.c").write_text("int x;\n", encoding="utf-8")
+        (self.root / "machorun" / "scripts" / "build.sh").write_text(
+            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        )
+        subprocess.run(["git", "init"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(["git", "add", "machorun"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.email=prepare-test@example.com",
+                "-c",
+                "user.name=prepare-test",
+                "commit",
+                "-m",
+                "init",
+            ],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+        )
+        tree = subprocess.run(
+            ["git", "rev-parse", "HEAD:machorun"],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.tree = tree.stdout.strip()
+        self.build_calls: list[list[str]] = []
+        import prepare as prepare_mod
+
+        self._orig_run = prepare_mod._run
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _touch_loader(self) -> Path:
+        loader = self.root / "machorun" / "build" / "machorun"
+        loader.parent.mkdir(parents=True, exist_ok=True)
+        loader.write_bytes(b"fake-loader\n")
+        loader.chmod(0o755)
+        return loader
+
+    def _intercept_build(self, argv: list[str], cwd=None):
+        if argv and argv[0] == "sh" and len(argv) >= 3 and argv[2] == "loader":
+            self.build_calls.append(list(argv))
+            self._touch_loader()
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        return self._orig_run(argv, cwd=cwd)
+
+    def test_matching_stamp_is_satisfied_reused(self) -> None:
+        loader = self._touch_loader()
+        write_source_tree_stamp(loader_source_tree_stamp(self.root), self.tree)
+        with patch("prepare._run", side_effect=self._intercept_build):
+            out = maybe_build_loader(self.root, verify_only=False, arch="aarch64")
+        self.assertEqual(out.status, "satisfied")
+        self.assertEqual(out.id, "machorun-loader")
+        self.assertIn("reused=1", out.detail)
+        self.assertIn(str(loader), out.detail)
+        self.assertEqual(self.build_calls, [])
+
+    def test_stale_stamp_cold_builds_with_reason(self) -> None:
+        self._touch_loader()
+        old = "a" * 40
+        write_source_tree_stamp(loader_source_tree_stamp(self.root), old)
+        with patch("prepare._run", side_effect=self._intercept_build):
+            out = maybe_build_loader(self.root, verify_only=False, arch="aarch64")
+        self.assertEqual(out.status, "cold-built")
+        self.assertEqual(len(self.build_calls), 1)
+        self.assertIn(f"reason=source-tree {old}→{self.tree}", out.detail)
+        self.assertEqual(
+            loader_source_tree_stamp(self.root).read_text(encoding="utf-8").strip(),
+            self.tree,
+        )
+
+    def test_missing_stamp_cold_builds(self) -> None:
+        self._touch_loader()
+        self.assertFalse(loader_source_tree_stamp(self.root).exists())
+        with patch("prepare._run", side_effect=self._intercept_build):
+            out = maybe_build_loader(self.root, verify_only=False, arch="aarch64")
+        self.assertEqual(out.status, "cold-built")
+        self.assertEqual(len(self.build_calls), 1)
+        self.assertIn("reason=no-stamp", out.detail)
+        self.assertEqual(
+            loader_source_tree_stamp(self.root).read_text(encoding="utf-8").strip(),
+            self.tree,
+        )
+
+    def test_verify_only_stale_is_unsatisfied_never_satisfied(self) -> None:
+        self._touch_loader()
+        old = "b" * 40
+        write_source_tree_stamp(loader_source_tree_stamp(self.root), old)
+        with patch("prepare._run", side_effect=self._intercept_build):
+            out = maybe_build_loader(self.root, verify_only=True, arch="aarch64")
+        self.assertEqual(out.status, "unsatisfied")
+        self.assertIn(f"reason=source-tree {old}→{self.tree}", out.detail)
+        self.assertEqual(self.build_calls, [])
+        self.assertNotIn("reused=1", out.detail)
 
 
 if __name__ == "__main__":

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -74,6 +74,58 @@ phase2_git() {
         -C "$abs" "$@"
 }
 
+# Product stamp next to the artefact. The loader uses the contracted name
+# machorun/build/.source-tree (same identifier as HEAD:machorun / the
+# machorun-inrepo attestation). Other products get a sibling
+# .source-tree.<basename> so rebuilding the loader cannot make darwin/objc4/
+# quartz/tbd look fresh. build.sh's build/.input-hashes hashes a filtered
+# glob (*.c/*.h/*.sh, not *.S) under a different identifier than the pin;
+# reuse names the tree the pin already prints. A binary older than its own
+# source must not pass every gate.
+phase2_source_tree_stamp_path() {
+    local product=$1
+    local dir base
+    dir=$(dirname "$product")
+    base=$(basename "$product")
+    if [ "$base" = machorun ]; then
+        printf '%s/.source-tree\n' "$dir"
+    else
+        printf '%s/.source-tree.%s\n' "$dir" "$base"
+    fi
+}
+
+# Empty stdout = stamp matches HEAD:machorun. Otherwise no-stamp or
+# source-tree <old>→<new>.
+phase2_source_tree_reason() {
+    local root=$1 product=$2
+    local live stamp_file stamp
+    live=$(phase2_git "$root" rev-parse HEAD:machorun 2>/dev/null | tr -d '[:space:]') || live=
+    stamp_file=$(phase2_source_tree_stamp_path "$product")
+    if [ ! -f "$stamp_file" ]; then
+        printf '%s\n' no-stamp
+        return 0
+    fi
+    stamp=$(tr -d '[:space:]' < "$stamp_file")
+    if [ -z "$stamp" ]; then
+        printf '%s\n' no-stamp
+        return 0
+    fi
+    if [ -n "$live" ] && [ "$stamp" = "$live" ]; then
+        return 0
+    fi
+    printf 'source-tree %s→%s\n' "$stamp" "${live:-unknown}"
+}
+
+phase2_write_source_tree_stamp() {
+    local root=$1 product=$2
+    local live stamp_file
+    live=$(phase2_git "$root" rev-parse HEAD:machorun 2>/dev/null | tr -d '[:space:]') || return 1
+    [ -n "$live" ] || return 1
+    stamp_file=$(phase2_source_tree_stamp_path "$product")
+    mkdir -p "$(dirname "$stamp_file")"
+    printf '%s\n' "$live" > "$stamp_file"
+}
+
 # Probe Focus pin. One line, never silent:
 #   MATCH toplevel=... observed=<sha>
 #   MISMATCH start=... toplevel=... expected=<sha> observed=<sha>

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -198,14 +198,17 @@ echo "==== machorun substrate (build.sh all, objc4, quartz, tbd) ===="
 
 ensure_loader() {
     local bin=$MACHORUN/build/machorun
-    if phase2_is_elf_x86_loader "$bin"; then
-        note machorun-loader satisfied
+    local reason
+    reason=$(phase2_source_tree_reason "$W" "$bin")
+    if phase2_is_elf_x86_loader "$bin" && [ -z "$reason" ]; then
+        note machorun-loader satisfied "reused=1"
         return 0
     fi
-    echo "== cold-build loader (CC=$CC)"
+    echo "== cold-build loader (CC=$CC${reason:+; reason=$reason})"
     sh "$MACHORUN/scripts/build.sh" loader
     if phase2_is_elf_x86_loader "$bin"; then
-        note machorun-loader cold-built
+        phase2_write_source_tree_stamp "$W" "$bin" || true
+        note machorun-loader cold-built "${reason:+reason=$reason}"
         return 0
     fi
     cannot machorun-loader BUILD_LOADER "scripts/build.sh loader did not produce an x86-64 ELF PIE at $bin"
@@ -214,14 +217,17 @@ ensure_loader() {
 
 ensure_darwin() {
     local dylib=$MACHORUN/darwin/usr/lib/libSystem.B.dylib
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        note machorun-darwin satisfied
+    local reason
+    reason=$(phase2_source_tree_reason "$W" "$dylib")
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib" && [ -z "$reason" ]; then
+        note machorun-darwin satisfied "reused=1"
         return 0
     fi
-    echo "== cold-build darwin userland (x86_64-apple-macos)"
+    echo "== cold-build darwin userland (x86_64-apple-macos${reason:+; reason=$reason})"
     sh "$MACHORUN/scripts/build.sh" darwin
     if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        note machorun-darwin cold-built
+        phase2_write_source_tree_stamp "$W" "$dylib" || true
+        note machorun-darwin cold-built "${reason:+reason=$reason}"
         return 0
     fi
     cannot machorun-darwin BUILD_DARWIN "libSystem.B.dylib is not X86_64 Mach-O after build.sh darwin ($(file -b "$dylib" 2>/dev/null || echo missing))"
@@ -230,14 +236,17 @@ ensure_darwin() {
 
 ensure_objc4() {
     local dylib=$MACHORUN/darwin/usr/lib/libobjc.A.dylib
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        note machorun-objc4 satisfied
+    local reason
+    reason=$(phase2_source_tree_reason "$W" "$dylib")
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib" && [ -z "$reason" ]; then
+        note machorun-objc4 satisfied "reused=1"
         return 0
     fi
-    echo "== cold-build objc4 (unblocks the objc fixture CANNOT_BUILD_LIBOBJC_X86)"
+    echo "== cold-build objc4 (unblocks the objc fixture CANNOT_BUILD_LIBOBJC_X86${reason:+; reason=$reason})"
     bash "$MACHORUN/scripts/build_objc4.sh"
     if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        note machorun-objc4 cold-built
+        phase2_write_source_tree_stamp "$W" "$dylib" || true
+        note machorun-objc4 cold-built "${reason:+reason=$reason}"
         return 0
     fi
     cannot machorun-objc4 BUILD_LIBOBJC_X86 "libobjc.A.dylib is not X86_64 Mach-O after build_objc4.sh"
@@ -246,14 +255,17 @@ ensure_objc4() {
 
 ensure_quartz() {
     local dylib=$MACHORUN/darwin/usr/lib/libquartz.dylib
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        note machorun-quartz satisfied
+    local reason
+    reason=$(phase2_source_tree_reason "$W" "$dylib")
+    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib" && [ -z "$reason" ]; then
+        note machorun-quartz satisfied "reused=1"
         return 0
     fi
-    echo "== cold-build quartz"
+    echo "== cold-build quartz${reason:+; reason=$reason}"
     bash "$MACHORUN/scripts/build_quartz.sh"
     if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        note machorun-quartz cold-built
+        phase2_write_source_tree_stamp "$W" "$dylib" || true
+        note machorun-quartz cold-built "${reason:+reason=$reason}"
         return 0
     fi
     cannot machorun-quartz BUILD_QUARTZ_X86 "libquartz.dylib is not X86_64 Mach-O after build_quartz.sh"
@@ -262,10 +274,12 @@ ensure_quartz() {
 
 ensure_tbd() {
     local tbd=$MACHORUN/sdk/usr/lib/libSystem.tbd
-    if [ -s "$tbd" ] && grep -q x86_64 "$tbd" && [ -x "$MACHORUN/build/machorun" ]; then
+    local reason
+    reason=$(phase2_source_tree_reason "$W" "$tbd")
+    if [ -s "$tbd" ] && grep -q x86_64 "$tbd" && [ -x "$MACHORUN/build/machorun" ] && [ -z "$reason" ]; then
         # Idempotent: a non-empty x86_64-macos tbd plus a live loader is enough.
         if grep -q 'x86_64-macos' "$tbd" 2>/dev/null || grep -q x86_64 "$tbd"; then
-            note machorun-tbd satisfied
+            note machorun-tbd satisfied "reused=1"
             return 0
         fi
     fi
@@ -273,7 +287,7 @@ ensure_tbd() {
         cannot machorun-tbd GENERATE_TBD "gen_tbd.sh CHECK 1 needs the host ELF loader; loader is missing"
         return 1
     fi
-    echo "== cold-generate .tbd (CHECK 1 against this loader)"
+    echo "== cold-generate .tbd (CHECK 1 against this loader${reason:+; reason=$reason})"
     # CHECK 4 scans every dylib under darwin/usr/lib. An arm64 staged
     # libswiftcompat beside a freshly built x86 libSystem is a mixed-slice
     # coin toss, not a generated stub. Park arm64 dylibs beside (do not
@@ -297,7 +311,8 @@ ensure_tbd() {
     st=$?
     set -e
     if [ "$st" -eq 0 ] && [ -s "$tbd" ]; then
-        note machorun-tbd cold-built
+        phase2_write_source_tree_stamp "$W" "$tbd" || true
+        note machorun-tbd cold-built "${reason:+reason=$reason}"
         return 0
     fi
     tbd_state=missing

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -94,6 +94,49 @@ expect_grep 'Column 2 is cputype' "$COMMON" "x86 Mach-O check documents cputype 
 expect_grep 'RUNG_SCOREBOARD' "$PHASE2" "RUNG_SCOREBOARD"
 expect_grep 'ENV_PREPARE_SUMMARY' "$PHASE2" "ENV_PREPARE_SUMMARY"
 expect_grep 'never overwrite' "$PHASE2" "arm64 overwrite refusal in header"
+expect_grep 'phase2_source_tree_reason' "$PHASE2" \
+    "machorun substrate reuse consults HEAD:machorun stamp"
+expect_grep 'phase2_write_source_tree_stamp' "$PHASE2" \
+    "cold-build writes .source-tree next to the product"
+expect_grep 'reused=1' "$PHASE2" "satisfied loader/darwin/objc4/quartz/tbd print reused=1"
+expect_grep ':+reason=' "$PHASE2" "cold-built prints reason=source-tree or no-stamp"
+
+echo "== source-tree stamp helpers (HEAD:machorun, not existence)"
+# shellcheck source=common.inc
+. "$COMMON"
+STAMP_FIX=$(mktemp -d /tmp/phase2-source-tree.XXXXXX)
+mkdir -p "$STAMP_FIX/machorun/src" "$STAMP_FIX/machorun/build"
+printf 'int x;\n' > "$STAMP_FIX/machorun/src/util.c"
+git -C "$STAMP_FIX" -c init.defaultBranch=main init -q >/dev/null
+git -C "$STAMP_FIX" add machorun
+git -C "$STAMP_FIX" -c user.email=phase2-test@example.com -c user.name=phase2-test \
+    commit -q -m init
+LIVE_TREE=$(phase2_git "$STAMP_FIX" rev-parse HEAD:machorun)
+LOADER_BIN=$STAMP_FIX/machorun/build/machorun
+reason=$(phase2_source_tree_reason "$STAMP_FIX" "$LOADER_BIN")
+if [ "$reason" = no-stamp ]; then
+    ok "missing stamp is reason=no-stamp"
+else
+    die_test "missing stamp expected no-stamp, got: $reason"
+fi
+phase2_write_source_tree_stamp "$STAMP_FIX" "$LOADER_BIN"
+reason=$(phase2_source_tree_reason "$STAMP_FIX" "$LOADER_BIN")
+if [ -z "$reason" ]; then
+    ok "matching HEAD:machorun stamp is reusable"
+else
+    die_test "matching stamp should be empty reason, got: $reason"
+fi
+printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > "$(phase2_source_tree_stamp_path "$LOADER_BIN")"
+reason=$(phase2_source_tree_reason "$STAMP_FIX" "$LOADER_BIN")
+case "$reason" in
+    source-tree\ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa→"$LIVE_TREE")
+        ok "stale stamp is source-tree old→HEAD:machorun ($reason)"
+        ;;
+    *)
+        die_test "stale stamp expected source-tree old→$LIVE_TREE, got: $reason"
+        ;;
+esac
+rm -rf "$STAMP_FIX"
 
 echo "== denominators (committed runners, not invented)"
 smoke=$(grep -c '^check(' "$UD_RUNNER" || true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Measurement (x86_64 box, main `04004023`, after PR #62)

`scripts/env/prepare.py` `maybe_build_loader` treated a loader as current if the file existed. After PR #62 (`machorun/src/util.c` changed at 08:00) a loader built at 07:38 from PR #55 source still passed every gate:

```
ENV_PREPARE machorun-loader satisfied
ENV_PREPARE_SATISFIED id=machorun-inrepo tree=9d4fdacc7b0f0890a7d6559daff291448eaef95f reused=1
ENV_PREPARE_SATISFIED id=machorun-loader path=.../machorun/build/machorun reused=1
focus_widget_guest: attested machorun source=HEAD:machorun tree=9d4fdacc…
…
machorun: .../libswift_DarwinFoundation2.dylib: dyld-shared-cache image without fixup info; not loadable
```

The tree attestation named the NEW source (`9d4fdacc`, which contains the fix) while the binary that ran was built from the OLD source. `machorun/build/.input-hashes` existed (written by `build.sh`) but `prepare.py` never consulted it. A binary older than its own source passed every check.

## Rule

Reuse a machorun product only when it is provably from the current source: compare `git rev-parse HEAD:machorun` (the same value `machorun-inrepo` prints) against a stamp written next to the product at build time.

- Loader stamp: `machorun/build/.source-tree`, written by `prepare.py` after a successful `build.sh loader` and by `phase2.sh` after each substrate cold-build.
- Darwin / objc4 / quartz / tbd get a sibling `.source-tree.<basename>` so rebuilding one artefact cannot make another look fresh.
- Mismatch → rebuild (`cold-built`) with `reason=source-tree <old>→<new>`.
- Missing stamp → rebuild with `reason=no-stamp`.
- `verify_only` → `unsatisfied` with the same reason, never `satisfied`.

**Why `.source-tree` (HEAD:machorun), not `.input-hashes`:** `check_stale.sh` already records per-artefact content hashes covering `src/*.c` (and darwin/objc4/quartz inputs) via a `*.c/*.h/*.sh` glob. That would have caught a `util.c` change. It is still the wrong identifier for this gate: the in-repo pin prints `HEAD:machorun`, and the failure was that attestation naming the new tree while an old binary passed every existence check. `.input-hashes` also misses `*.S` (`tlv_asm.S`). Reuse names the tree the pin already attests.

`maybe_build_loader` is the prepare.py existence-reuse path. `machorun-darwin` / `objc4` / `quartz` / `tbd` live in `scripts/x86/phase2.sh` `ensure_*` (same existence-reuse bug); those now use the same stamp. `darwin-userland` and `tbd-stubs` in prepare.py remain presence-only (they do not cold-build).

## Operator command (x86 box)

```bash
bash x86_stage_inputs_phase2.sh
```

After a machorun source change, expect:

```
ENV_PREPARE machorun-loader cold-built reason=source-tree <old>→<new>
```

(or `reason=no-stamp` if the product was never stamped). Second run, unchanged source:

```
ENV_PREPARE machorun-loader satisfied reused=1
```

## Tests (this VM)

- `python3 scripts/env/test_prepare.py` — **12 passed** (4 new stamp cases: matching reused=1, stale cold-built, no-stamp cold-built, verify_only stale unsatisfied; `_run` monkeypatched, temp git fixture so `HEAD:machorun` resolves).
- `python3 scripts/env/test_contract.py` — **10 passed**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32e2c339-1b81-4e53-8444-f916550df0c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32e2c339-1b81-4e53-8444-f916550df0c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

