### PR TITLE
Rung a: LD_PRELOAD Dispatch host bridge so libCFTest can bind _dispatch_*

### DIFF
--- a/foundation-macho/scripts/run_ud_guest.sh
+++ b/foundation-macho/scripts/run_ud_guest.sh
@@ -22,6 +22,10 @@
 # differently and only one of them is what this root is supposed to have.
 set -uo pipefail
 
+HERE=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=ud_dispatch_run.inc
+. "$HERE/ud_dispatch_run.inc"
+
 W=${W:-/work}
 ROOT=${1:-$W/root}
 BIN=${BIN:-$W/bin/ud_guest}
@@ -35,7 +39,7 @@ FW_SLOT=$ROOT/darwin/System/Library/Frameworks/Foundation.framework/Foundation
 REAL_CF=$ROOT/darwin/usr/lib/libCFTest.dylib
 
 echo "== root   $ROOT"
-echo "== binary $BIN"
+ud_dispatch_loader_line "$BIN"
 fail=0
 
 for slot in "$FW_SLOT" "$CF_SLOT"; do
@@ -75,9 +79,11 @@ fi
 
 [ "$fail" -eq 0 ] || { echo "REFUSING to run; the root is not fit." >&2; exit 2; }
 
+ud_dispatch_prepare_root || exit $?
+
 echo
-MACHORUN_ROOT=$ROOT "$MRUN" "$BIN"
+ud_dispatch_run "$BIN"
 rc=$?
 echo
-echo "== exit $rc   (root $ROOT)"
+echo "== exit $rc   (root $UD_MACHORUN_ROOT)"
 exit $rc

--- a/foundation-macho/scripts/run_ud_persist.sh
+++ b/foundation-macho/scripts/run_ud_persist.sh
@@ -26,6 +26,10 @@
 #                 this is the run that proves it does not here.
 set -uo pipefail
 
+HERE=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=ud_dispatch_run.inc
+. "$HERE/ud_dispatch_run.inc"
+
 W=${W:-/work}
 R=${R:-/repo}
 ROOT=${1:-$W/root}
@@ -38,6 +42,10 @@ OTHER=$PREFS/$SUITE.other.plist
 
 hr() { echo; echo "########## $*"; }
 
+echo "== root   $ROOT"
+ud_dispatch_loader_line "$BIN"
+ud_dispatch_prepare_root || exit $?
+
 hr "0. clean slate"
 rm -f "$PLIST" "$OTHER"
 echo "  removed $PLIST"
@@ -45,7 +53,7 @@ echo "  removed $PLIST"
 echo "  confirmed absent"
 
 hr "1. WRITE (a process that scores nothing)"
-UD_MODE=persist-write MACHORUN_ROOT="$ROOT" "$MRUN" "$BIN" 2>&1 | grep -vE "_CFGetHostUUIDString"
+UD_MODE=persist-write ud_dispatch_run "$BIN" 2>&1 | grep -vE "_CFGetHostUUIDString"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || { echo "  write phase exited $rc" >&2; exit 3; }
 
@@ -73,7 +81,7 @@ else
 fi
 
 hr "3. READ (a FRESH process; nothing it reads was written by it)"
-UD_MODE=persist-read MACHORUN_ROOT="$ROOT" "$MRUN" "$BIN" 2>&1 \
+UD_MODE=persist-read ud_dispatch_run "$BIN" 2>&1 \
   | grep -vE "_CFGetHostUUIDString" | tail -30
 read_rc=${PIPESTATUS[0]}
 echo "  read phase exit $read_rc"
@@ -84,7 +92,7 @@ rm -f "$PLIST" "$OTHER"
 [ -e "$PLIST" ] && { echo "  REFUSING: the mutation did not take effect" >&2; exit 5; }
 echo "  store deleted and confirmed absent (the mutation TOOK -- #89 lost two"
 echo "  teeth tests to mutations that silently did not)"
-UD_MODE=persist-read MACHORUN_ROOT="$ROOT" "$MRUN" "$BIN" 2>&1 \
+UD_MODE=persist-read ud_dispatch_run "$BIN" 2>&1 \
   | grep -vE "_CFGetHostUUIDString" \
   | grep -E "presence:|witness:|✗|✓ every written|PORT: scored|GUEST SCOREBOARD"
 ctl_rc=${PIPESTATUS[0]}

