### PR TITLE
Stamp overlay sysroot tbds and refuse incomplete include_next wrappers

### DIFF
--- a/swiftcore-macho/scripts/build_stdlib.sh
+++ b/swiftcore-macho/scripts/build_stdlib.sh
@@ -342,7 +342,9 @@ file -b "$MACHORUN/darwin/usr/lib/libSystem.B.dylib"
 ls "$MACHORUN/sdk/usr/lib"/*.tbd | wc -l | sed 's/^/tbds generated: /'
 
 # ---------------------------------------------------------------------------
-# 3. Stage the Swift sysroot
+# 3. Stage the Swift sysroot. .tbd stubs are copied from
+#    scratch/sysroot_fe4[-x86_64] (phase2 stages machorun gen_tbd into that
+#    tree), not from a leftover MacOSX.sdk whose stamp ignored tbd bytes.
 # ---------------------------------------------------------------------------
 step "stage_sdk"
 ln -sfn "$MACHORUN" "$W/machorun"

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -119,6 +119,8 @@ fi
 # Overlay sysroot must carry Intel math.h (fmaxl) + machorun sys/proc.h
 # (extern_proc) *and* every header Darwin Clang overlay maps name (complex.h
 # from full/sdk-gaps). libc++ usr/include/c++/v1 is outside that closure.
+# Stamp keys usr/lib/*.tbd from scratch/sysroot_fe4[-x86_64] (phase2 copies
+# machorun gen_tbd there); print_headers emits source= tbd_sha=.
 # Refuse *before* cmake bakes -DSWIFT_SDK_OSX_PATH.
 if [ "$PRINT_FLAGS" != 1 ] && [ "$SWIFTCORE_DARWIN_ARCH" = x86_64 ]; then
   overlay_sysroot_print_headers "$SDK"

--- a/swiftcore-macho/scripts/configure.sh
+++ b/swiftcore-macho/scripts/configure.sh
@@ -121,6 +121,8 @@ fi
 # from full/sdk-gaps). libc++ usr/include/c++/v1 is outside that closure.
 # Stamp keys usr/lib/*.tbd from scratch/sysroot_fe4[-x86_64] (phase2 copies
 # machorun gen_tbd there); print_headers emits source= tbd_sha=.
+# include_next wrappers (objc4-priv crt_externs.h) must have a later
+# -isysroot target (usr/local/include wrapper, usr/include public header).
 # Refuse *before* cmake bakes -DSWIFT_SDK_OSX_PATH.
 if [ "$PRINT_FLAGS" != 1 ] && [ "$SWIFTCORE_DARWIN_ARCH" = x86_64 ]; then
   overlay_sysroot_print_headers "$SDK"

--- a/swiftcore-macho/scripts/overlay_sysroot.inc
+++ b/swiftcore-macho/scripts/overlay_sysroot.inc
@@ -12,8 +12,10 @@
 # Stamp covers the overlay-darwin header set + Darwin.modulemap recipe
 # (stage_overlay_darwin.sh + enumerated module headers) + machorun sys/proc.h
 # + the SDK copy's link inputs: usr/lib/*.tbd, usr/lib/swift/*.tbd,
-# usr/lib/swift/*.swiftmodule/*, and HEAD:machorun (darwin tbds originate in
-# machorun gen_tbd; phase2 copies them into scratch/sysroot_fe4[-x86_64]).
+# usr/lib/swift/*.swiftmodule/*, HEAD:machorun (darwin tbds originate in
+# machorun gen_tbd; phase2 copies them into scratch/sysroot_fe4[-x86_64]),
+# and the crt_externs.h include_next chain (objc4-priv wrapper in front of
+# the public machorun-sdk / FE header).
 # Required *staged* headers (ConditionalMacros.h included) must be present in
 # the dest tree: input-sha MATCH of the pin is not completeness. .tbd stubs
 # are copied FROM that FE sysroot (fallback: machorun gen_tbd output / the
@@ -24,6 +26,14 @@
 # overlay compiles load via -sdk (usr/include/module.modulemap + Darwin*.modulemap),
 # not libc++ usr/include/c++/v1/module.modulemap. Source Darwin headers from the
 # FE sysroot / full/sdk-gaps / machorun / overlay-darwin pins.
+#
+# clang -target x86_64-apple-macos -isysroot $SDK searches usr/local/include
+# then usr/include. objc4-priv/crt_externs.h is a wrapper (`#include_next
+# <crt_externs.h>`). Flattening it onto usr/include (stage_sdk used to) leaves
+# no later dir for the public header — Darwin.o dies at crt_externs.h:13.
+# The working (stale) copy had the public machorun-sdk / FE file at
+# usr/include/crt_externs.h. Restage puts the wrapper at usr/local/include
+# and the public header at usr/include.
 
 if [ -n "${SWIFTCORE_OVERLAY_SYSROOT_INC:-}" ]; then
     return 0 2>/dev/null || exit 0
@@ -40,9 +50,10 @@ OPENUIKIT_ROOT=${OPENUIKIT_ROOT:-$(cd "$SWIFTCORE_ROOT/.." && pwd)}
 . "$OPENUIKIT_ROOT/scripts/x86/common.inc"
 
 # Bump when staging steps, the Darwin.modulemap header list, modulemap
-# header closure, the required staged-header / tbd completeness gate, or the
-# tbd / swiftmodule / HEAD:machorun stamp inputs change.
-OVERLAY_SYSROOT_RECIPE=overlay-darwin.5
+# header closure, the required staged-header / tbd completeness gate, the
+# tbd / swiftmodule / HEAD:machorun stamp inputs, or the include_next
+# wrapper layout change.
+OVERLAY_SYSROOT_RECIPE=overlay-darwin.6
 OVERLAY_SYSROOT_STAMP=.overlay-sysroot-inputs
 
 # Same enumeration as stage_overlay_darwin.sh DARWIN_MODULE_HEADERS.
@@ -256,15 +267,213 @@ overlay_sysroot_print_stamp_diff() {
     done < <(overlay_sysroot_stamp_diff "$stamp" || true)
 }
 
+# Names from `#include_next <foo.h>` / `"foo.h"` in a header. Empty if none.
+overlay_sysroot_include_next_names() {
+    local f=$1
+    [ -f "$f" ] || return 0
+    sed -n 's/^[[:space:]]*#[[:space:]]*include_next[[:space:]]*[<"]\([^>"]*\)[>"].*/\1/p' "$f"
+}
+
+overlay_sysroot_is_include_next_wrapper() {
+    local f=$1
+    [ -f "$f" ] || return 1
+    overlay_sysroot_include_next_names "$f" | grep -q .
+}
+
+# clang -target *-apple-macos -isysroot $SDK (overlay -sdk): usr/local/include
+# then usr/include. Resource dir is not an SDK dir we stage into.
+overlay_sysroot_isysroot_include_dirs() {
+    local sdk=${1:?overlay_sysroot_isysroot_include_dirs: sdk}
+    printf '%s\n' "$sdk/usr/local/include"
+    printf '%s\n' "$sdk/usr/include"
+}
+
+overlay_sysroot_objc4_priv_crt() {
+    local cand
+    for cand in \
+        ${W:+$W/objc4-priv/crt_externs.h} \
+        "$OPENUIKIT_ROOT/machorun/vendor/objc4-priv/crt_externs.h"
+    do
+        [ -n "$cand" ] || continue
+        if [ -f "$cand" ]; then
+            printf '%s\n' "$cand"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Public Apple crt_externs.h (no include_next). Working overlay copy / FE /
+# machorun-sdk. Never the objc4-priv wrapper.
+overlay_sysroot_public_crt_externs() {
+    local root f
+    while IFS= read -r root; do
+        [ -n "$root" ] || continue
+        f=$root/crt_externs.h
+        [ -f "$f" ] || continue
+        overlay_sysroot_is_include_next_wrapper "$f" && continue
+        printf '%s\n' "$f"
+        return 0
+    done < <(overlay_sysroot_header_search_roots "")
+    return 1
+}
+
+# One "name<TAB>wrapper_rel" per include_next whose target is not in a later
+# -isysroot dir. Return 1 if any are missing.
+# overlay_sysroot_include_next_missing_entries <sdk>
+overlay_sysroot_include_next_missing_entries() {
+    local sdk=${1:?overlay_sysroot_include_next_missing_entries: sdk}
+    local dir f name later found any=0 wrapper_dir rest
+    while IFS= read -r dir; do
+        [ -n "$dir" ] || continue
+        [ -d "$dir" ] || continue
+        while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            while IFS= read -r name; do
+                [ -n "$name" ] || continue
+                found=0
+                rest=0
+                while IFS= read -r later; do
+                    [ -n "$later" ] || continue
+                    if [ "$later" = "$dir" ]; then
+                        rest=1
+                        continue
+                    fi
+                    [ "$rest" -eq 1 ] || continue
+                    if [ -f "$later/$name" ]; then
+                        found=1
+                        break
+                    fi
+                done < <(overlay_sysroot_isysroot_include_dirs "$sdk")
+                if [ "$found" -eq 0 ]; then
+                    wraprel=${f#"$sdk/"}
+                    if [ "$wraprel" = "$f" ]; then
+                        wraprel=${f#"$(realpath "$sdk" 2>/dev/null || printf '%s' "$sdk")/"}
+                    fi
+                    printf '%s\t%s\n' "$name" "$wraprel"
+                    any=1
+                fi
+            done < <(overlay_sysroot_include_next_names "$f")
+        done < <(find "$dir" -name '*.h' ! -path '*/c++/v1/*' -print | LC_ALL=C sort)
+    done < <(overlay_sysroot_isysroot_include_dirs "$sdk")
+    [ "$any" -eq 0 ]
+}
+
+overlay_sysroot_include_next_ok() {
+    overlay_sysroot_include_next_missing_entries "$1" >/dev/null
+}
+
+# Restore the public header behind an include_next wrapper. clang -isysroot
+# searches usr/local/include then usr/include: wrapper in front, public
+# machorun-sdk / FE header behind. Overlay compiles pass -sdk only.
+# overlay_sysroot_fill_include_next_wrappers <dest>
+overlay_sysroot_fill_include_next_wrappers() {
+    local dest=${1:?overlay_sysroot_fill_include_next_wrappers: dest}
+    local name wraprel wrap public n=0
+    mkdir -p "$dest/usr/include" "$dest/usr/local/include"
+    while IFS=$'\t' read -r name wraprel; do
+        [ -n "$name" ] || continue
+        wrap=$dest/$wraprel
+        public=
+        if [ "$name" = crt_externs.h ]; then
+            public=$(overlay_sysroot_public_crt_externs || true)
+        else
+            while IFS= read -r src_root; do
+                [ -n "$src_root" ] || continue
+                if [ -f "$src_root/$name" ] \
+                    && ! overlay_sysroot_is_include_next_wrapper "$src_root/$name"; then
+                    public=$src_root/$name
+                    break
+                fi
+            done < <(overlay_sysroot_header_search_roots "$dest")
+        fi
+        if [ -z "$public" ] || [ ! -f "$public" ]; then
+            echo "overlay_sysroot: include_next $name wrapper=$wraprel public=ABSENT"
+            continue
+        fi
+        mkdir -p "$dest/usr/local/include/$(dirname "$name")" \
+            "$dest/usr/include/$(dirname "$name")"
+        # Wrapper in the front -isysroot dir; public header behind. Copy the
+        # wrapper away from usr/include *before* overwriting that slot.
+        if [ -f "$wrap" ] && overlay_sysroot_is_include_next_wrapper "$wrap" \
+            && [ "$wraprel" != "usr/local/include/$name" ]; then
+            cp -a "$wrap" "$dest/usr/local/include/$name"
+            echo "overlay_sysroot: include_next wrapper $name → usr/local/include (front -isysroot dir)"
+        fi
+        cp -a "$public" "$dest/usr/include/$name"
+        echo "overlay_sysroot: include_next target $name from $public → usr/include"
+        n=$((n + 1))
+    done < <(overlay_sysroot_include_next_missing_entries "$dest" || true)
+    echo "overlay_sysroot: filled $n include_next targets into $dest"
+}
+
+# objc4-priv flatten: include_next wrappers go to usr/local/include (clang
+# Darwin -isysroot front dir). Everything else stays on usr/include. Never
+# overwrite the public machorun-sdk / FE header with a wrapper.
+# overlay_sysroot_install_objc4_priv <priv_dir> <sdk>
+overlay_sysroot_install_objc4_priv() {
+    local priv=${1:?overlay_sysroot_install_objc4_priv: priv}
+    local sdk=${2:?overlay_sysroot_install_objc4_priv: sdk}
+    local rel src dest
+    [ -d "$priv" ] || return 0
+    while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        src=$priv/$rel
+        [ -f "$src" ] || continue
+        if overlay_sysroot_is_include_next_wrapper "$src"; then
+            dest=$sdk/usr/local/include/$rel
+            echo "overlay_sysroot: objc4-priv include_next $rel → usr/local/include (public header stays at usr/include)"
+        else
+            dest=$sdk/usr/include/$rel
+        fi
+        mkdir -p "$(dirname "$dest")"
+        install -D "$src" "$dest"
+    done < <(cd "$priv" && find . -name '*.h' | sed 's|^\./||' | LC_ALL=C sort)
+}
+
+overlay_sysroot_print_include_next() {
+    local sdk=${1:?overlay_sysroot_print_include_next: sdk}
+    local name wraprel any=0
+    while IFS=$'\t' read -r name wraprel; do
+        [ -n "$name" ] || continue
+        echo "overlay_sysroot: include_next missing header=$name wrapper=$wraprel"
+        any=1
+    done < <(overlay_sysroot_include_next_missing_entries "$sdk" || true)
+    if [ "$any" -eq 0 ]; then
+        echo "overlay_sysroot: include_next complete"
+    fi
+}
+
+# Named CANNOT. Exit 2. wrapper whose include_next target is absent.
+# overlay_sysroot_refuse_include_next <sdk>
+overlay_sysroot_refuse_include_next() {
+    local sdk=${1:?overlay_sysroot_refuse_include_next: sdk}
+    local name wraprel resolved entries=""
+    while IFS=$'\t' read -r name wraprel; do
+        [ -n "$name" ] || continue
+        echo "overlay_sysroot: include_next missing header=$name wrapper=$wraprel" >&2
+        entries="${entries:+$entries,}$name@$wraprel"
+    done < <(overlay_sysroot_include_next_missing_entries "$sdk" || true)
+    if [ -z "$entries" ]; then
+        return 0
+    fi
+    resolved=$(realpath "$sdk" 2>/dev/null || printf '%s' "$sdk")
+    echo "CANNOT_OVERLAY_SYSROOT_INCLUDE_NEXT tree=$sdk realpath=$resolved missing=$entries reason=wrapper #include_next has no later -isysroot target (clang Darwin -isysroot searches usr/local/include then usr/include; overlay compiles pass -sdk only). Working copy: public machorun-sdk/FE crt_externs.h at usr/include; objc4-priv wrapper at usr/local/include." >&2
+    return 2
+}
+
 # overlay_sysroot_input_lines
 # recipe + sha of the overlay-darwin header set + modulemap recipe + proc.h
-# + source usr/lib/*.tbd + usr/lib/swift/*.tbd + swiftmodules + HEAD:machorun.
+# + source usr/lib/*.tbd + usr/lib/swift/*.tbd + swiftmodules + HEAD:machorun
+# + public crt_externs.h / objc4-priv wrapper (include_next chain).
 overlay_sysroot_input_lines() {
     local src=$SWIFTCORE_ROOT/sdk/overlay-darwin
-    local proc tbd_src tbd_rel
+    local proc tbd_src tbd_rel public_crt priv_crt
     proc=$(overlay_sysroot_proc_h || true)
     tbd_src=$(overlay_sysroot_resolve_source || true)
     [ -n "$tbd_src" ] || tbd_src=ABSENT
+    public_crt=$(overlay_sysroot_public_crt_externs || true)
+    priv_crt=$(overlay_sysroot_objc4_priv_crt || true)
     printf 'recipe=%s\n' "$OVERLAY_SYSROOT_RECIPE"
     printf 'overlay-darwin.math.h=%s\n' "$(overlay_sysroot_sha_or_absent "$src/math.h")"
     printf 'overlay-darwin.MacTypes.h=%s\n' "$(overlay_sysroot_sha_or_absent "$src/MacTypes.h")"
@@ -279,7 +488,10 @@ overlay_sysroot_input_lines() {
     printf 'required.headers=%s\n' \
         "$(printf '%s\n' "${OVERLAY_SYSROOT_REQUIRED_HEADERS[@]}" | sha256sum | awk '{print $1}')"
     printf 'modulemap.closure=darwin_clang_overlay_maps\n'
+    printf 'include_next.dirs=usr/local/include,usr/include\n'
     printf 'machorun.sys/proc.h=%s\n' "$(overlay_sysroot_sha_or_absent "${proc:-}")"
+    printf 'machorun.crt_externs.h=%s\n' "$(overlay_sysroot_sha_or_absent "${public_crt:-}")"
+    printf 'objc4-priv.crt_externs.h=%s\n' "$(overlay_sysroot_sha_or_absent "${priv_crt:-}")"
     # gen_tbd origin (darwin usr/lib/*.tbd). Not a substitute for hashing the
     # generated tbd bytes: PR #67 updated gen_tbd output without this tree
     # hash changing between overlay stamp writes.
@@ -380,6 +592,7 @@ overlay_sysroot_print_headers() {
         fi
     done
     overlay_sysroot_print_modulemap_closure "$sdk"
+    overlay_sysroot_print_include_next "$sdk"
     overlay_sysroot_print_tbds "$sdk"
     if [ -f "$sdk/$OVERLAY_SYSROOT_STAMP" ]; then
         echo "overlay_sysroot: stamp=$sdk/$OVERLAY_SYSROOT_STAMP"
@@ -399,6 +612,8 @@ overlay_sysroot_print_headers() {
 }
 
 # Return 0 if the tree has the Darwin overlay surface we refuse-before-cmake on.
+# include_next wrappers whose later -isysroot target is absent (objc4-priv
+# crt_externs.h flattened onto usr/include) are incomplete.
 # overlay_sysroot_headers_ok <sdk>
 overlay_sysroot_headers_ok() {
     local sdk=$1
@@ -412,6 +627,7 @@ overlay_sysroot_headers_ok() {
     fi
     overlay_sysroot_has_extern_proc "$sdk/usr/include/sys/proc.h" || return 1
     overlay_sysroot_modulemap_headers_ok "$sdk" || return 1
+    overlay_sysroot_include_next_ok "$sdk" || return 1
 }
 
 # Clang module maps overlay Swift compiles load via -sdk (no -fmodule-map-file).
@@ -773,6 +989,9 @@ overlay_sysroot_refuse_incomplete() {
     if ! overlay_sysroot_refuse_modulemap_headers "$sdk"; then
         rc=2
     fi
+    if ! overlay_sysroot_refuse_include_next "$sdk"; then
+        rc=2
+    fi
     return "$rc"
 }
 
@@ -859,7 +1078,7 @@ overlay_sysroot_begin() {
             overlay_sysroot_print_stamp_diff "$live/$OVERLAY_SYSROOT_STAMP"
         fi
         if ! overlay_sysroot_tree_complete "$live"; then
-            echo "overlay_sysroot: live tree incomplete (required headers or usr/lib/*.tbd)"
+            echo "overlay_sysroot: live tree incomplete (required headers, usr/lib/*.tbd, or include_next wrapper target)"
         fi
     fi
     id=$(overlay_sysroot_inputs_id)
@@ -890,6 +1109,7 @@ overlay_sysroot_finish() {
     local live=$parent/MacOSX.sdk
     overlay_sysroot_copy_tbds "$fresh" "$live"
     overlay_sysroot_fill_modulemap_headers "$fresh"
+    overlay_sysroot_fill_include_next_wrappers "$fresh"
     overlay_sysroot_write_stamp "$fresh"
     overlay_sysroot_commit_live "$live" "$fresh"
     overlay_sysroot_print_headers "$live"

--- a/swiftcore-macho/scripts/overlay_sysroot.inc
+++ b/swiftcore-macho/scripts/overlay_sysroot.inc
@@ -10,11 +10,14 @@
 # not create this run; displace the live MacOSX.sdk aside (.stale-<utc>).
 #
 # Stamp covers the overlay-darwin header set + Darwin.modulemap recipe
-# (stage_overlay_darwin.sh + enumerated module headers) + machorun sys/proc.h.
+# (stage_overlay_darwin.sh + enumerated module headers) + machorun sys/proc.h
+# + the SDK copy's link inputs: usr/lib/*.tbd, usr/lib/swift/*.tbd,
+# usr/lib/swift/*.swiftmodule/*, and HEAD:machorun (darwin tbds originate in
+# machorun gen_tbd; phase2 copies them into scratch/sysroot_fe4[-x86_64]).
 # Required *staged* headers (ConditionalMacros.h included) must be present in
 # the dest tree: input-sha MATCH of the pin is not completeness. .tbd stubs
-# from machorun gen_tbd / the displaced tree are copied into the fresh dest
-# before the live MacOSX.sdk is moved aside.
+# are copied FROM that FE sysroot (fallback: machorun gen_tbd output / the
+# displaced tree) into the fresh dest before the live MacOSX.sdk is moved aside.
 #
 # Staged Darwin*.modulemap files name headers (complex.h, …). Those files must
 # resolve under usr/include before cmake. Closure is the Darwin Clang maps
@@ -37,8 +40,9 @@ OPENUIKIT_ROOT=${OPENUIKIT_ROOT:-$(cd "$SWIFTCORE_ROOT/.." && pwd)}
 . "$OPENUIKIT_ROOT/scripts/x86/common.inc"
 
 # Bump when staging steps, the Darwin.modulemap header list, modulemap
-# header closure, or the required staged-header / tbd completeness gate change.
-OVERLAY_SYSROOT_RECIPE=overlay-darwin.4
+# header closure, the required staged-header / tbd completeness gate, or the
+# tbd / swiftmodule / HEAD:machorun stamp inputs change.
+OVERLAY_SYSROOT_RECIPE=overlay-darwin.5
 OVERLAY_SYSROOT_STAMP=.overlay-sysroot-inputs
 
 # Same enumeration as stage_overlay_darwin.sh DARWIN_MODULE_HEADERS.
@@ -69,6 +73,9 @@ OVERLAY_SYSROOT_DEST=
 OVERLAY_SYSROOT_REUSE=0
 OVERLAY_SYSROOT_DISPLACED=
 OVERLAY_SYSROOT_TBD_SEARCHED=()
+OVERLAY_SYSROOT_SOURCE=ABSENT
+OVERLAY_SYSROOT_SOURCE_KIND=
+OVERLAY_SYSROOT_TBD_SHA=ABSENT
 
 overlay_sysroot_sha_or_absent() {
     local f=$1
@@ -94,12 +101,170 @@ overlay_sysroot_proc_h() {
     return 1
 }
 
+# Darwin usr/lib/*.tbd in the FE sysroot are copied from machorun gen_tbd
+# (phase2_stage_darwin_tbds_into_sysroot). Swift usr/lib/swift/*.tbd come from
+# scripts/x86/gen_swift_tbd.sh, not gen_tbd. Stamp HEAD:machorun for the
+# gen_tbd origin; stamp the tbd bytes themselves so a gen_tbd rerun without a
+# new commit (e.g. PR #67 _fmal) restages the overlay SDK copy.
+overlay_sysroot_machorun_head() {
+    local live
+    live=$(phase2_git "$OPENUIKIT_ROOT" rev-parse HEAD:machorun 2>/dev/null | tr -d '[:space:]') || live=
+    if [ -n "$live" ]; then
+        printf '%s\n' "$live"
+    else
+        printf 'ABSENT\n'
+    fi
+}
+
+# scratch/sysroot_fe4[-x86_64]: the tree phase2 stages from machorun gen_tbd.
+# Never the unsuffixed arm64 sysroot_fe4 on an x86_64 overlay.
+overlay_sysroot_source_candidates() {
+    local arch=${SWIFTCORE_DARWIN_ARCH:-x86_64}
+    [ -n "${SWIFTCORE_FE_SYSROOT:-}" ] && printf '%s\n' "$SWIFTCORE_FE_SYSROOT"
+    if [ -n "${W:-}" ]; then
+        printf '%s\n' "$W/scratch/sysroot_fe4-${arch}"
+        if [ "$arch" = x86_64 ]; then
+            printf '%s\n' "$W/scratch/sysroot_fe4-x86_64"
+        else
+            printf '%s\n' "$W/scratch/sysroot_fe4"
+        fi
+    fi
+    if [ "$arch" = x86_64 ]; then
+        printf '%s\n' "$OPENUIKIT_ROOT/scratch/sysroot_fe4-x86_64"
+    else
+        printf '%s\n' "$OPENUIKIT_ROOT/scratch/sysroot_fe4"
+    fi
+}
+
+overlay_sysroot_gen_tbd_candidates() {
+    [ -n "${W:-}" ] && printf '%s\n' "$W/machorun-sdk"
+    [ -n "${MACHORUN:-}" ] && printf '%s\n' "$MACHORUN/sdk"
+    [ -n "${W:-}" ] && printf '%s\n' "$W/machorun/sdk"
+    printf '%s\n' "$OPENUIKIT_ROOT/machorun/sdk"
+}
+
+overlay_sysroot_tree_has_tbds() {
+    local root=$1
+    local f
+    [ -n "$root" ] || return 1
+    [ -d "$root/usr/lib" ] || return 1
+    for f in "$root/usr/lib"/*.tbd; do
+        [ -e "$f" ] || [ -L "$f" ] || continue
+        return 0
+    done
+    return 1
+}
+
+overlay_sysroot_resolve_source() {
+    local cand root
+    OVERLAY_SYSROOT_SOURCE=ABSENT
+    OVERLAY_SYSROOT_SOURCE_KIND=
+    while IFS= read -r cand; do
+        [ -n "$cand" ] || continue
+        [ -e "$cand" ] || [ -L "$cand" ] || continue
+        overlay_sysroot_tree_has_tbds "$cand" || continue
+        root=$(realpath "$cand" 2>/dev/null || printf '%s' "$cand")
+        OVERLAY_SYSROOT_SOURCE=$root
+        OVERLAY_SYSROOT_SOURCE_KIND=fe
+        printf '%s\n' "$root"
+        return 0
+    done < <(overlay_sysroot_source_candidates)
+    while IFS= read -r cand; do
+        [ -n "$cand" ] || continue
+        [ -e "$cand" ] || [ -L "$cand" ] || continue
+        overlay_sysroot_tree_has_tbds "$cand" || continue
+        root=$(realpath "$cand" 2>/dev/null || printf '%s' "$cand")
+        OVERLAY_SYSROOT_SOURCE=$root
+        OVERLAY_SYSROOT_SOURCE_KIND=gen_tbd
+        printf '%s\n' "$root"
+        return 0
+    done < <(overlay_sysroot_gen_tbd_candidates)
+    return 1
+}
+
+overlay_sysroot_tbd_relpaths() {
+    local root=$1
+    local dir f
+    [ -n "$root" ] && [ "$root" != ABSENT ] || return 0
+    for dir in usr/lib usr/lib/swift; do
+        [ -d "$root/$dir" ] || continue
+        for f in "$root/$dir"/*.tbd; do
+            [ -e "$f" ] || [ -L "$f" ] || continue
+            printf '%s\n' "$dir/$(basename "$f")"
+        done
+    done | LC_ALL=C sort -u
+}
+
+overlay_sysroot_hash_tbds() {
+    local root=$1
+    local rel list
+    if [ -z "$root" ] || [ "$root" = ABSENT ]; then
+        printf 'ABSENT\n'
+        return 0
+    fi
+    list=$(overlay_sysroot_tbd_relpaths "$root")
+    if [ -z "$list" ]; then
+        printf 'ABSENT\n'
+        return 0
+    fi
+    {
+        while IFS= read -r rel; do
+            [ -n "$rel" ] || continue
+            printf '%s %s\n' "$rel" "$(overlay_sysroot_sha_or_absent "$root/$rel")"
+        done <<EOF
+$list
+EOF
+    } | sha256sum | awk '{print $1}'
+}
+
+overlay_sysroot_hash_swiftmodules() {
+    local root=$1
+    local f rel lines=""
+    if [ -z "$root" ] || [ "$root" = ABSENT ] || [ ! -d "$root/usr/lib/swift" ]; then
+        printf 'ABSENT\n'
+        return 0
+    fi
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        rel=${f#"$root/"}
+        lines="${lines}${rel} $(overlay_sysroot_sha_or_absent "$f")"$'\n'
+    done < <(find "$root/usr/lib/swift" -path '*.swiftmodule/*' \( -type f -o -type l \) | LC_ALL=C sort)
+    if [ -z "$lines" ]; then
+        printf 'ABSENT\n'
+        return 0
+    fi
+    printf '%s' "$lines" | sha256sum | awk '{print $1}'
+}
+
+# overlay_sysroot: source=<path> tbd_sha=<…> on every run.
+overlay_sysroot_print_source() {
+    local src tbd_sha
+    src=$(overlay_sysroot_resolve_source || true)
+    [ -n "$src" ] || src=ABSENT
+    tbd_sha=$(overlay_sysroot_hash_tbds "$src")
+    OVERLAY_SYSROOT_SOURCE=$src
+    OVERLAY_SYSROOT_TBD_SHA=$tbd_sha
+    echo "overlay_sysroot: source=${src} tbd_sha=${tbd_sha}"
+}
+
+overlay_sysroot_print_stamp_diff() {
+    local stamp=$1
+    local line
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        echo "overlay_sysroot: $line"
+    done < <(overlay_sysroot_stamp_diff "$stamp" || true)
+}
+
 # overlay_sysroot_input_lines
-# recipe + sha of the overlay-darwin header set + modulemap recipe + proc.h.
+# recipe + sha of the overlay-darwin header set + modulemap recipe + proc.h
+# + source usr/lib/*.tbd + usr/lib/swift/*.tbd + swiftmodules + HEAD:machorun.
 overlay_sysroot_input_lines() {
     local src=$SWIFTCORE_ROOT/sdk/overlay-darwin
-    local proc
+    local proc tbd_src tbd_rel
     proc=$(overlay_sysroot_proc_h || true)
+    tbd_src=$(overlay_sysroot_resolve_source || true)
+    [ -n "$tbd_src" ] || tbd_src=ABSENT
     printf 'recipe=%s\n' "$OVERLAY_SYSROOT_RECIPE"
     printf 'overlay-darwin.math.h=%s\n' "$(overlay_sysroot_sha_or_absent "$src/math.h")"
     printf 'overlay-darwin.MacTypes.h=%s\n' "$(overlay_sysroot_sha_or_absent "$src/MacTypes.h")"
@@ -115,6 +280,18 @@ overlay_sysroot_input_lines() {
         "$(printf '%s\n' "${OVERLAY_SYSROOT_REQUIRED_HEADERS[@]}" | sha256sum | awk '{print $1}')"
     printf 'modulemap.closure=darwin_clang_overlay_maps\n'
     printf 'machorun.sys/proc.h=%s\n' "$(overlay_sysroot_sha_or_absent "${proc:-}")"
+    # gen_tbd origin (darwin usr/lib/*.tbd). Not a substitute for hashing the
+    # generated tbd bytes: PR #67 updated gen_tbd output without this tree
+    # hash changing between overlay stamp writes.
+    printf 'machorun.HEAD=%s\n' "$(overlay_sysroot_machorun_head)"
+    printf 'tbd_sha=%s\n' "$(overlay_sysroot_hash_tbds "$tbd_src")"
+    printf 'usr/lib/swift.modules=%s\n' "$(overlay_sysroot_hash_swiftmodules "$tbd_src")"
+    if [ "$tbd_src" != ABSENT ]; then
+        while IFS= read -r tbd_rel; do
+            [ -n "$tbd_rel" ] || continue
+            printf '%s=%s\n' "$tbd_rel" "$(overlay_sysroot_sha_or_absent "$tbd_src/$tbd_rel")"
+        done < <(overlay_sysroot_tbd_relpaths "$tbd_src")
+    fi
 }
 
 overlay_sysroot_write_stamp() {
@@ -165,6 +342,7 @@ overlay_sysroot_print_headers() {
     local sdk=${1:?overlay_sysroot_print_headers: sdk}
     local rel h
     echo "overlay_sysroot: tree=$sdk"
+    overlay_sysroot_print_source
     if [ -L "$sdk" ]; then
         echo "overlay_sysroot: symlink -> $(readlink "$sdk")"
     fi
@@ -213,6 +391,7 @@ overlay_sysroot_print_headers() {
             fi
         else
             echo "overlay_sysroot: stamp=MISMATCH recipe=$OVERLAY_SYSROOT_RECIPE"
+            overlay_sysroot_print_stamp_diff "$sdk/$OVERLAY_SYSROOT_STAMP"
         fi
     else
         echo "overlay_sysroot: stamp=ABSENT"
@@ -454,16 +633,72 @@ overlay_sysroot_print_tbds() {
     echo "overlay_sysroot: tbds tree=$sdk realpath=$resolved count=$n"
 }
 
-# Copy *.tbd into dest/usr/lib from each source tree's usr/lib. Never
-# overwrite a tbd already in dest. Search: extra args, live MacOSX.sdk,
-# displaced tree, machorun gen_tbd output.
+# Copy *.tbd (and swiftmodule files) into dest from src. overwrite=1 replaces
+# dest files so scratch/sysroot_fe4[-x86_64] wins over a stale machorun-sdk
+# copy stage_sdk.sh already laid down.
+# overlay_sysroot_copy_tbds_from <src> <dest> <overwrite 0|1>
+overlay_sysroot_copy_tbds_from() {
+    local src=${1:?overlay_sysroot_copy_tbds_from: src}
+    local dest=${2:?overlay_sysroot_copy_tbds_from: dest}
+    local overwrite=${3:-0}
+    local lib t bn n=0 swift_n=0 rel f
+    lib=$src/usr/lib
+    [ -d "$lib" ] || return 0
+    mkdir -p "$dest/usr/lib"
+    OVERLAY_SYSROOT_TBD_SEARCHED+=("$lib")
+    for t in "$lib"/*.tbd; do
+        [ -e "$t" ] || [ -L "$t" ] || continue
+        bn=$(basename "$t")
+        if [ "$overwrite" != 1 ] && [ -e "$dest/usr/lib/$bn" ]; then
+            continue
+        fi
+        cp -a "$t" "$dest/usr/lib/$bn"
+        n=$((n + 1))
+    done
+    if [ -d "$src/usr/lib/swift" ]; then
+        mkdir -p "$dest/usr/lib/swift"
+        for t in "$src/usr/lib/swift"/*.tbd; do
+            [ -e "$t" ] || [ -L "$t" ] || continue
+            bn=$(basename "$t")
+            if [ "$overwrite" != 1 ] && [ -e "$dest/usr/lib/swift/$bn" ]; then
+                continue
+            fi
+            cp -a "$t" "$dest/usr/lib/swift/$bn"
+            swift_n=$((swift_n + 1))
+        done
+        while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            rel=${f#"$src/usr/lib/swift/"}
+            if [ "$overwrite" != 1 ] && [ -e "$dest/usr/lib/swift/$rel" ]; then
+                continue
+            fi
+            mkdir -p "$(dirname "$dest/usr/lib/swift/$rel")"
+            cp -a "$f" "$dest/usr/lib/swift/$rel"
+            swift_n=$((swift_n + 1))
+        done < <(find "$src/usr/lib/swift" -path '*.swiftmodule/*' \( -type f -o -type l \) | LC_ALL=C sort)
+    fi
+    if [ "$n" -gt 0 ] || [ "$swift_n" -gt 0 ]; then
+        echo "overlay_sysroot: copied $n tbds + $swift_n swift inputs from $src → $dest"
+    else
+        echo "overlay_sysroot: tbd search $lib (none new)"
+    fi
+}
+
+# Copy *.tbd into dest from each source tree's usr/lib. The FE sysroot
+# (scratch/sysroot_fe4[-x86_64]) is the primary source and overwrites; other
+# trees (live MacOSX.sdk, displaced, machorun gen_tbd) fill gaps only.
 # overlay_sysroot_copy_tbds <dest> [src_sdk...]
 overlay_sysroot_copy_tbds() {
     local dest=${1:?overlay_sysroot_copy_tbds: dest}
     shift
-    local src root lib t bn n srcs
+    local src root srcs primary seen=""
     OVERLAY_SYSROOT_TBD_SEARCHED=()
     mkdir -p "$dest/usr/lib"
+    primary=$(overlay_sysroot_resolve_source || true)
+    if [ -n "$primary" ]; then
+        overlay_sysroot_copy_tbds_from "$primary" "$dest" 1
+        seen=" $primary "
+    fi
     srcs=("$@")
     for src in \
         ${W:+$W/sdk/MacOSX.sdk} \
@@ -476,8 +711,7 @@ overlay_sysroot_copy_tbds() {
         [ -n "$src" ] || continue
         srcs+=("$src")
     done
-    local seen="" s
-    for src in "${srcs[@]}"; do
+    for src in "${srcs[@]+"${srcs[@]}"}"; do
         [ -n "$src" ] || continue
         [ -e "$src" ] || [ -L "$src" ] || continue
         root=$(realpath "$src" 2>/dev/null || printf '%s' "$src")
@@ -488,24 +722,7 @@ overlay_sysroot_copy_tbds() {
             OVERLAY_SYSROOT_TBD_SEARCHED+=("$root (dest)")
             continue
         fi
-        lib=$root/usr/lib
-        OVERLAY_SYSROOT_TBD_SEARCHED+=("$lib")
-        [ -d "$lib" ] || continue
-        n=0
-        for t in "$lib"/*.tbd; do
-            [ -f "$t" ] || continue
-            bn=$(basename "$t")
-            if [ -e "$dest/usr/lib/$bn" ]; then
-                continue
-            fi
-            cp -a "$t" "$dest/usr/lib/$bn"
-            n=$((n + 1))
-        done
-        if [ "$n" -gt 0 ]; then
-            echo "overlay_sysroot: copied $n tbds from $lib → $dest/usr/lib"
-        else
-            echo "overlay_sysroot: tbd search $lib (none new)"
-        fi
+        overlay_sysroot_copy_tbds_from "$root" "$dest" 0
     done
     echo "overlay_sysroot: tbd dest=$dest/usr/lib count=$(overlay_sysroot_tbd_count "$dest")"
 }
@@ -522,7 +739,7 @@ overlay_sysroot_refuse_empty_tbds() {
     resolved=$(realpath "$sdk" 2>/dev/null || printf '%s' "$sdk")
     searched=$(printf '%s,' "${OVERLAY_SYSROOT_TBD_SEARCHED[@]:-}" | sed 's/,$//')
     [ -n "$searched" ] || searched=none
-    echo "CANNOT_OVERLAY_SYSROOT_TBDS tree=$sdk realpath=$resolved count=0 searched=$searched reason=no .tbd stubs in this sysroot; ld64 would see a lie. machorun gen_tbd output and the displaced MacOSX.sdk usr/lib must be copied into the fresh overlay dest." >&2
+    echo "CANNOT_OVERLAY_SYSROOT_TBDS tree=$sdk realpath=$resolved count=0 searched=$searched reason=no .tbd stubs in this sysroot; ld64 would see a lie. scratch/sysroot_fe4[-x86_64] (phase2, from machorun gen_tbd) and the displaced MacOSX.sdk usr/lib must be copied into the fresh overlay dest." >&2
     return 2
 }
 
@@ -624,6 +841,7 @@ overlay_sysroot_begin() {
     OVERLAY_SYSROOT_DEST=
     OVERLAY_SYSROOT_DISPLACED=
     mkdir -p "$parent"
+    overlay_sysroot_print_source
     if [ -e "$live" ] || [ -L "$live" ]; then
         if overlay_sysroot_stamp_matches "$live" && overlay_sysroot_tree_complete "$live"; then
             echo "overlay_sysroot: reuse $live (stamp MATCH recipe=$OVERLAY_SYSROOT_RECIPE)"
@@ -632,7 +850,14 @@ overlay_sysroot_begin() {
             return 0
         fi
         echo "overlay_sysroot: live $live will not be reused:"
-        overlay_sysroot_stamp_diff "$live/$OVERLAY_SYSROOT_STAMP" || true
+        if [ ! -f "$live/$OVERLAY_SYSROOT_STAMP" ]; then
+            echo "overlay_sysroot: stamp=ABSENT"
+        elif overlay_sysroot_stamp_matches "$live"; then
+            echo "overlay_sysroot: stamp=MATCH recipe=$OVERLAY_SYSROOT_RECIPE"
+        else
+            echo "overlay_sysroot: stamp=MISMATCH recipe=$OVERLAY_SYSROOT_RECIPE"
+            overlay_sysroot_print_stamp_diff "$live/$OVERLAY_SYSROOT_STAMP"
+        fi
         if ! overlay_sysroot_tree_complete "$live"; then
             echo "overlay_sysroot: live tree incomplete (required headers or usr/lib/*.tbd)"
         fi
@@ -656,8 +881,9 @@ overlay_sysroot_begin() {
 }
 
 # overlay_sysroot_finish <sdk_parent> <fresh_dir>
-# Copy .tbd stubs from the still-live MacOSX.sdk (and machorun gen_tbd)
-# into dest *before* displacing the live tree.
+# Copy .tbd stubs from scratch/sysroot_fe4[-x86_64] (phase2 / machorun gen_tbd)
+# into dest *before* displacing the live tree. Gap-fill from the still-live
+# MacOSX.sdk and machorun/sdk.
 overlay_sysroot_finish() {
     local parent=${1:?overlay_sysroot_finish: sdk parent}
     local fresh=${2:?overlay_sysroot_finish: fresh}

--- a/swiftcore-macho/scripts/stage_sdk.sh
+++ b/swiftcore-macho/scripts/stage_sdk.sh
@@ -68,9 +68,13 @@ done
 
 # 3. machorun's clean-room private SPI headers (TargetConditionals, ptrauth,
 #    os/*, mach-o/dyld_priv.h, ...) sit at the sysroot root the same way
-#    machorun's own builds consume them.
+#    machorun's own builds consume them. include_next wrappers (objc4-priv
+#    crt_externs.h) go to usr/local/include — clang Darwin -isysroot searches
+#    that dir first, then usr/include, where the public machorun-sdk header
+#    already landed in step 1. Flattening the wrapper onto usr/include left
+#    no later SDK dir; Darwin.o died at crt_externs.h:13.
 if [ -d "$W/objc4-priv" ]; then
-  (cd "$W/objc4-priv" && find . -name '*.h' -exec install -D {} "$SDK/usr/include/{}" \; ) || true
+  overlay_sysroot_install_objc4_priv "$W/objc4-priv" "$SDK"
 fi
 [ -f "$W/machorun-sdk/local/TargetConditionals.h" ] && \
   cp -f "$W/machorun-sdk/local/TargetConditionals.h" "$SDK/usr/include/TargetConditionals.h"

--- a/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
+++ b/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Overlay sysroot staging is input-keyed. A pre-existing MacOSX.sdk with
 # clean-room math.h / no stamp is displaced, never rm'd; mismatch restages
-# into a fresh directory. Refuse-before-cmake if math.h lacks fmaxl,
-# sys/proc.h lacks extern_proc, or a Darwin Clang overlay map names a header
-# that is not on disk. libc++ usr/include/c++/v1/module.modulemap is outside
-# that closure and must not refuse.
+# into a fresh directory. Stamp also keys usr/lib/*.tbd from the FE sysroot
+# (scratch/sysroot_fe4[-x86_64], phase2 / machorun gen_tbd): a tbd-only
+# source change is MISMATCH, not MATCH. Refuse-before-cmake if math.h lacks
+# fmaxl, sys/proc.h lacks extern_proc, or a Darwin Clang overlay map names a
+# header that is not on disk. libc++ usr/include/c++/v1/module.modulemap is
+# outside that closure and must not refuse.
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
@@ -79,6 +81,9 @@ grep -q 'fmaxl=yes' "$tmp/print1" \
   && echo "  OK  fmaxl=yes" || { echo "  FAIL fmaxl not yes"; cat "$tmp/print1"; fail=1; }
 grep -q 'extern_proc=yes' "$tmp/print1" \
   && echo "  OK  extern_proc=yes" || { echo "  FAIL extern_proc not yes"; fail=1; }
+grep -q 'overlay_sysroot: source=ABSENT tbd_sha=ABSENT' "$tmp/print1" \
+  && echo "  OK  source=ABSENT tbd_sha=ABSENT (no FE sysroot)" \
+  || { echo "  FAIL source/tbd_sha line"; cat "$tmp/print1"; fail=1; }
 
 mkdir -p "$tmp/bad/usr/include/sys"
 echo '/* clean-room math.h — no fmaxl */' > "$tmp/bad/usr/include/math.h"
@@ -152,6 +157,136 @@ echo "=== matching stamp + complete headers → reuse, no second dest ==="
 overlay_sysroot_begin "$tmp/sdk"
 need '[ "${OVERLAY_SYSROOT_REUSE}" = 1 ]' "second begin reuses"
 need '[ -f "$stale/CANARY" ]' "stale canary still exists after reuse"
+
+echo
+echo "=== tbd-only change in FE source → stamp=MISMATCH and restage ==="
+fe=$W/scratch/sysroot_fe4-x86_64
+mkdir -p "$fe/usr/lib" "$fe/usr/lib/swift/Darwin.swiftmodule"
+cat > "$fe/usr/lib/libSystem.B.tbd" <<'TBD'
+--- !tapi-tbd-v3
+archs: [ x86_64 ]
+install-name: /usr/lib/libSystem.B.dylib
+exports:
+  - archs: [ x86_64 ]
+    symbols: [ _fmaxl ]
+TBD
+ln -sfn libSystem.B.tbd "$fe/usr/lib/libSystem.tbd"
+echo '--- !tapi-tbd-v3' > "$fe/usr/lib/swift/libswiftCore.tbd"
+echo 'module Darwin {}' > "$fe/usr/lib/swift/Darwin.swiftmodule/x86_64-apple-macos.swiftinterface"
+
+sdk_tbd=$tmp/sdkTbd
+mkdir -p "$sdk_tbd"
+overlay_sysroot_begin "$sdk_tbd" >"$tmp/begin_fe" 2>&1
+st=$?
+cat "$tmp/begin_fe"
+[ "$st" -eq 0 ] && echo "  OK  first FE begin rc=0" || { echo "  FAIL first FE begin rc=$st"; fail=1; }
+grep -q "overlay_sysroot: source=$fe tbd_sha=" "$tmp/begin_fe" \
+  && echo "  OK  begin source=scratch/sysroot_fe4-x86_64" \
+  || { echo "  FAIL begin source line"; cat "$tmp/begin_fe"; fail=1; }
+grep -q 'tbd_sha=ABSENT' "$tmp/begin_fe" \
+  && { echo "  FAIL tbd_sha=ABSENT with FE tbds present"; fail=1; } \
+  || echo "  OK  tbd_sha is not ABSENT"
+need '[ "${OVERLAY_SYSROOT_REUSE}" = 0 ]' "first FE begin restages"
+fresh_fe=$OVERLAY_SYSROOT_DEST
+fill_required_headers "$fresh_fe"
+set +e
+overlay_sysroot_finish "$sdk_tbd" "$fresh_fe" >"$tmp/fe.finish1" 2>&1
+fin_st=$?
+set -e
+cat "$tmp/fe.finish1"
+[ "$fin_st" -eq 0 ] && echo "  OK  first FE finish rc=0" || { echo "  FAIL first FE finish rc=$fin_st"; fail=1; }
+grep -q '_fmaxl' "$sdk_tbd/MacOSX.sdk/usr/lib/libSystem.tbd" \
+  && echo "  OK  dest libSystem.tbd came from FE source" \
+  || { echo "  FAIL dest missing FE tbd"; fail=1; }
+[ -f "$sdk_tbd/MacOSX.sdk/usr/lib/swift/libswiftCore.tbd" ] \
+  && echo "  OK  dest has usr/lib/swift/libswiftCore.tbd" \
+  || { echo "  FAIL dest missing swift tbd"; fail=1; }
+[ -f "$sdk_tbd/MacOSX.sdk/usr/lib/swift/Darwin.swiftmodule/x86_64-apple-macos.swiftinterface" ] \
+  && echo "  OK  dest has Darwin.swiftmodule slice" \
+  || { echo "  FAIL dest missing swiftmodule"; fail=1; }
+grep -q "overlay_sysroot: source=$fe tbd_sha=" "$tmp/fe.finish1" \
+  && echo "  OK  finish print_headers source= FE sysroot" \
+  || { echo "  FAIL finish source line"; fail=1; }
+grep -q '^machorun.HEAD=' "$sdk_tbd/MacOSX.sdk/$OVERLAY_SYSROOT_STAMP" \
+  && echo "  OK  stamp records machorun.HEAD (darwin tbds from gen_tbd)" \
+  || { echo "  FAIL stamp missing machorun.HEAD"; fail=1; }
+grep -q '^usr/lib/libSystem.tbd=' "$sdk_tbd/MacOSX.sdk/$OVERLAY_SYSROOT_STAMP" \
+  && echo "  OK  stamp records usr/lib/libSystem.tbd" \
+  || { echo "  FAIL stamp missing libSystem.tbd key"; cat "$sdk_tbd/MacOSX.sdk/$OVERLAY_SYSROOT_STAMP"; fail=1; }
+
+echo
+echo "=== nothing changed in FE source → stamp=MATCH ==="
+overlay_sysroot_begin "$sdk_tbd" >"$tmp/begin_match" 2>&1
+st=$?
+cat "$tmp/begin_match"
+[ "$st" -eq 0 ] && echo "  OK  MATCH begin rc=0" || { echo "  FAIL MATCH begin rc=$st"; fail=1; }
+need '[ "${OVERLAY_SYSROOT_REUSE}" = 1 ]' "unchanged FE source reuses (stamp MATCH)"
+grep -q 'stamp MATCH' "$tmp/begin_match" \
+  && echo "  OK  begin printed stamp MATCH" \
+  || { echo "  FAIL MATCH text"; cat "$tmp/begin_match"; fail=1; }
+grep -q "overlay_sysroot: source=$fe tbd_sha=" "$tmp/begin_match" \
+  && echo "  OK  MATCH run still prints source= tbd_sha=" \
+  || { echo "  FAIL MATCH source line"; fail=1; }
+
+echo
+echo "=== only libSystem.tbd changes in FE source → stamp=MISMATCH, displace, restage ==="
+# Simulate PR #67: gen_tbd / phase2 updated _fmal in the FE tree; overlay
+# headers and HEAD:machorun are unchanged.
+cat > "$fe/usr/lib/libSystem.B.tbd" <<'TBD'
+--- !tapi-tbd-v3
+archs: [ x86_64 ]
+install-name: /usr/lib/libSystem.B.dylib
+exports:
+  - archs: [ x86_64 ]
+    symbols: [ _fmaxl, _fmal ]
+TBD
+overlay_sysroot_begin "$sdk_tbd" >"$tmp/begin_mis" 2>&1
+st=$?
+cat "$tmp/begin_mis"
+[ "$st" -eq 0 ] && echo "  OK  tbd-mismatch begin rc=0" || { echo "  FAIL tbd-mismatch begin rc=$st"; fail=1; }
+need '[ "${OVERLAY_SYSROOT_REUSE}" = 0 ]' "tbd-only change restages (REUSE=0)"
+grep -q 'overlay_sysroot: stamp=MISMATCH' "$tmp/begin_mis" \
+  && echo "  OK  stamp=MISMATCH" \
+  || { echo "  FAIL missing stamp=MISMATCH"; cat "$tmp/begin_mis"; fail=1; }
+grep -qE 'overlay_sysroot: usr/lib/libSystem\.tbd [0-9a-f]+->[0-9a-f]+' "$tmp/begin_mis" \
+  && echo "  OK  libSystem.tbd old->new" \
+  || { echo "  FAIL libSystem.tbd diff"; cat "$tmp/begin_mis"; fail=1; }
+grep -q 'overlay-darwin.math.h' "$tmp/begin_mis" \
+  && { echo "  FAIL header keys also mismatched on tbd-only change"; fail=1; } \
+  || echo "  OK  overlay-darwin headers did not mismatch"
+need '[[ "$OVERLAY_SYSROOT_DEST" == *MacOSX.sdk.overlay-* ]]' "tbd mismatch fresh dest"
+fresh_mis=$OVERLAY_SYSROOT_DEST
+fill_required_headers "$fresh_mis"
+set +e
+overlay_sysroot_finish "$sdk_tbd" "$fresh_mis" >"$tmp/fe.finish2" 2>&1
+fin_st=$?
+set -e
+cat "$tmp/fe.finish2"
+[ "$fin_st" -eq 0 ] && echo "  OK  tbd restage finish rc=0" || { echo "  FAIL tbd restage finish rc=$fin_st"; fail=1; }
+grep -q '_fmal' "$sdk_tbd/MacOSX.sdk/usr/lib/libSystem.tbd" \
+  && echo "  OK  restaged dest libSystem.tbd has _fmal" \
+  || { echo "  FAIL restaged dest still lacks _fmal"; fail=1; }
+stale_tbd=$(ls -d "$sdk_tbd"/MacOSX.sdk.stale-* 2>/dev/null | head -1)
+if [ -n "$stale_tbd" ] && [ -f "$stale_tbd/usr/lib/libSystem.B.tbd" ]; then
+  echo "  OK  previous SDK displaced to $stale_tbd (not rm'd)"
+  grep -q '_fmal' "$stale_tbd/usr/lib/libSystem.B.tbd" \
+    && { echo "  FAIL displaced tree already has _fmal"; fail=1; } \
+    || echo "  OK  displaced tree still has the pre-_fmal tbd"
+else
+  echo "  FAIL no stale tree after tbd restage"
+  ls -la "$sdk_tbd" || true
+  fail=1
+fi
+
+echo
+echo "=== after tbd restage, nothing changed → MATCH again ==="
+overlay_sysroot_begin "$sdk_tbd" >"$tmp/begin_again" 2>&1
+st=$?
+cat "$tmp/begin_again"
+need '[ "${OVERLAY_SYSROOT_REUSE}" = 1 ]' "post-restage unchanged source MATCH"
+grep -q 'stamp MATCH' "$tmp/begin_again" \
+  && echo "  OK  post-restage stamp MATCH" \
+  || { echo "  FAIL post-restage MATCH"; cat "$tmp/begin_again"; fail=1; }
 
 echo
 echo "=== listed required header missing → refuse (not stamp MATCH) ==="

--- a/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
+++ b/swiftcore-macho/scripts/test_overlay_sysroot_stamp.sh
@@ -4,9 +4,10 @@
 # into a fresh directory. Stamp also keys usr/lib/*.tbd from the FE sysroot
 # (scratch/sysroot_fe4[-x86_64], phase2 / machorun gen_tbd): a tbd-only
 # source change is MISMATCH, not MATCH. Refuse-before-cmake if math.h lacks
-# fmaxl, sys/proc.h lacks extern_proc, or a Darwin Clang overlay map names a
-# header that is not on disk. libc++ usr/include/c++/v1/module.modulemap is
-# outside that closure and must not refuse.
+# fmaxl, sys/proc.h lacks extern_proc, a Darwin Clang overlay map names a
+# header that is not on disk, or an include_next wrapper (objc4-priv
+# crt_externs.h) has no later -isysroot target. libc++ usr/include/c++/v1
+# module.modulemap is outside that closure and must not refuse.
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
@@ -484,6 +485,190 @@ if grep -n 'rm -rf "$W/sdk"' "$SCRIPT_DIR/stage_sdk.sh"; then
   fail=1
 else
   echo "  OK  no rm -rf \$W/sdk"
+fi
+
+echo
+echo "=== stage_sdk.sh does not flatten include_next wrappers onto usr/include ==="
+if grep -nF 'install -D {} "$SDK/usr/include/{}"' "$SCRIPT_DIR/stage_sdk.sh"; then
+  echo "  FAIL stage_sdk.sh still install -D objc4-priv onto usr/include"
+  fail=1
+else
+  echo "  OK  no flatten install -D onto usr/include"
+fi
+grep -q 'overlay_sysroot_install_objc4_priv' "$SCRIPT_DIR/stage_sdk.sh" \
+  && echo "  OK  stage_sdk calls overlay_sysroot_install_objc4_priv" \
+  || { echo "  FAIL stage_sdk missing overlay_sysroot_install_objc4_priv"; fail=1; }
+
+echo
+echo "=== objc4-priv include_next wrapper at usr/include is refused ==="
+wrap=$OPENUIKIT_ROOT/machorun/vendor/objc4-priv/crt_externs.h
+pub=$OPENUIKIT_ROOT/machorun/sdk/usr/include/crt_externs.h
+need '[ -f "$wrap" ]' "objc4-priv crt_externs.h present"
+need '[ -f "$pub" ]' "machorun-sdk public crt_externs.h present"
+grep -q include_next "$wrap" \
+  && echo "  OK  objc4-priv crt_externs.h is include_next wrapper" \
+  || { echo "  FAIL wrapper lacks include_next"; fail=1; }
+grep -q include_next "$pub" \
+  && { echo "  FAIL public crt_externs.h has include_next"; fail=1; } \
+  || echo "  OK  public crt_externs.h has no include_next"
+mkdir -p "$tmp/crtwrap/usr/include" "$tmp/crtwrap/usr/lib"
+fill_required_headers "$tmp/crtwrap"
+echo '--- !tapi-tbd-v3' > "$tmp/crtwrap/usr/lib/libSystem.B.tbd"
+cp "$wrap" "$tmp/crtwrap/usr/include/crt_externs.h"
+overlay_sysroot_write_stamp "$tmp/crtwrap"
+if overlay_sysroot_tree_complete "$tmp/crtwrap"; then
+  echo "  FAIL tree_complete true with wrapper-only crt_externs.h"
+  fail=1
+else
+  echo "  OK  tree_complete false (wrapper target absent)"
+fi
+set +e
+print_wrap=$(overlay_sysroot_print_headers "$tmp/crtwrap" 2>&1)
+refuse_wrap=$(overlay_sysroot_refuse_incomplete "$tmp/crtwrap" 2>&1)
+st=$?
+set -e
+printf '%s\n' "$print_wrap" | grep -q 'include_next missing header=crt_externs.h' \
+  && echo "  OK  print names missing crt_externs.h" \
+  || { echo "  FAIL print include_next"; printf '%s\n' "$print_wrap" | tail -20; fail=1; }
+[ "$st" -eq 2 ] && echo "  OK  wrapper-only refuse rc=2" \
+  || { echo "  FAIL wrapper-only refuse rc=$st"; printf '%s\n' "$refuse_wrap"; fail=1; }
+printf '%s\n' "$refuse_wrap" | grep -q 'CANNOT_OVERLAY_SYSROOT_INCLUDE_NEXT' \
+  && echo "  OK  CANNOT_OVERLAY_SYSROOT_INCLUDE_NEXT" \
+  || { echo "  FAIL missing INCLUDE_NEXT marker"; printf '%s\n' "$refuse_wrap"; fail=1; }
+printf '%s\n' "$refuse_wrap" | grep -q 'crt_externs.h@usr/include/crt_externs.h' \
+  && echo "  OK  missing names wrapper path" \
+  || { echo "  FAIL missing attribution"; printf '%s\n' "$refuse_wrap"; fail=1; }
+
+echo
+echo "=== fill_include_next_wrappers restores public header behind wrapper ==="
+overlay_sysroot_fill_include_next_wrappers "$tmp/crtwrap" | tee "$tmp/crt.fill"
+grep -q 'usr/local/include' "$tmp/crt.fill" \
+  && echo "  OK  fill moved wrapper to usr/local/include" \
+  || { echo "  FAIL fill did not mention usr/local/include"; cat "$tmp/crt.fill"; fail=1; }
+need '[ -f "$tmp/crtwrap/usr/local/include/crt_externs.h" ]' \
+  "wrapper at usr/local/include/crt_externs.h"
+need '[ -f "$tmp/crtwrap/usr/include/crt_externs.h" ]' \
+  "public header at usr/include/crt_externs.h"
+overlay_sysroot_is_include_next_wrapper "$tmp/crtwrap/usr/local/include/crt_externs.h" \
+  && echo "  OK  usr/local/include/crt_externs.h is the wrapper" \
+  || { echo "  FAIL usr/local is not the wrapper"; fail=1; }
+overlay_sysroot_is_include_next_wrapper "$tmp/crtwrap/usr/include/crt_externs.h" \
+  && { echo "  FAIL usr/include still the wrapper"; fail=1; } \
+  || echo "  OK  usr/include/crt_externs.h is not the wrapper"
+grep -q _NSGetArgc "$tmp/crtwrap/usr/include/crt_externs.h" \
+  && echo "  OK  usr/include declares _NSGetArgc" \
+  || { echo "  FAIL public header lacks _NSGetArgc"; fail=1; }
+if overlay_sysroot_tree_complete "$tmp/crtwrap"; then
+  echo "  OK  tree_complete true after fill"
+else
+  echo "  FAIL tree_complete false after fill"
+  fail=1
+fi
+set +e
+refuse_filled=$(overlay_sysroot_refuse_incomplete "$tmp/crtwrap" 2>&1)
+st=$?
+set -e
+[ "$st" -eq 0 ] && echo "  OK  filled refuse rc=0" \
+  || { echo "  FAIL filled refuse rc=$st"; printf '%s\n' "$refuse_filled"; fail=1; }
+printf '%s\n' "$refuse_filled" | grep -q CANNOT_OVERLAY_SYSROOT_INCLUDE_NEXT \
+  && { echo "  FAIL filled still INCLUDE_NEXT"; printf '%s\n' "$refuse_filled"; fail=1; } \
+  || echo "  OK  filled is not INCLUDE_NEXT"
+
+echo
+echo "=== working copy (public header only, no wrapper) still complete ==="
+mkdir -p "$tmp/crtpub/usr/include" "$tmp/crtpub/usr/lib"
+fill_required_headers "$tmp/crtpub"
+echo '--- !tapi-tbd-v3' > "$tmp/crtpub/usr/lib/libSystem.B.tbd"
+cp "$pub" "$tmp/crtpub/usr/include/crt_externs.h"
+if overlay_sysroot_tree_complete "$tmp/crtpub"; then
+  echo "  OK  public-only tree_complete true"
+else
+  echo "  FAIL public-only tree_complete false"
+  fail=1
+fi
+set +e
+refuse_pub=$(overlay_sysroot_refuse_incomplete "$tmp/crtpub" 2>&1)
+st=$?
+set -e
+[ "$st" -eq 0 ] && echo "  OK  public-only refuse rc=0" \
+  || { echo "  FAIL public-only refuse rc=$st"; printf '%s\n' "$refuse_pub"; fail=1; }
+
+echo
+echo "=== overlay_sysroot_install_objc4_priv keeps public usr/include ==="
+mkdir -p "$tmp/privsrc" "$tmp/sdkinst/usr/include/os"
+cp "$wrap" "$tmp/privsrc/crt_externs.h"
+mkdir -p "$tmp/privsrc/os"
+echo '/* not a wrapper */' > "$tmp/privsrc/os/lock_private.h"
+echo '/* public from machorun-sdk step 1 */' > "$tmp/sdkinst/usr/include/crt_externs.h"
+echo '_NSGetArgc public' >> "$tmp/sdkinst/usr/include/crt_externs.h"
+overlay_sysroot_install_objc4_priv "$tmp/privsrc" "$tmp/sdkinst"
+need '[ -f "$tmp/sdkinst/usr/local/include/crt_externs.h" ]' \
+  "install put wrapper at usr/local/include"
+need '[ -f "$tmp/sdkinst/usr/include/os/lock_private.h" ]' \
+  "non-wrapper priv header still at usr/include"
+overlay_sysroot_is_include_next_wrapper "$tmp/sdkinst/usr/local/include/crt_externs.h" \
+  && echo "  OK  installed wrapper is include_next" \
+  || { echo "  FAIL installed usr/local is not wrapper"; fail=1; }
+overlay_sysroot_is_include_next_wrapper "$tmp/sdkinst/usr/include/crt_externs.h" \
+  && { echo "  FAIL install overwrote usr/include with wrapper"; fail=1; } \
+  || echo "  OK  usr/include crt_externs.h not overwritten"
+grep -q '_NSGetArgc public' "$tmp/sdkinst/usr/include/crt_externs.h" \
+  && echo "  OK  step-1 public header preserved" \
+  || { echo "  FAIL public header lost"; fail=1; }
+
+echo
+echo "=== clang -isysroot finds public crt_externs.h via include_next ==="
+clang18=$(command -v clang-18 || true)
+if [ -n "$clang18" ]; then
+  clang_sdk=$tmp/clangsdk
+  mkdir -p "$clang_sdk"
+  cp -a "$OPENUIKIT_ROOT/machorun/sdk/usr" "$clang_sdk/usr"
+  mkdir -p "$clang_sdk/usr/local/include"
+  cp "$pub" "$clang_sdk/usr/include/crt_externs.h"
+  cp "$wrap" "$clang_sdk/usr/local/include/crt_externs.h"
+  printf '%s\n' '#include <crt_externs.h>' > "$tmp/crt_probe.c"
+  set +e
+  pre=$("$clang18" -target x86_64-apple-macos13.0 -isysroot "$clang_sdk" \
+    -E "$tmp/crt_probe.c" 2>"$tmp/crt_probe.err")
+  st=$?
+  set -e
+  [ "$st" -eq 0 ] && echo "  OK  clang -E rc=0" \
+    || { echo "  FAIL clang -E rc=$st"; cat "$tmp/crt_probe.err"; fail=1; }
+  printf '%s\n' "$pre" | grep -q _NSGetArgc \
+    && echo "  OK  clang -E sees _NSGetArgc (public header via include_next)" \
+    || { echo "  FAIL clang -E missing _NSGetArgc"; fail=1; }
+  printf '%s\n' "$pre" | grep -q __progname \
+    && echo "  OK  clang -E sees __progname (objc4-priv wrapper)" \
+    || { echo "  FAIL clang -E missing wrapper __progname"; fail=1; }
+  printf '%s\n' "$pre" | grep -q usr/local/include/crt_externs.h \
+    && echo "  OK  -E entered usr/local/include wrapper first" \
+    || { echo "  FAIL -E did not enter usr/local/include"; fail=1; }
+  printf '%s\n' "$pre" | grep -q usr/include/crt_externs.h \
+    && echo "  OK  -E include_next'd usr/include public header" \
+    || { echo "  FAIL -E did not reach usr/include"; fail=1; }
+  # Wrapper-only (the restage bug): same -E must fail at include_next.
+  mkdir -p "$tmp/clangbad/usr/include"
+  cp "$wrap" "$tmp/clangbad/usr/include/crt_externs.h"
+  set +e
+  "$clang18" -target x86_64-apple-macos13.0 -isysroot "$tmp/clangbad" \
+    -E "$tmp/crt_probe.c" >/dev/null 2>"$tmp/crt_probe_bad.err"
+  badst=$?
+  set -e
+  if grep -q "file not found" "$tmp/crt_probe_bad.err"; then
+    echo "  OK  wrapper-only clang -E fails at include_next (operator shape)"
+  else
+    echo "  FAIL wrapper-only clang -E did not reproduce crt_externs.h file not found"
+    echo "  rc=$badst"
+    cat "$tmp/crt_probe_bad.err" | head -20
+    fail=1
+  fi
+  grep -q 'crt_externs.h:13:15' "$tmp/crt_probe_bad.err" \
+    && echo "  OK  error is crt_externs.h:13:15" \
+    || { echo "  FAIL error is not crt_externs.h:13:15"; cat "$tmp/crt_probe_bad.err"; fail=1; }
+  [ "$badst" -ne 0 ] && echo "  OK  wrapper-only clang -E rc!=0" \
+    || { echo "  FAIL wrapper-only clang -E succeeded"; fail=1; }
+else
+  echo "  skip clang -E (no clang-18)"
 fi
 
 echo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## After PR #67 (x86_64 box, main a19c9dd1 / operator a140e5ec)

PR #67 added `_fmal` (and the other libSystem/libc++ symbols) to machorun's generated tbds. The x86 sysroot picked them up (`scratch/sysroot_fe4-x86_64/usr/lib/libSystem.B.tbd`, `'_fmal'` present). The overlay build did not: every ninja overlay still failed `ld64.lld: error: undefined symbol: fmal`, because the links use `-isysroot /root/work/sdk/MacOSX.sdk`, a copy staged by `configure.sh` / `overlay_sysroot.inc`, whose `usr/lib/libSystem.tbd` still lacked `_fmal`.

The stamp (`.overlay-sysroot-inputs`) covered the overlay-darwin header set + Darwin.modulemap recipe — not the tbds. A tbd-only change in the source sysroot reported `stamp=MATCH` and the stale copy was reused.

### Stamp inputs (recipe `overlay-darwin.6`)

Reuse keys on everything the overlay links and compiles read from the SDK copy:

- overlay-darwin headers + Darwin.modulemap recipe + `sys/proc.h`
- `usr/lib/*.tbd` and `usr/lib/swift/*.tbd` (per-file keys + aggregate `tbd_sha`)
- `usr/lib/swift/*.swiftmodule/*`
- `machorun.HEAD` (`git rev-parse HEAD:machorun`) — darwin `usr/lib/*.tbd` originate in machorun **gen_tbd**; phase2 copies them into `scratch/sysroot_fe4[-x86_64]`
- public `crt_externs.h` / objc4-priv wrapper (include_next chain)

Mismatch still prints `key old->new` and **displaces** the live `MacOSX.sdk` aside (`.stale-<utc>`), never `rm`. Copy source is `scratch/sysroot_fe4[-x86_64]`. Every run prints:

```
overlay_sysroot: source=<path> tbd_sha=<sha>
```

## Operator restage (deleted `.overlay-sysroot-inputs`; x86 box, main a140e5ec)

TBD staleness is confirmed fixed by a restage — `swift_Builtin_float` now **BUILDS** (`fmal` resolved) — but the restaged copy was incomplete in a different way:

```
OVERLAY swiftDarwin-macosx-x86_64 FAILED first_error=/root/work/sdk/MacOSX.sdk/usr/include/crt_externs.h:13:15: error: 'crt_externs.h' file not found
OVERLAY swift_Concurrency-macosx-x86_64 FAILED first_error=(same crt_externs.h:13:15)
OVERLAY swiftObservation-macosx-x86_64 FAILED first_error=(same)
OVERLAY swift_StringProcessing-macosx-x86_64 FAILED first_error=FAILED: lib/swift/macosx/libswiftCore.so
OVERLAY swift_RegexParser-macosx-x86_64 FAILED first_error=FAILED: lib/swift/macosx/libswiftCore.so
OVERLAY swiftSynchronization FAILED dep=swiftDarwin
built: swift_Builtin_float, _DarwinFoundation1/2/3, _errno, ObjectiveC
```

### Working vs broken `crt_externs.h` (`.stale-<utc>` vs fresh restage)

clang Darwin `-isysroot $SDK` (overlay compiles pass `-sdk` only; no extra `-I` for objc4-priv) searches:

1. `$SDK/usr/local/include`
2. clang resource dir (not an SDK dir we stage into)
3. `$SDK/usr/include`

| copy | `usr/include/crt_externs.h` | `usr/local/include/crt_externs.h` |
|---|---|---|
| Working (hand-grown / `.stale-<utc>`) | public Apple header from machorun-sdk / FE (`_NSGetArgc`, **no** `#include_next`) | objc4-priv wrapper, or absent |
| Broken restage | objc4-priv wrapper (`#include_next <crt_externs.h>` at line 13) | absent |

`stage_sdk.sh` copied machorun-sdk (real header), then flattened `objc4-priv` **onto** `usr/include`, overwriting with the wrapper. `include_next` from `usr/include` has no later SDK dir → `crt_externs.h:13:15` file not found.

Complete layout this change restages:

- `usr/local/include/crt_externs.h` = objc4-priv **wrapper** (front `-isysroot` dir)
- `usr/include/crt_externs.h` = public machorun-sdk / FE header

`overlay_sysroot_refuse_incomplete` now refuses a wrapper whose later `-isysroot` target is absent (`CANNOT_OVERLAY_SYSROOT_INCLUDE_NEXT`). `overlay_sysroot_install_objc4_priv` never flattens include_next wrappers onto `usr/include`. `fill_include_next_wrappers` repairs a leftover flattened tree. A working copy with only the public header (no wrapper) still `tree_complete`.

## `_StringProcessing` / `_RegexParser` vs `libswiftCore.so`

Those two overlays failing `FAILED: lib/swift/macosx/libswiftCore.so` is the **pre-existing Darwin core `.so` link / unarch flatten issue**, not a new overlay-sysroot hole.

Linux-host CMake names the Darwin core `libswiftCore.so` (not `.dylib`). Overlay ninja targets depend on that Darwin product, including the unarch flatten `lib/swift/macosx/libswiftCore.so` (`lipo_single_arch` copies `lib/swift/macosx/${arch}/libswiftCore.so` onto the unarch path). Mach-O overlays **should** keep depending on that Darwin-named `.so`. They do **not** need a host ELF `libswiftCore`. Do not drop the ninja dep because the filename looks like ELF.

## Operator command

Same command as PR #64:

```bash
NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
  SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
  bash swiftcore-macho/scripts/build_stdlib.sh
```

After this change a restage (recipe `overlay-darwin.6` mismatches `.5` stamps, or a wrapper-only tree is `tree=INCOMPLETE`) should print the wrapper → `usr/local/include` layout and Darwin.o should get past `crt_externs.h:13`. `_StringProcessing` / `_RegexParser` will still wait on the Darwin `libswiftCore.so` unarch/link.

## Test

`test_overlay_sysroot_stamp.sh`:

- tbd-only FE change → `stamp=MISMATCH` + restage (dest has `_fmal`)
- wrapper-only `usr/include/crt_externs.h` → refuse rc=2, `CANNOT_OVERLAY_SYSROOT_INCLUDE_NEXT`
- `fill_include_next_wrappers` → public at `usr/include`, wrapper at `usr/local/include`, refuse rc=0
- `clang-18 -target x86_64-apple-macos13.0 -isysroot $sdk -E` of `#include <crt_externs.h>` sees `_NSGetArgc` + `__progname`; wrapper-only reproduces `crt_externs.h:13:15: error: 'crt_externs.h' file not found`

Also `test_overlay_darwin.sh`, `test_build_stdlib_print_flags.sh`, `test_configure_arch.sh`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01dfd371-b8b8-4f10-a99f-3f64b8f2168e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01dfd371-b8b8-4f10-a99f-3f64b8f2168e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