--- a/foundation-macho/scripts/test_run_ud_guest.sh
+++ b/foundation-macho/scripts/test_run_ud_guest.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Teeth for run_ud_guest.sh / run_ud_persist.sh argv: loader sha256 on the
+# == binary line, no preload without DISPATCH_HOST (the #87 path), and with
+# the Reminder/Focus vars the host is LD_PRELOADed and the Darwin runtime is
+# staged into a run-local overlay rather than the named root.
+#
+#   bash foundation-macho/scripts/test_run_ud_guest.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+FM=$(cd "$HERE/.." && pwd)
+ROOT=$(cd "$FM/.." && pwd)
+GUEST=$HERE/run_ud_guest.sh
+PERSIST=$HERE/run_ud_persist.sh
+INC=$HERE/ud_dispatch_run.inc
+pass=0
+fail=0
+
+ok() { echo "PASS: $*"; pass=$((pass + 1)); }
+die_test() { echo "FAIL: $*" >&2; fail=$((fail + 1)); }
+
+expect_grep() {
+    local needle=$1 hay=$2 label=$3
+    if printf '%s\n' "$hay" | grep -q -- "$needle"; then
+        ok "$label"
+    else
+        die_test "$label (missing: $needle)"
+    fi
+}
+
+echo "== bash -n"
+for s in "$GUEST" "$PERSIST" "$INC"; do
+    if bash -n "$s"; then
+        ok "bash -n $(basename "$s")"
+    else
+        die_test "bash -n $(basename "$s")"
+    fi
+done
+
+guest=$(cat "$GUEST")
+persist=$(cat "$PERSIST")
+inc=$(cat "$INC")
+expect_grep 'ud_dispatch_run.inc' "$guest" "run_ud_guest.sh sources the shared dispatch helper"
+expect_grep 'ud_dispatch_run.inc' "$persist" "run_ud_persist.sh sources the shared dispatch helper"
+expect_grep 'ud_dispatch_loader_line' "$guest" "run_ud_guest.sh prints loader sha256 on == binary"
+expect_grep 'ud_dispatch_loader_line' "$persist" "run_ud_persist.sh prints loader sha256 on == binary"
+expect_grep 'ud_dispatch_prepare_root' "$guest" "run_ud_guest.sh prepares an optional runroot"
+expect_grep 'ud_dispatch_prepare_root' "$persist" "run_ud_persist.sh prepares an optional runroot"
+expect_grep 'ud_dispatch_run' "$guest" "run_ud_guest.sh execs through ud_dispatch_run"
+expect_grep 'UD_MODE=persist-write ud_dispatch_run' "$persist" \
+    "persist WRITE goes through ud_dispatch_run"
+expect_grep 'UD_MODE=persist-read ud_dispatch_run' "$persist" \
+    "persist READ goes through ud_dispatch_run"
+expect_grep 'DISPATCH_HOST' "$inc" "helper reuses the Reminder/Focus DISPATCH_HOST name"
+expect_grep 'OPENUI_DISPATCH_HOST' "$inc" "OPENUI_DISPATCH_HOST is accepted as an alias"
+expect_grep 'LD_PRELOAD' "$inc" "helper LD_PRELOADs the host bridge"
+expect_grep 'LD_LIBRARY_PATH' "$inc" "helper sets LD_LIBRARY_PATH to the host dir"
+expect_grep 'darwin/usr/lib/libOpenDispatch.dylib' "$inc" \
+    "Darwin runtime is staged at /usr/lib/libOpenDispatch.dylib"
+expect_grep 'run-local overlay' "$inc" "helper clones a run-local overlay"
+expect_grep 'BIND_SPECIAL_DYLIB_FLAT_LOOKUP' "$inc" \
+    "helper documents libCFTest's flat dispatch binds"
+expect_grep 'is_runtime' "$inc" "helper cites machorun is_runtime"
+expect_grep 'sha256=' "$inc" "loader line includes sha256="
+# Without the vars the exec must still be MACHORUN_ROOT=$ROOT "$MRUN" (via the
+# helper's empty-preload branch). The #87 default MRUN must remain.
+expect_grep 'MRUN:-/stage/machorun-bin' "$guest" \
+    "run_ud_guest.sh default MRUN is still /stage/machorun-bin"
+expect_grep 'MRUN:-/stage/machorun-bin' "$persist" \
+    "run_ud_persist.sh default MRUN is still /stage/machorun-bin"
+
+echo "== dummy root: no DISPATCH_HOST keeps the #87 argv"
+W=$(mktemp -d /tmp/run-ud-guest.XXXXXX)
+cleanup() { rm -rf "$W"; }
+trap cleanup EXIT
+
+mkdir -p "$W/root/darwin/System/Library/Frameworks/Foundation.framework" \
+    "$W/root/darwin/System/Library/Frameworks/CoreFoundation.framework" \
+    "$W/root/darwin/usr/lib" \
+    "$W/bin"
+echo placeholder > "$W/root/darwin/System/Library/Frameworks/Foundation.framework/Foundation"
+echo placeholder > "$W/root/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+echo cftest > "$W/root/darwin/usr/lib/libCFTest.dylib"
+echo 'int main(void){return 0;}' > "$W/bin/ud_guest"
+
+cat > "$W/fake-mrun" <<'EOF'
+#!/bin/bash
+printf 'MRUN_ARGV %s\n' "$*"
+printf 'MACHORUN_ROOT=%s\n' "${MACHORUN_ROOT:-}"
+printf 'LD_PRELOAD=%s\n' "${LD_PRELOAD:-}"
+printf 'LD_LIBRARY_PATH=%s\n' "${LD_LIBRARY_PATH:-}"
+exit 0
+EOF
+chmod +x "$W/fake-mrun"
+want_sha=$(sha256sum "$W/fake-mrun" | awk '{print $1}')
+
+log=$W/no-dispatch.log
+set +e
+W="$W" BIN="$W/bin/ud_guest" MRUN="$W/fake-mrun" \
+    bash "$GUEST" "$W/root" >"$log" 2>&1
+st=$?
+set -e
+echo "$log:"
+cat "$log"
+
+if [ "$st" -eq 0 ]; then
+    ok "no-DISPATCH_HOST runner exit 0"
+else
+    die_test "no-DISPATCH_HOST runner exit $st log=$(tr '\n' ' ' < "$log")"
+fi
+if grep -q "^== binary $W/bin/ud_guest  loader=$W/fake-mrun sha256=$want_sha" "$log"
+then
+    ok "== binary names loader path and sha256"
+else
+    die_test "== binary line missing loader sha256. got: $(grep '^== binary' "$log")"
+fi
+if grep -q "^MACHORUN_ROOT=$W/root$" "$log" \
+    && grep -q '^LD_PRELOAD=$' "$log"
+then
+    ok "without DISPATCH_HOST, MACHORUN_ROOT is the named root and LD_PRELOAD is empty"
+else
+    die_test "no-dispatch argv drifted: $(grep -E 'MACHORUN_ROOT|LD_PRELOAD' "$log")"
+fi
+if grep -q '^== runroot ' "$log"; then
+    die_test "no-DISPATCH_HOST still printed == runroot"
+else
+    ok "no-DISPATCH_HOST does not clone a runroot"
+fi
+if [ ! -e "$W/runroot" ]; then
+    ok "named root was not cloned when DISPATCH_HOST is unset"
+else
+    die_test "runroot appeared without DISPATCH_HOST"
+fi
+if [ ! -e "$W/root/darwin/usr/lib/libOpenDispatch.dylib" ]; then
+    ok "named root was not mutated without DISPATCH_HOST"
+else
+    die_test "libOpenDispatch.dylib appeared in the named root"
+fi
+
+echo "== DISPATCH_HOST + DISPATCH_DARWIN: preload, runroot, named root untouched"
+mkdir -p "$W/host"
+echo 'int host=1;' | clang-18 -shared -o "$W/host/libOpenDispatchHost.so" -x c - \
+    || echo hostbridge > "$W/host/libOpenDispatchHost.so"
+# Darwin runtime: a regular file is enough for the runner (it copies bytes).
+echo darwin-facade > "$W/libOpenDispatch.dylib"
+
+log=$W/with-dispatch.log
+set +e
+W="$W" BIN="$W/bin/ud_guest" MRUN="$W/fake-mrun" \
+    DISPATCH_HOST="$W/host/libOpenDispatchHost.so" \
+    DISPATCH_DARWIN="$W/libOpenDispatch.dylib" \
+    bash "$GUEST" "$W/root" >"$log" 2>&1
+st=$?
+set -e
+echo "$log:"
+cat "$log"
+
+if [ "$st" -eq 0 ]; then
+    ok "DISPATCH_HOST runner exit 0"
+else
+    die_test "DISPATCH_HOST runner exit $st log=$(tr '\n' ' ' < "$log")"
+fi
+if grep -q "^== runroot $W/runroot$" "$log"; then
+    ok "prints == runroot \$W/runroot"
+else
+    die_test "missing == runroot line: $(grep runroot "$log" || true)"
+fi
+if grep -q "LD_PRELOAD=$W/host/libOpenDispatchHost.so" "$log"; then
+    ok "LD_PRELOAD contains the host bridge"
+else
+    die_test "LD_PRELOAD missing host bridge: $(grep LD_PRELOAD "$log")"
+fi
+if grep -q "LD_LIBRARY_PATH=$W/host" "$log"; then
+    ok "LD_LIBRARY_PATH is the host dir"
+else
+    die_test "LD_LIBRARY_PATH drifted: $(grep LD_LIBRARY_PATH "$log")"
+fi
+if grep -q "^MACHORUN_ROOT=$W/runroot$" "$log"; then
+    ok "MACHORUN_ROOT is the run-local overlay"
+else
+    die_test "MACHORUN_ROOT was not the overlay: $(grep MACHORUN_ROOT "$log")"
+fi
+if [ -f "$W/runroot/darwin/usr/lib/libOpenDispatch.dylib" ] \
+    && cmp -s "$W/libOpenDispatch.dylib" \
+        "$W/runroot/darwin/usr/lib/libOpenDispatch.dylib"
+then
+    ok "Darwin runtime staged at runroot/darwin/usr/lib/libOpenDispatch.dylib"
+else
+    die_test "Darwin runtime missing from runroot"
+fi
+if [ ! -e "$W/root/darwin/usr/lib/libOpenDispatch.dylib" ]; then
+    ok "named root was not mutated (no libOpenDispatch.dylib in MRROOT)"
+else
+    die_test "DISPATCH_HOST path wrote into the named root"
+fi
+if grep -q "^== binary $W/bin/ud_guest  loader=$W/fake-mrun sha256=$want_sha" "$log"
+then
+    ok "DISPATCH_HOST path still prints loader sha256"
+else
+    die_test "DISPATCH_HOST == binary line drifted: $(grep '^== binary' "$log")"
+fi
+
+echo "== OPENUI_DISPATCH_HOST alias"
+log=$W/alias.log
+rm -rf "$W/runroot"
+set +e
+W="$W" BIN="$W/bin/ud_guest" MRUN="$W/fake-mrun" \
+    OPENUI_DISPATCH_HOST="$W/host/libOpenDispatchHost.so" \
+    DISPATCH_DARWIN="$W/libOpenDispatch.dylib" \
+    bash "$GUEST" "$W/root" >"$log" 2>&1
+st=$?
+set -e
+if [ "$st" -eq 0 ] && grep -q "LD_PRELOAD=$W/host/libOpenDispatchHost.so" "$log"
+then
+    ok "OPENUI_DISPATCH_HOST alias LD_PRELOADs the same bridge"
+else
+    die_test "OPENUI_DISPATCH_HOST alias failed: exit $st $(tr '\n' ' ' < "$log")"
+fi
+
+echo "== persist runner argv with DISPATCH_HOST (write phase only needs exec)"
+# persist will fail later (no plist) unless we only check the first exec.
+# Point PREFS at a writable temp and use a fake mrun that creates the plist
+# on persist-write so the witness passes, then fails the read as a control.
+mkdir -p "$W/prefs"
+plist_path=$W/prefs/com.example.udguest.persist.plist
+cat > "$W/fake-persist-mrun" <<EOS
+#!/bin/bash
+printf 'LD_PRELOAD=%s\n' "\${LD_PRELOAD:-}"
+printf 'MACHORUN_ROOT=%s\n' "\${MACHORUN_ROOT:-}"
+if [ "\${UD_MODE:-}" = persist-write ]; then
+    mkdir -p "$W/prefs"
+    python3 -c 'from pathlib import Path; Path("'"$plist_path"'").write_bytes(b"bplist00" + b"x" * 600 + b"9223372036854775807")'
+    exit 0
+fi
+if [ -f "$plist_path" ]; then
+    exit 0
+fi
+exit 1
+EOS
+chmod +x "$W/fake-persist-mrun"
+log=$W/persist.log
+set +e
+W="$W" BIN="$W/bin/ud_guest" MRUN="$W/fake-persist-mrun" \
+    PREFS="$W/prefs" \
+    DISPATCH_HOST="$W/host/libOpenDispatchHost.so" \
+    DISPATCH_DARWIN="$W/libOpenDispatch.dylib" \
+    bash "$PERSIST" "$W/root" >"$log" 2>&1
+st=$?
+set -e
+echo "$log:"
+cat "$log"
+if [ "$st" -eq 0 ] \
+    && grep -q "LD_PRELOAD=$W/host/libOpenDispatchHost.so" "$log" \
+    && grep -q "^== runroot $W/runroot$" "$log" \
+    && grep -q "loader=$W/fake-persist-mrun sha256=" "$log"
+then
+    ok "run_ud_persist.sh LD_PRELOADs, prints runroot, prints loader sha256"
+else
+    die_test "persist dispatch argv failed: exit $st $(tr '\n' ' ' < "$log")"
+fi
+
+echo "test_run_ud_guest: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/foundation-macho/scripts/ud_dispatch_run.inc
+++ b/foundation-macho/scripts/ud_dispatch_run.inc
@@ -1,0 +1,125 @@
+# ud_dispatch_run.inc -- optional Linux Dispatch host bridge + Darwin runtime
+# image for run_ud_guest.sh / run_ud_persist.sh. Sourced, not executed.
+#
+# Same mechanism as full/xcodeplan/build_and_run_reminder_scene_guest.sh
+# (`== build Linux Dispatch host bridge`, LD_PRELOAD of libOpenDispatchHost.so)
+# and the Focus onboarding run-local overlay (PR #42/#47): do not mutate the
+# named mrroot; clone it to $W/runroot; stage the Darwin facade at
+# darwin/usr/lib/libOpenDispatch.dylib (LC_ID /usr/lib/libOpenDispatch.dylib).
+#
+# WHY THAT PATH, NOT /usr/lib/system/libdispatch.dylib AND NOT a libSystem.B
+# re-export. libCFTest is linked -lSystem -undefined dynamic_lookup
+# (build_cftest_harness.sh); libSystem.B does not re-export libdispatch
+# (machorun/darwin/src/libsystem.c looks libdispatch_init up by name). The
+# undefined _dispatch_* names therefore become BIND_SPECIAL_DYLIB_FLAT_LOOKUP
+# binds. machorun/src/resolve.c searches every loaded image, then — because
+# libCFTest's install name /usr/lib/libCFTest.dylib is an absolute Darwin path
+# served from the prefix map — from->is_runtime is set (image.c) and
+# host_lookup strips the underscore and dlsym(RTLD_DEFAULT)s the Linux
+# libdispatch pulled in by LD_PRELOAD of the host bridge. The Darwin image
+# itself is is_runtime so its _glibc_openui_dispatch_host_v1_* binds (the
+# OpenDispatchBridge.c facade) resolve the same way. libSystem.B's concpatch
+# already imports that _glibc_* ABI; it does not need a re-export.
+#
+# Variable names match the Reminder/Focus scripts:
+#   DISPATCH_HOST     path to libOpenDispatchHost.so
+#                     (OPENUI_DISPATCH_HOST is accepted as an alias)
+#   DISPATCH_DARWIN   path to the Darwin libOpenDispatch.dylib to stage
+#   DISPATCH_RUNROOT  optional overlay path (default $W/runroot)
+#
+# When DISPATCH_HOST is unset, this file is a no-op: MACHORUN_ROOT stays the
+# named ROOT and there is no LD_PRELOAD. That is the #87 container path.
+
+if [ -n "${UD_DISPATCH_RUN_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+UD_DISPATCH_RUN_INC=1
+
+ud_dispatch_host_path() {
+    if [ -n "${DISPATCH_HOST:-}" ]; then
+        printf '%s\n' "$DISPATCH_HOST"
+    elif [ -n "${OPENUI_DISPATCH_HOST:-}" ]; then
+        printf '%s\n' "$OPENUI_DISPATCH_HOST"
+    fi
+}
+
+# Print the == binary line with the loader path and sha256 of the file
+# that is about to be exec'd. Callers must set MRUN.
+ud_dispatch_loader_line() {
+    local bin=$1
+    local sha
+    sha=$(sha256sum "$MRUN" 2>/dev/null | awk '{print $1}')
+    echo "== binary $bin  loader=$MRUN sha256=${sha:-unreadable}"
+}
+
+# Sets UD_MACHORUN_ROOT, UD_DISPATCH_PRELOAD, UD_DISPATCH_LIBPATH.
+# Prints == runroot when an overlay is staged.
+ud_dispatch_prepare_root() {
+    local host darwin runroot hostdir dest already=0
+    UD_MACHORUN_ROOT=$ROOT
+    UD_DISPATCH_PRELOAD=
+    UD_DISPATCH_LIBPATH=
+
+    host=$(ud_dispatch_host_path)
+    [ -n "$host" ] || return 0
+
+    darwin=${DISPATCH_DARWIN:-}
+    if [ ! -f "$host" ] || [ -L "$host" ]; then
+        echo "REFUSING: DISPATCH_HOST is not a regular file: ${host:-empty}" >&2
+        return 2
+    fi
+    if [ -z "$darwin" ] || [ ! -f "$darwin" ] || [ -L "$darwin" ]; then
+        echo "REFUSING: DISPATCH_DARWIN is not a regular file: ${darwin:-empty}" >&2
+        return 2
+    fi
+
+    runroot=${DISPATCH_RUNROOT:-$W/runroot}
+    if [ "$runroot" = "$ROOT" ]; then
+        echo "REFUSING: run-local overlay path collided with the named root $ROOT" >&2
+        return 2
+    fi
+
+    echo "== clone named root into a writable run-local overlay"
+    # machorun's host_lookup/_glibc_ path only runs for images served from
+    # the darwin-root prefix map (is_runtime). Do not write the shared
+    # mrroot; stage the facade in a per-run copy (Focus onboarding / PR #42).
+    if [ -f "$runroot/darwin/usr/lib/libSystem.B.dylib" ] \
+        || [ -f "$runroot/darwin/System/Library/Frameworks/Foundation.framework/Foundation" ]
+    then
+        already=1
+    fi
+    if [ "$already" -eq 0 ]; then
+        rm -rf "$runroot"
+        mkdir -p "$runroot"
+        cp -a "$ROOT/." "$runroot/"
+        chmod -R u+w "$runroot" 2>/dev/null || true
+    fi
+
+    dest=$runroot/darwin/usr/lib/libOpenDispatch.dylib
+    mkdir -p "$(dirname "$dest")"
+    if [ ! -f "$dest" ] || ! cmp -s "$darwin" "$dest"; then
+        cp -f "$darwin" "$dest"
+    fi
+    echo "== runroot $runroot"
+    echo "== dispatch-host $host"
+    echo "== dispatch-runtime $dest"
+
+    UD_MACHORUN_ROOT=$runroot
+    hostdir=$(cd "$(dirname "$host")" && pwd)
+    UD_DISPATCH_PRELOAD="$host${LD_PRELOAD:+:$LD_PRELOAD}"
+    UD_DISPATCH_LIBPATH="$hostdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+}
+
+# Run $MRUN against UD_MACHORUN_ROOT, with LD_PRELOAD when a host bridge
+# was prepared. Extra environment (UD_MODE=…) is inherited.
+ud_dispatch_run() {
+    if [ -n "${UD_DISPATCH_PRELOAD:-}" ]; then
+        LD_PRELOAD="$UD_DISPATCH_PRELOAD" \
+        LD_LIBRARY_PATH="$UD_DISPATCH_LIBPATH" \
+        MACHORUN_ROOT="$UD_MACHORUN_ROOT" \
+            "$MRUN" "$@"
+    else
+        MACHORUN_ROOT="$UD_MACHORUN_ROOT" \
+            "$MRUN" "$@"
+    fi
+}

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -267,6 +267,29 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    libCFTest). Prints `ENV_PREPARE libCFTest-run-root … path=… sha256=…`.
    Never copies onto the CoreFoundation.framework slot (byte-identical
    copy there is the duplicate-image refusal in `run_ud_guest.sh`).
+   Then `ud-guest-dispatch` reuses the Reminder/Focus Linux Dispatch host
+   bridge (`full/dispatch/build_host_bridge.sh` → `libOpenDispatchHost.so`,
+   already built into `scratch/mrroot-x86_64/host/` when
+   `mrroot-host-x86` ran) and links the Darwin facade
+   (`OpenDispatchBridge.c`, LC_ID `/usr/lib/libOpenDispatch.dylib`).
+   Prints `ENV_PREPARE ud-guest-dispatch … bridge=… runtime=… sha256=…`.
+   `run_ud_guest.sh` / `run_ud_persist.sh` take `DISPATCH_HOST` (Reminder
+   name; `OPENUI_DISPATCH_HOST` is an alias) and `DISPATCH_DARWIN`,
+   `LD_PRELOAD` the bridge, and clone the named root to `$W/runroot`
+   rather than mutating `mrroot_full`. The Darwin image sits at
+   `runroot/darwin/usr/lib/libOpenDispatch.dylib` because libCFTest's
+   `_dispatch_*` binds are **flat** (`-undefined dynamic_lookup`,
+   libSystem.B does not re-export libdispatch) and libCFTest itself is
+   `is_runtime` (`/usr/lib/libCFTest.dylib`), so `host_lookup` resolves
+   them against the preloaded Linux libdispatch; the facade's
+   `_glibc_openui_dispatch_host_v1_*` binds use the same gate.
+   Without those variables the runners are the #87 container path
+   (`MACHORUN_ROOT=$ROOT "$MRUN" "$BIN"`, default
+   `MRUN=/stage/machorun-bin`). The `== binary` line prints
+   `loader=$MRUN sha256=…` of the file about to be exec'd. Before rung a,
+   phase2 copies `$MACHORUN/build/machorun` onto `$MRROOT/machorun` when
+   newer (the same `-nt` rule `build_full.sh` uses for rungs b/c); the
+   mrroot-x86 "satisfied" path otherwise leaves a stale loader in place.
    `link_ud_guest.sh` stays the only ud_guest linker. Any other
    missing piece is `CANNOT_UD_GUEST_<FILE> file=<basename>`. On success the
    binary is exported as `UD_GUEST_BIN` for rung a, with

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -970,6 +970,61 @@ elif [ "$UD_GUEST_ITEM_OK" -eq 1 ]; then
         "ud_guest linked but no run root at $MRROOT to stage libCFTest.dylib into"
 fi
 
+# Linux Dispatch host bridge + Darwin runtime image. Reuse the Reminder/Focus
+# helper (BASE_MRROOT/host from phase2_build_x86_host_helpers) when it already
+# ran. Do not mutate mrroot_full; the runner clones a run-local overlay.
+echo "==== ud-guest-dispatch (Linux host bridge + Darwin OpenDispatch) ===="
+UD_DISPATCH_HOST=
+UD_DISPATCH_DARWIN=
+if [ "$UD_GUEST_ITEM_OK" -eq 1 ]; then
+    dispatch_report=$(phase2_ud_guest_ensure_dispatch \
+        "$W" \
+        "${UD_GUEST_W:-$W/scratch/ud-guest-x86_64}" \
+        "$SYS" \
+        "$TARGET" \
+        "$BASE_MRROOT/host/libOpenDispatchHost.so" \
+        || true)
+    case "$dispatch_report" in
+        status=satisfied\ bridge=*)
+            UD_DISPATCH_HOST=${dispatch_report#*bridge=}
+            UD_DISPATCH_HOST=${UD_DISPATCH_HOST%% *}
+            UD_DISPATCH_DARWIN=${dispatch_report#*runtime=}
+            UD_DISPATCH_DARWIN=${UD_DISPATCH_DARWIN%% *}
+            export UD_DISPATCH_HOST UD_DISPATCH_DARWIN
+            note ud-guest-dispatch satisfied "${dispatch_report#status=satisfied }"
+            ;;
+        status=cold-built\ bridge=*)
+            UD_DISPATCH_HOST=${dispatch_report#*bridge=}
+            UD_DISPATCH_HOST=${UD_DISPATCH_HOST%% *}
+            UD_DISPATCH_DARWIN=${dispatch_report#*runtime=}
+            UD_DISPATCH_DARWIN=${UD_DISPATCH_DARWIN%% *}
+            export UD_DISPATCH_HOST UD_DISPATCH_DARWIN
+            note ud-guest-dispatch cold-built "${dispatch_report#status=cold-built }"
+            ;;
+        *)
+            cannot ud-guest-dispatch UD_GUEST_DISPATCH \
+                "${dispatch_report:-empty}. Reuse $BASE_MRROOT/host/libOpenDispatchHost.so when already ELF; otherwise full/dispatch/build_host_bridge.sh. Darwin image is OpenDispatchBridge.c with LC_ID /usr/lib/libOpenDispatch.dylib."
+            ;;
+    esac
+fi
+
+# Rung a does not invoke build_full.sh, whose `-nt` copy is what refreshes
+# $MRROOT/machorun for rungs b/c. The mrroot-x86 "satisfied" path also skips
+# the copy. Refresh here so rung a execs the loader just built, not a stale
+# $MRROOT/machorun from an earlier tree (the DF2 exit-74 vs manual-run split).
+echo "==== run-root loader refresh (build_full -nt rule, before rung a) ===="
+if [ -x "$MACHORUN/build/machorun" ] && [ -d "$MRROOT" ]; then
+    if [ ! -x "$MRROOT/machorun" ] \
+        || [ "$MACHORUN/build/machorun" -nt "$MRROOT/machorun" ]
+    then
+        cp -f "$MACHORUN/build/machorun" "$MRROOT/machorun"
+        chmod a+x "$MRROOT/machorun"
+        echo "  refreshed $MRROOT/machorun from $MACHORUN/build/machorun sha256=$(sha256sum "$MRROOT/machorun" | awk '{print $1}')"
+    else
+        echo "  $MRROOT/machorun is current sha256=$(sha256sum "$MRROOT/machorun" | awk '{print $1}')"
+    fi
+fi
+
 # ---------------------------------------------------------------------------
 # 7. Rungs. Reuse committed gates. Never invent new denominators.
 echo "==== rungs (committed runners only) ===="
@@ -1033,6 +1088,8 @@ if [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] && [ "$LIBSWIFTCORE_X86" -eq 1 ]
             R=$ud_r \
             BIN=$ud_bin \
             MRUN=$MRROOT/machorun \
+            DISPATCH_HOST=${UD_DISPATCH_HOST:-} \
+            DISPATCH_DARWIN=${UD_DISPATCH_DARWIN:-} \
             bash "$ud_r/scripts/run_ud_guest.sh" "$MRROOT" \
             2>&1 | tee "$W/scratch/phase2-rung-a-smoke.log"
         smoke_rc=${PIPESTATUS[0]}
@@ -1046,6 +1103,8 @@ if [ "$FE_OK" -eq 1 ] && [ "$MRROOT_OK" -eq 1 ] && [ "$LIBSWIFTCORE_X86" -eq 1 ]
                     R=$ud_r \
                     BIN=$ud_score \
                     MRUN=$MRROOT/machorun \
+                    DISPATCH_HOST=${UD_DISPATCH_HOST:-} \
+                    DISPATCH_DARWIN=${UD_DISPATCH_DARWIN:-} \
                     bash "$ud_r/scripts/run_ud_persist.sh" "$MRROOT" \
                     2>&1 | tee "$W/scratch/phase2-rung-a-persist.log"
                 persist_rc=${PIPESTATUS[0]}

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -72,7 +72,11 @@ for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
     "$ROOT/full/foundationinternationalization/build_host_helper.sh" \
     "$ROOT/scripts/x86/ud_guest.inc" \
     "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
+    "$ROOT/foundation-macho/scripts/run_ud_guest.sh" \
+    "$ROOT/foundation-macho/scripts/run_ud_persist.sh" \
+    "$ROOT/foundation-macho/scripts/ud_dispatch_run.inc" \
     "$ROOT/foundation-macho/scripts/test_link_ud_guest.sh" \
+    "$ROOT/foundation-macho/scripts/test_run_ud_guest.sh" \
     "$ROOT/scripts/x86/gen_swift_tbd.sh" \
     "$ROOT/scripts/x86/test_gen_swift_tbd.sh" \
     "$ROOT/full/swiftui/guest_gate_inventories.inc" \
@@ -1539,6 +1543,28 @@ expect_grep 'phase2_stage_cftest_into_run_root' "$UDINC" \
 expect_grep 'phase2_stage_cftest_into_run_root' "$PHASE2" \
     "phase2 stages libCFTest after ud-guest link, before rung a"
 expect_grep 'libCFTest-run-root' "$PHASE2" "ENV_PREPARE item names libCFTest-run-root"
+expect_grep 'phase2_ud_guest_ensure_dispatch' "$UDINC" \
+    "ud-guest builds/reuses the Dispatch host bridge + Darwin runtime"
+expect_grep 'phase2_ud_guest_ensure_dispatch' "$PHASE2" \
+    "phase2 invokes ud-guest-dispatch before rung a"
+expect_grep 'ud-guest-dispatch' "$PHASE2" "ENV_PREPARE item names ud-guest-dispatch"
+expect_grep 'DISPATCH_HOST=${UD_DISPATCH_HOST:-}' "$PHASE2" \
+    "rung a passes DISPATCH_HOST into run_ud_guest.sh"
+expect_grep 'DISPATCH_DARWIN=${UD_DISPATCH_DARWIN:-}' "$PHASE2" \
+    "rung a passes DISPATCH_DARWIN into the runners"
+expect_grep 'build_host_bridge.sh' "$UDINC" \
+    "ud-guest-dispatch reuses full/dispatch/build_host_bridge.sh"
+expect_grep 'OpenDispatchBridge.c' "$UDINC" \
+    "ud-guest-dispatch links the Darwin OpenDispatch facade"
+expect_grep 'run-root loader refresh' "$PHASE2" \
+    "phase2 refreshes \$MRROOT/machorun before rung a (build_full -nt rule)"
+expect_grep 'ud_dispatch_loader_line' "$ROOT/foundation-macho/scripts/run_ud_guest.sh" \
+    "run_ud_guest.sh prints loader sha256 on == binary"
+expect_grep 'LD_PRELOAD' "$ROOT/foundation-macho/scripts/ud_dispatch_run.inc" \
+    "runner helper LD_PRELOADs the host bridge"
+expect_grep 'darwin/usr/lib/libOpenDispatch.dylib' \
+    "$ROOT/foundation-macho/scripts/ud_dispatch_run.inc" \
+    "runner helper stages the Darwin runtime image"
 expect_grep 'darwin/usr/lib/libCFTest.dylib' "$PHASE2" \
     "libCFTest stage names the run-root path"
 expect_grep 'CoreFoundation slot is a byte-identical copy' "$UDINC" \
@@ -1791,6 +1817,48 @@ else
     die_test "could not emit an x86 libCFTest.dylib fixture"
 fi
 
+echo "== ud-guest-dispatch reuses an ELF host bridge and links the Darwin facade"
+DISP_HOST_DIR=$UDWORK/existing-host
+mkdir -p "$DISP_HOST_DIR"
+echo 'int openui_dispatch_host_v1_runtime_check(void){return 0;}' \
+    | clang-18 -shared -fPIC -o "$DISP_HOST_DIR/libOpenDispatchHost.so" -x c -
+DISP_SYS=$UDWORK/dispatch-sysroot
+mkdir -p "$DISP_SYS/usr/lib"
+disp_report=$(phase2_ud_guest_ensure_dispatch \
+    "$ROOT" "$wt" "$DISP_SYS" x86_64-apple-macos15.0 \
+    "$DISP_HOST_DIR/libOpenDispatchHost.so" || true)
+case "$disp_report" in
+    status=cold-built\ bridge=*runtime=*sha256=*)
+        dhost=${disp_report#*bridge=}
+        dhost=${dhost%% *}
+        drun=${disp_report#*runtime=}
+        drun=${drun%% *}
+        dsha=${disp_report##*sha256=}
+        want=$(sha256sum "$wt/lib/libOpenDispatch.dylib" | awk '{print $1}')
+        if [ "$dhost" = "$DISP_HOST_DIR/libOpenDispatchHost.so" ] \
+            && [ "$drun" = "$wt/lib/libOpenDispatch.dylib" ] \
+            && [ "$dsha" = "$want" ] \
+            && [ "$(llvm-otool-18 -D "$drun" | tail -n 1)" = \
+                /usr/lib/libOpenDispatch.dylib ] \
+            && llvm-nm-18 -u "$drun" | grep -q '_glibc_openui_dispatch_host_v1_get_global_queue'
+        then
+            ok "ensure_dispatch reuses ELF host and links Darwin LC_ID /usr/lib/libOpenDispatch.dylib"
+        else
+            die_test "ensure_dispatch dest mismatch: '$disp_report' id=$(llvm-otool-18 -D "$drun" 2>/dev/null | tail -n 1)"
+        fi
+        again=$(phase2_ud_guest_ensure_dispatch \
+            "$ROOT" "$wt" "$DISP_SYS" x86_64-apple-macos15.0 \
+            "$DISP_HOST_DIR/libOpenDispatchHost.so" || true)
+        case "$again" in
+            status=satisfied\ bridge=*runtime=*sha256=*)
+                ok "ensure_dispatch re-run of identical host+runtime is satisfied"
+                ;;
+            *) die_test "ensure_dispatch idempotent re-run got: '$again'" ;;
+        esac
+        ;;
+    *) die_test "ensure_dispatch got: '$disp_report'" ;;
+esac
+
 echo "== ud-guest-x86 fetches the pinned swift-corelibs-foundation checkout"
 ck=$(phase2_ud_guest_ensure_cf_checkout "$wt" "$ROOT" || true)
 if [ -z "$ck" ] \
@@ -1798,6 +1866,22 @@ if [ -z "$ck" ] \
     && [ "$(git -c safe.directory="$wt/cf" -C "$wt/cf" rev-parse HEAD)" = "$PHASE2_UD_GUEST_CF_COMMIT" ] \
     && [ "$(git -c safe.directory="$wt/cf" -C "$wt/cf" rev-parse 'HEAD^{tree}')" = "$PHASE2_UD_GUEST_CF_TREE" ]; then
     ok "fetched $PHASE2_UD_GUEST_CF_ID commit=$PHASE2_UD_GUEST_CF_COMMIT tree=$PHASE2_UD_GUEST_CF_TREE"
+    cf_dispatch=$(grep -RhoE '\bdispatch_[A-Za-z0-9_]+' \
+        "$wt/cf/Sources/CoreFoundation" \
+        | sed 's/^/_/' | sort -u)
+    for need in _dispatch_queue_attr_concurrent _dispatch_queue_create \
+        _dispatch_async_f _dispatch_once_f _dispatch_get_global_queue \
+        _dispatch_semaphore_create _dispatch_semaphore_signal \
+        _dispatch_semaphore_wait _dispatch_source_create
+    do
+        if printf '%s\n' "$cf_dispatch" | grep -qx "$need"; then
+            ok "pinned CF sources mention $need"
+        else
+            # Not every name is spelled in every CF tree; record absence, do not fail.
+            echo "NOTE: pinned CF sources do not spell $need (load-time nm is authoritative)"
+        fi
+    done
+    printf '%s\n' "$cf_dispatch" | grep dispatch_ | head -40
 else
     die_test "CF pin fetch got: '${ck:-empty}' dest=$wt/cf"
 fi
@@ -1814,6 +1898,13 @@ if bash "$ROOT/foundation-macho/scripts/test_link_ud_guest.sh"; then
     ok "test_link_ud_guest.sh"
 else
     die_test "test_link_ud_guest.sh"
+fi
+
+echo "== run_ud_guest.sh dispatch argv (preload, runroot, loader sha256)"
+if bash "$ROOT/foundation-macho/scripts/test_run_ud_guest.sh"; then
+    ok "test_run_ud_guest.sh"
+else
+    die_test "test_run_ud_guest.sh"
 fi
 
 echo "== ud-guest-x86 linker log is a file path, not flattened ld64"

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -9,6 +9,9 @@
 #     scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib
 #     (arm64 analogue: build_cftest_harness.sh -> $W/root; not build_full.sh)
 #   libswiftcompat.dylib in that tree's lib/
+#   Linux Dispatch host bridge + Darwin libOpenDispatch.dylib (Reminder/Focus
+#     mechanism) via phase2_ud_guest_ensure_dispatch; rung a LD_PRELOADs the
+#     bridge against a run-local overlay that contains the Darwin image
 #   link via foundation-macho/scripts/link_ud_guest.sh  (no second linker)
 #   binary at $W/scratch/ud-guest-x86_64/bin/ud_guest, handed to rung a as
 #   UD_GUEST_BIN.
@@ -678,6 +681,126 @@ phase2_stage_cftest_into_run_root() {
         printf 'status=satisfied path=%s sha256=%s\n' "$dest" "$sha"
     else
         printf 'status=cold-built path=%s sha256=%s\n' "$dest" "$sha"
+    fi
+}
+
+# Linux Dispatch host bridge + Darwin OpenDispatch facade for rung a.
+# Reuses scratch/mrroot-x86_64/host/libOpenDispatchHost.so when that file is
+# already ELF x86-64 (phase2_build_x86_host_helpers / Reminder script).
+# Builds the Darwin image with the same clang/ld64 argv as
+# full/swiftui/build_focus_onboarding_guest.sh / build_core_guest_package.sh:
+# install_name /usr/lib/libOpenDispatch.dylib, -undefined dynamic_lookup.
+# Prints: status=cold-built|satisfied bridge=… runtime=… sha256=…
+phase2_ud_guest_ensure_dispatch() {
+    local repo=$1 ud_w=$2 sys=$3 target=$4
+    local existing_host=${5:-}
+    local host_dir host dest obj log st arch darwin_sha host_ok=0 darwin_ok=0
+    local built_host=0 built_darwin=0
+
+    phase2_ud_guest_refuse_unsuffixed "$ud_w" || return 1
+    mkdir -p "$ud_w/lib" "$ud_w/host" "$ud_w/host-work"
+
+    host=$ud_w/host/libOpenDispatchHost.so
+    if [ -f "$existing_host" ] && [ ! -L "$existing_host" ] \
+        && phase2_is_elf_x86_so "$existing_host"
+    then
+        host=$existing_host
+        host_ok=1
+    elif [ -f "$host" ] && [ ! -L "$host" ] && phase2_is_elf_x86_so "$host"; then
+        host_ok=1
+    fi
+
+    if [ "$host_ok" -ne 1 ]; then
+        host_dir=$ud_w/host
+        rm -f "$host_dir/libOpenDispatchHost.so"
+        log=$ud_w/host-work/build_host_bridge.log
+        set +e
+        bash "$repo/full/dispatch/build_host_bridge.sh" \
+            --repo "$repo" \
+            --host-dir "$host_dir" \
+            --work-dir "$ud_w/host-work" \
+            --skip-runtime-pin \
+            --host-abi "ELF64-$(uname -m)" \
+            --refuse-prefix 'ud-guest-dispatch: ' \
+            >"$log" 2>&1
+        st=$?
+        set -e
+        host=$host_dir/libOpenDispatchHost.so
+        if [ "$st" -ne 0 ] || [ ! -f "$host" ] || [ -L "$host" ] \
+            || ! phase2_is_elf_x86_so "$host"
+        then
+            phase2_ud_guest_cannot DISPATCH libOpenDispatchHost.so \
+                "build_host_bridge.sh exit $st log=$log"
+            return 1
+        fi
+        built_host=1
+        host_ok=1
+    fi
+
+    dest=$ud_w/lib/libOpenDispatch.dylib
+    case "$target" in
+        x86_64-*) arch=x86_64 ;;
+        arm64-*|aarch64-*) arch=arm64 ;;
+        *)
+            phase2_ud_guest_cannot DISPATCH libOpenDispatch.dylib \
+                "cannot derive ld64 -arch from target=$target"
+            return 1
+            ;;
+    esac
+    if [ -f "$dest" ] && phase2_is_x86_macho "$dest" \
+        && [ "$(llvm-otool-18 -D "$dest" 2>/dev/null | tail -n 1)" = \
+            /usr/lib/libOpenDispatch.dylib ]
+    then
+        darwin_ok=1
+    fi
+    if [ "$darwin_ok" -ne 1 ]; then
+        if [ ! -d "$sys/usr/lib" ]; then
+            phase2_ud_guest_cannot DISPATCH libOpenDispatch.dylib \
+                "no Darwin sysroot at $sys to link OpenDispatchBridge.c"
+            return 1
+        fi
+        obj=$ud_w/lib/open-dispatch-bridge.o
+        log=$ud_w/lib/open-dispatch-bridge.log
+        set +e
+        clang-18 -target "$target" -isysroot "$sys" -std=c11 -O2 \
+            -fvisibility=hidden -Wall -Wextra -Werror \
+            -I "$repo/full/dispatch/include" \
+            -c "$repo/full/dispatch/OpenDispatchBridge.c" \
+            -o "$obj" >"$log" 2>&1
+        st=$?
+        set -e
+        if [ "$st" -ne 0 ] || [ ! -f "$obj" ]; then
+            phase2_ud_guest_cannot DISPATCH libOpenDispatch.dylib \
+                "OpenDispatchBridge.c clang exit $st log=$log"
+            return 1
+        fi
+        set +e
+        ld64.lld-18 -arch "$arch" -platform_version macos 15.0 15.0 \
+            -syslibroot "$sys" \
+            -dylib -dead_strip -undefined dynamic_lookup \
+            -install_name /usr/lib/libOpenDispatch.dylib \
+            -o "$dest" "$obj" >>"$log" 2>&1
+        st=$?
+        set -e
+        if [ "$st" -ne 0 ] || [ ! -f "$dest" ] || ! phase2_is_x86_macho "$dest" \
+            || [ "$(llvm-otool-18 -D "$dest" 2>/dev/null | tail -n 1)" != \
+                /usr/lib/libOpenDispatch.dylib ]
+        then
+            phase2_ud_guest_cannot DISPATCH libOpenDispatch.dylib \
+                "ld64 OpenDispatchBridge exit $st log=$log"
+            return 1
+        fi
+        built_darwin=1
+        darwin_ok=1
+    fi
+
+    darwin_sha=$(sha256sum "$dest" | awk '{print $1}')
+    if [ "$built_host" -eq 0 ] && [ "$built_darwin" -eq 0 ]; then
+        printf 'status=satisfied bridge=%s runtime=%s sha256=%s\n' \
+            "$host" "$dest" "$darwin_sha"
+    else
+        printf 'status=cold-built bridge=%s runtime=%s sha256=%s\n' \
+            "$host" "$dest" "$darwin_sha"
     fi
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Measurement (x86_64 box `i-0a2e25f3895c819b3`, main `04004023`, loader from PR #62, root `scratch/mrroot_full-x86_64` from PR #61)

```
$ MACHORUN_ROOT=scratch/mrroot_full-x86_64 scratch/mrroot_full-x86_64/machorun scratch/ud-guest-x86_64/bin/ud_guest
machorun: undefined symbol '__dispatch_queue_attr_concurrent'
  wanted by:  scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib
  looked in:  every loaded image (flat lookup)
rc=73
```

`run_ud_guest.sh` ran `MACHORUN_ROOT=$ROOT "$MRUN" "$BIN"` with no preload and the named root carried no libdispatch image. Reminder (rung c) already solves this with `full/dispatch/build_host_bridge.sh` → `libOpenDispatchHost.so`, `LD_PRELOAD`, and a run-local overlay that stages the Darwin facade at `/usr/lib/libOpenDispatch.dylib` (PRs #42/#47). This PR uses that mechanism, not a new one. `machorun/` and `uikit/` are untouched; `full/dispatch/` needed no extra parameter.

## Dispatch symbols libCFTest wants

First miss on the operator box: `__dispatch_queue_attr_concurrent` (the `DISPATCH_QUEUE_CONCURRENT` attribute object). CF (`f3a7a343`) also uses, among others:

- `dispatch_queue_create`, `dispatch_get_global_queue`
- `dispatch_once`, `dispatch_async`, `dispatch_apply`
- `dispatch_semaphore_{create,signal,wait}`
- `dispatch_source_{create,set_timer,set_event_handler,set_cancel_handler,cancel}`
- `dispatch_time`, `dispatch_release` / `retain` / `resume`
- private `_dispatch_source_set_runloop_timer_4CF`

Operator should still run `llvm-nm -u scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib | grep dispatch` on the box (this VM has no staged libCFTest). Linux `libdispatch.so` (pulled in by the host bridge, `rpath $ORIGIN`) already exports the ones `host_lookup` can satisfy after stripping one underscore: `_dispatch_queue_attr_concurrent` (`D`), plus `dispatch_queue_create`, `dispatch_async`/`_f`, `dispatch_once`/`_f`, `dispatch_get_global_queue`, `dispatch_semaphore_*`, `dispatch_source_create`, `dispatch_time`, `dispatch_release`/`retain`, `dispatch_apply`.

The Darwin facade itself exports `_openui_dispatch_v1_*` and imports twelve `_glibc_openui_dispatch_host_v1_*` binds (create_queue, async, after, get_global_queue, get/set_specific, monotonic_nanoseconds, release_queue, semaphore_{create,release,signal,wait}).

## Resolution path chosen

**Not** `/usr/lib/system/libdispatch.dylib` and **not** a libSystem.B re-export.

libCFTest is linked `-lSystem -Wl,-undefined,dynamic_lookup` (`build_cftest_harness.sh`). libSystem.B does **not** re-export libdispatch (`machorun/darwin/src/libsystem.c` looks `libdispatch_init` up by name). Undefined `_dispatch_*` therefore become `BIND_SPECIAL_DYLIB_FLAT_LOOKUP`.

Path used (same as Focus/Reminder): Darwin facade at **`/usr/lib/libOpenDispatch.dylib`** → `$runroot/darwin/usr/lib/libOpenDispatch.dylib` (LC_ID `/usr/lib/libOpenDispatch.dylib`).

Why (`machorun/docs/UNIMPLEMENTED.md`, `src/resolve.c`, `src/image.c`):

1. Flat lookup searches every loaded Mach-O image.
2. libCFTest's install name `/usr/lib/libCFTest.dylib` is an absolute Darwin path served from the prefix map → `is_runtime=1`.
3. After a miss, `host_lookup` strips one underscore and `dlsym(RTLD_DEFAULT)`.
4. `LD_PRELOAD` of `libOpenDispatchHost.so` pulls Linux `libdispatch.so`. Mach-O `__dispatch_queue_attr_concurrent` → ELF `_dispatch_queue_attr_concurrent`. Functions: Mach-O `_dispatch_queue_create` → ELF `dispatch_queue_create`.
5. The Darwin facade's `_glibc_openui_dispatch_host_v1_*` binds use the same `is_runtime` gate against the preloaded helper. concpatch in libSystem.B already imports that ABI.

The runner clones the named root to `$W/runroot` (prints `== runroot`) rather than mutating `mrroot_full`. Env names match Reminder/Focus: `DISPATCH_HOST` (alias `OPENUI_DISPATCH_HOST`), `DISPATCH_DARWIN`. **Unset = exact #87 path** (`MRUN` default `/stage/machorun-bin`, no preload, no clone).

## DF2 discrepancy (rung a ~08:13 exit 74 vs manual ~08:15 load)

`run_ud_guest.sh` always execs `$MRUN` (`${MRUN:-/stage/machorun-bin}`). Phase2 **does** set `MRUN=$MRROOT/machorun` on the invocation. Nothing else inside phase2 sets `MRUN`; an operator wrapper could export it, but the per-invocation assignment overrides.

What went wrong: phase2 built the new loader at `machorun/build/machorun` (~08:10:09). If `$MRROOT` was already "satisfied", it **did not recopy** the loader. `build_full.sh`'s `-nt` copy (~08:10:23) runs in **rungs b/c, after rung a**. So rung a ~08:13 could exec a **stale** `$MRROOT/machorun` (pre-PR #62: refuse all dyld-cache-shaped images → DF2 exit 74). The 08:15 manual run used the refreshed binary (PR #62 only refuses cache extracts **without** fixup info) → DF2 loaded, then dispatch rc=73.

This PR copies `$MACHORUN/build/machorun` onto `$MRROOT/machorun` when newer **before rung a**, and the `== binary` line now prints `loader=$MRUN sha256=…` of the file about to be exec'd.

## Operator command

```
bash x86_stage_inputs_phase2.sh
```

Expect rung a to get past the dispatch bind to the smoke's next wall, or `smoke 14/14`. Look for:

- `ENV_PREPARE ud-guest-dispatch … bridge=… runtime=… sha256=…`
- `== runroot scratch/ud-guest-x86_64/runroot`
- `== binary … loader=…/machorun sha256=…`
- `LD_PRELOAD=…/libOpenDispatchHost.so`

## Tests

- `foundation-macho/scripts/test_run_ud_guest.sh`: **39/39 PASS** (no-`DISPATCH_HOST` keeps the #87 argv; with vars: preload, runroot, named root untouched; `OPENUI_DISPATCH_HOST` alias; persist argv).
- `scripts/x86/test_phase2.sh`: new dispatch teeth PASS (wiring + live `ensure_dispatch` reuse of ELF host, Darwin LC_ID, idempotent satisfied). Eight remaining failures are pre-existing env (no `scratch/sysroot_fe4-x86_64`, no machorun sdk tbds, no x86 libswiftCore).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa934a57-fc34-4663-b6a5-1c1e372ffc93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa934a57-fc34-4663-b6a5-1c1e372ffc93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

