### PR TITLE
Key libCFTest / ud_guest reuse on input stamps, not sibling stub files

### DIFF
--- a/foundation-macho/scripts/build_cftest_harness.sh
+++ b/foundation-macho/scripts/build_cftest_harness.sh
@@ -10,6 +10,16 @@
 # list or a stale backup. So: link once to find out what is undefined, then
 # stub exactly that.
 #
+# Reuse of lib/libCFTest.dylib is keyed on lib/libCFTest.dylib.inputs, written
+# at link time: sha256 of every object linked (cfobjc + nscf + probe +
+# cfstubs.o), the stub-set files, the libSystem/libobjc tbds, and the linker
+# argv. A present dylib whose sibling stub text files match the pin is NOT
+# enough — that is how a regenerated 214-name list sat next to a 143-stub
+# dylib. Matching stamp → reused=1 stamp=<sha>. Mismatch →
+# reason=inputs <key> old->new and relink. stub-func-active.txt newer than
+# the dylib is a CANNOT naming both mtimes in verify-only (CFTEST_VERIFY_ONLY=1),
+# and a forced relink otherwise.
+#
 # Objects come from scripts/build_cfobjc.sh ($W/cfobjc/obj/*.o) and from the
 # NS* surface compiled here ($W/nscfobj/*.o) with the argv build_cf_probes.sh
 # already committed for NSCFConstantString.m. This script is the LINKER
@@ -51,9 +61,136 @@ extra_inc=()
 if [ -d "$CFEXTRA" ]; then
     extra_inc=(-idirafter "$CFEXTRA")
 fi
+CFTEST_EXPECT_FUNC=${CFTEST_EXPECT_FUNC:-$FM/docs/cf-census/cftest-stub-func-active.txt}
+CFTEST_EXPECT_DATA=${CFTEST_EXPECT_DATA:-$FM/docs/cf-census/cftest-stub-data.txt}
 
 mkdir -p "$LIB" "$NSCF_OBJ" "$W" /tmp
 shopt -s nullglob
+
+cftest_file_sha() {
+    if [ -f "$1" ]; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        printf 'ABSENT\n'
+    fi
+}
+
+cftest_mtime_iso() {
+    if [ -e "$1" ]; then
+        date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
+    else
+        printf 'ABSENT\n'
+    fi
+}
+
+cftest_tbd() {
+    local base=$1 f
+    for f in "$SDK/usr/lib/${base}.tbd" \
+             "$SDK/usr/lib/${base}.B.tbd" \
+             "$SDK/usr/lib/${base}.A.tbd"; do
+        if [ -e "$f" ]; then
+            printf '%s\n' "$f"
+            return 0
+        fi
+    done
+    printf '%s\n' "$SDK/usr/lib/${base}.tbd"
+}
+
+cftest_obj_key() {
+    local o=$1
+    case "$o" in
+        "$CFOBJC_OBJ"/*) printf 'obj:cfobjc/%s\n' "$(basename "$o")" ;;
+        "$NSCF_OBJ"/*) printf 'obj:nscfobj/%s\n' "$(basename "$o")" ;;
+        *) printf 'obj:%s\n' "$(basename "$o")" ;;
+    esac
+}
+
+cftest_linked_objects() {
+    local o
+    [ -f "$W/probe_sysctl.o" ] && printf '%s\n' "$W/probe_sysctl.o"
+    for o in "$CFOBJC_OBJ"/*.o; do
+        [ -f "$o" ] && printf '%s\n' "$o"
+    done
+    for o in "$NSCF_OBJ"/*.o; do
+        [ -f "$o" ] && printf '%s\n' "$o"
+    done
+    [ -f "$W/cfstubs.o" ] && printf '%s\n' "$W/cfstubs.o"
+}
+
+cftest_final_link_words() {
+    printf '%s\n' \
+        "$CC" -target "$TRIPLE" -isysroot "$SDK" -fuse-ld=lld -B "$LLD" \
+        -nostdlib -dynamiclib -install_name /usr/lib/libCFTest.dylib \
+        -Wl,--error-limit=0 -Wl,-undefined,dynamic_lookup \
+        -L"$SDK/usr/lib" -L"$LIB"
+    cftest_linked_objects
+    printf '%s\n' -lSystem -lobjc
+    if [ "${#extra_libs[@]}" -gt 0 ]; then
+        printf '%s\n' "${extra_libs[@]}"
+    fi
+    printf '%s\n' -o "$LIB/libCFTest.dylib"
+}
+
+cftest_inputs_text() {
+    local o key sys_tbd objc_tbd
+    sys_tbd=$(cftest_tbd libSystem)
+    objc_tbd=$(cftest_tbd libobjc)
+    printf 'argv=%s\n' "$(cftest_final_link_words | sha256sum | awk '{print $1}')"
+    while IFS= read -r o; do
+        [ -n "$o" ] || continue
+        key=$(cftest_obj_key "$o")
+        printf '%s=%s\n' "$key" "$(cftest_file_sha "$o")"
+    done < <(cftest_linked_objects)
+    printf 'stub-data=%s\n' "$(cftest_file_sha "$W/stub-data.txt")"
+    printf 'stub-func-active=%s\n' "$(cftest_file_sha "$W/stub-func-active.txt")"
+    printf 'tbd:libSystem=%s\n' "$(cftest_file_sha "$sys_tbd")"
+    printf 'tbd:libobjc=%s\n' "$(cftest_file_sha "$objc_tbd")"
+}
+
+cftest_write_inputs() {
+    cftest_inputs_text > "$LIB/libCFTest.dylib.inputs"
+}
+
+cftest_inputs_id() {
+    cftest_file_sha "$LIB/libCFTest.dylib.inputs"
+}
+
+# Print "key old->new" lines. Return 0 iff the on-disk stamp matches.
+cftest_inputs_diff() {
+    local stamp=$LIB/libCFTest.dylib.inputs
+    local expected key val old changed=0
+    expected=$(cftest_inputs_text)
+    if [ ! -f "$stamp" ]; then
+        printf 'stamp ABSENT->present\n'
+        return 1
+    fi
+    while IFS='=' read -r key val; do
+        [ -n "$key" ] || continue
+        old=$(awk -F= -v k="$key" '$1==k { print substr($0, index($0,"=")+1); exit }' "$stamp")
+        [ -n "$old" ] || old=ABSENT
+        if [ "$old" != "$val" ]; then
+            printf '%s %s->%s\n' "$key" "$old" "$val"
+            changed=1
+        fi
+    done <<EOF
+$expected
+EOF
+    while IFS='=' read -r key val; do
+        [ -n "$key" ] || continue
+        if ! printf '%s\n' "$expected" | awk -F= -v k="$key" '$1==k { found=1 } END { exit !found }'
+        then
+            printf '%s %s->ABSENT\n' "$key" "$val"
+            changed=1
+        fi
+    done < "$stamp"
+    [ "$changed" -eq 0 ]
+}
+
+cftest_stub_stale_line() {
+    printf 'CANNOT_CFTEST_STALE file=libCFTest.dylib stub-func-active.txt=%s libCFTest.dylib=%s\n' \
+        "$(cftest_mtime_iso "$W/stub-func-active.txt")" \
+        "$(cftest_mtime_iso "$LIB/libCFTest.dylib")"
+}
 
 # nscf argv: build_cf_probes.sh rebuild_nscf (NSCFConstantString.m), applied
 # to every src/nscf/*.m. harvest_ns_classes.sh recorded 7 objects from
@@ -103,9 +240,6 @@ if [ "${#cf_objs[@]}" -eq 0 ]; then
     exit 2
 fi
 
-"$CC" -target "$TRIPLE" -isysroot "$SDK" -Os "${extra_inc[@]}" -c "$PROBE_SRC" \
-  -o "$W/probe_sysctl.o" 2>/tmp/probe.err || { echo "PROBE BUILD FAILED"; grep -m3 error: /tmp/probe.err; exit 2; }
-
 DISPATCH=
 if [ -f "${LIBDISPATCH_DYLIB:-}" ]; then
     DISPATCH=$LIBDISPATCH_DYLIB
@@ -123,6 +257,50 @@ fi
 extra_libs=()
 [ -n "$DISPATCH" ] && extra_libs+=("$DISPATCH")
 [ -n "$SWIFTCOMPAT" ] && extra_libs+=("$SWIFTCOMPAT")
+
+relink_reason=
+dylib=$LIB/libCFTest.dylib
+if [ -f "$dylib" ]; then
+    if [ -f "$W/stub-func-active.txt" ] && [ "$W/stub-func-active.txt" -nt "$dylib" ]; then
+        relink_reason=$(cftest_stub_stale_line)
+        if [ "${CFTEST_VERIFY_ONLY:-0}" = 1 ]; then
+            echo "$relink_reason"
+            echo "build_cftest_harness: stub-func-active.txt is newer than lib/libCFTest.dylib; refusing to call this satisfied (verify-only)." >&2
+            exit 2
+        fi
+        echo "$relink_reason"
+        echo "libCFTest relink reason=inputs stub-func-active.txt $(cftest_mtime_iso "$dylib")->$(cftest_mtime_iso "$W/stub-func-active.txt") (stub list newer than dylib)"
+    else
+        diff=$(cftest_inputs_diff || true)
+        if [ -z "$diff" ]; then
+            stamp_id=$(cftest_inputs_id)
+            echo "libCFTest reused=1 stamp=$stamp_id dest=$dylib"
+            if [ -d "$W/root/darwin/usr/lib" ]; then
+                cp -f "$dylib" "$W/root/darwin/usr/lib/libCFTest.dylib"
+            fi
+            exit 0
+        fi
+        first=$(printf '%s\n' "$diff" | head -1)
+        key=${first%% *}
+        rest=${first#"$key "}
+        relink_reason="reason=inputs $key $rest"
+        if [ "${CFTEST_VERIFY_ONLY:-0}" = 1 ]; then
+            echo "CANNOT_CFTEST_INPUTS file=libCFTest.dylib $relink_reason"
+            echo "$diff"
+            echo "build_cftest_harness: input stamp mismatch; refusing to call this satisfied (verify-only)." >&2
+            exit 2
+        fi
+        echo "libCFTest relink $relink_reason"
+        echo "$diff"
+    fi
+elif [ "${CFTEST_VERIFY_ONLY:-0}" = 1 ]; then
+    echo "CANNOT_CFTEST_INPUTS file=libCFTest.dylib reason=inputs stamp ABSENT->present"
+    echo "build_cftest_harness: no lib/libCFTest.dylib (verify-only)." >&2
+    exit 2
+fi
+
+"$CC" -target "$TRIPLE" -isysroot "$SDK" -Os "${extra_inc[@]}" -c "$PROBE_SRC" \
+  -o "$W/probe_sysctl.o" 2>/tmp/probe.err || { echo "PROBE BUILD FAILED"; grep -m3 error: /tmp/probe.err; exit 2; }
 
 "$CC" -target "$TRIPLE" -isysroot "$SDK" -fuse-ld=lld -B "$LLD" \
   -nostdlib -dynamiclib -Wl,--error-limit=0 \
@@ -152,7 +330,9 @@ comm -23 "$W/stub-func.txt" "$W/probe-defines.txt" > "$W/stub-func-active.txt"
 # real gap (STUB CALLED: CFStringCreateWithBytes). check_cftest_stubs.sh
 # prints CANNOT_CFTEST_STUBS extra=<names> missing=<names> and we stop
 # before generating abort stubs.
-stub_check=$(bash "$HERE/check_cftest_stubs.sh" "$W/stub-func-active.txt" "$W/stub-data.txt") || {
+stub_check=$(bash "$HERE/check_cftest_stubs.sh" \
+    "$W/stub-func-active.txt" "$W/stub-data.txt" \
+    "$CFTEST_EXPECT_FUNC" "$CFTEST_EXPECT_DATA") || {
     echo "$stub_check"
     echo "build_cftest_harness: refusing to link libCFTest with an unexpected stub set (docs/cf-census/cftest-stubs.md)." >&2
     exit 2
@@ -203,7 +383,8 @@ while read -r s; do i=$((i+1)); echo "void sf_$i(void) __asm__(\"_$s\");"; echo 
   "$W/probe_sysctl.o" "$CFOBJC_OBJ"/*.o "$NSCF_OBJ"/*.o "$W/cfstubs.o" \
   -lSystem -lobjc "${extra_libs[@]}" \
   -o "$LIB/libCFTest.dylib" 2>/tmp/lk.err || { echo "LINK FAILED"; grep -m5 -E "undefined|duplicate" /tmp/lk.err; exit 2; }
+cftest_write_inputs
 if [ -d "$W/root/darwin/usr/lib" ]; then
     cp -f "$LIB/libCFTest.dylib" "$W/root/darwin/usr/lib/libCFTest.dylib"
 fi
-echo "libCFTest relinked ($(wc -l < "$W/undef-now.txt") stubbed) dest=$LIB/libCFTest.dylib"
+echo "libCFTest relinked ($(wc -l < "$W/undef-now.txt") stubbed) dest=$LIB/libCFTest.dylib${relink_reason:+ $relink_reason}"

--- a/foundation-macho/scripts/build_cftest_harness.sh
+++ b/foundation-macho/scripts/build_cftest_harness.sh
@@ -321,7 +321,8 @@ awk "/^k[A-Z]/ || /^OBJC_CLASS/ {print > \"$W/stub-data.txt\"; next} {print > \"
 [ -s "$W/stub-func.txt" ] || : > "$W/stub-func.txt"
 [ -s "$W/stub-data.txt" ] || : > "$W/stub-data.txt"
 
-llvm-nm-18 --defined-only "$W/probe_sysctl.o" | awk '$2=="T"{print substr($3,2)}' | sort -u > "$W/probe-defines.txt"
+llvm-nm-18 --defined-only "$W/probe_sysctl.o" 2>/dev/null \
+  | awk '$2=="T"{print substr($3,2)}' | sort -u > "$W/probe-defines.txt" || true
 comm -23 "$W/stub-func.txt" "$W/probe-defines.txt" > "$W/stub-func-active.txt"
 
 # The stub set is derived every run, then pinned against

--- a/foundation-macho/scripts/check_cftest_stubs.sh
+++ b/foundation-macho/scripts/check_cftest_stubs.sh
@@ -38,8 +38,8 @@ trap cleanup EXIT
 : >>"$got_data"
 sort -u "$got_func" | grep -v '^$' >"$tmp/got-func" || true
 sort -u "$got_data" | grep -v '^$' >"$tmp/got-data" || true
-sort -u "$EXPECT_FUNC" | grep -v '^$' >"$tmp/exp-func"
-sort -u "$EXPECT_DATA" | grep -v '^$' >"$tmp/exp-data"
+sort -u "$EXPECT_FUNC" | grep -v '^$' >"$tmp/exp-func" || true
+sort -u "$EXPECT_DATA" | grep -v '^$' >"$tmp/exp-data" || true
 
 comm -13 "$tmp/exp-func" "$tmp/got-func" >"$tmp/extra-func" || true
 comm -23 "$tmp/exp-func" "$tmp/got-func" >"$tmp/miss-func" || true

--- a/foundation-macho/scripts/link_ud_guest.sh
+++ b/foundation-macho/scripts/link_ud_guest.sh
@@ -23,6 +23,13 @@
 # REPEATABLE, and it CHECKS. The freshness check is the point, not a courtesy
 # -- a binary older than its own inputs passes every git-level check there is.
 #
+# Reuse of bin/ud_guest is keyed on bin/ud_guest.inputs, written at link time:
+# sha256 of every object on the line, libCFTest.dylib, and the linker argv.
+# Existence of the binary is not enough (same class as the loader existence
+# reuse in PR #65). Matching stamp → reused=1 stamp=<sha>. Mismatch →
+# reason=inputs <key> old->new and relink. UD_GUEST_VERIFY_ONLY=1 reports
+# CANNOT_UD_GUEST_INPUTS instead of linking.
+#
 # NOT a compile step. The objects are built elsewhere (the port and runner by
 # the #87 recipe, FoundationEssentials by ~/swift-macho-linux's build_fe.sh).
 # This script only links, and it refuses rather than silently linking stale
@@ -107,14 +114,109 @@ DYLIBS=(-lswiftCore -lswiftDarwin -lswift_StringProcessing
 # path keeps it out of the search-order question entirely.
 DYLIBS+=("$W/lib/libCFTest.dylib" "$W/lib/libswiftcompat.dylib")
 
+ud_file_sha() {
+    if [ -f "$1" ]; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        printf 'ABSENT\n'
+    fi
+}
+
+ud_obj_key() {
+    printf 'obj:%s\n' "${1#$W/}"
+}
+
+ud_link_words() {
+    printf '%s\n' \
+        "$CC" -target "$TRIPLE" -isysroot "$SDK" \
+        -fuse-ld=lld -B "$LLD" -nostdlib \
+        "${LIBDIRS[@]}" \
+        -Wl,-rpath,/usr/lib/swift -Wl,-rpath,@loader_path \
+        "${INPUTS[@]}" "${DYLIBS[@]}" \
+        -o "$OUT"
+}
+
+ud_inputs_text() {
+    local o
+    printf 'argv=%s\n' "$(ud_link_words | sha256sum | awk '{print $1}')"
+    printf 'cftest=%s\n' "$(ud_file_sha "$W/lib/libCFTest.dylib")"
+    for o in "${INPUTS[@]}"; do
+        printf '%s=%s\n' "$(ud_obj_key "$o")" "$(ud_file_sha "$o")"
+    done
+}
+
+ud_write_inputs() {
+    mkdir -p "$(dirname "$OUT")"
+    ud_inputs_text > "$OUT.inputs"
+}
+
+ud_inputs_diff() {
+    local stamp=$OUT.inputs
+    local expected key val old changed=0
+    expected=$(ud_inputs_text)
+    if [ ! -f "$stamp" ]; then
+        printf 'stamp ABSENT->present\n'
+        return 1
+    fi
+    while IFS='=' read -r key val; do
+        [ -n "$key" ] || continue
+        old=$(awk -F= -v k="$key" '$1==k { print substr($0, index($0,"=")+1); exit }' "$stamp")
+        [ -n "$old" ] || old=ABSENT
+        if [ "$old" != "$val" ]; then
+            printf '%s %s->%s\n' "$key" "$old" "$val"
+            changed=1
+        fi
+    done <<EOF
+$expected
+EOF
+    while IFS='=' read -r key val; do
+        [ -n "$key" ] || continue
+        if ! printf '%s\n' "$expected" | awk -F= -v k="$key" '$1==k { found=1 } END { exit !found }'
+        then
+            printf '%s %s->ABSENT\n' "$key" "$val"
+            changed=1
+        fi
+    done < "$stamp"
+    [ "$changed" -eq 0 ]
+}
+
 echo "== inputs"
 for o in "${INPUTS[@]}"; do
     printf '   %-46s %10s bytes  %s\n' "${o#$W/}" "$(wc -c < "$o")" \
         "$(date -r "$o" -u '+%H:%M:%S')"
 done
 
-echo "==> linking $OUT CC=$CC"
+relink_reason=
 mkdir -p "$(dirname "$OUT")"
+if [ -f "$OUT" ]; then
+    diff=$(ud_inputs_diff || true)
+    if [ -z "$diff" ]; then
+        stamp_id=$(ud_file_sha "$OUT.inputs")
+        echo "ud_guest reused=1 stamp=$stamp_id dest=$OUT"
+        echo "== $OUT"
+        echo "   $(wc -c < "$OUT") bytes"
+        llvm-otool-18 -L "$OUT" | tail -n +2 | sed 's/^/   /'
+        exit 0
+    fi
+    first=$(printf '%s\n' "$diff" | head -1)
+    key=${first%% *}
+    rest=${first#"$key "}
+    relink_reason="reason=inputs $key $rest"
+    if [ "${UD_GUEST_VERIFY_ONLY:-0}" = 1 ]; then
+        echo "CANNOT_UD_GUEST_INPUTS file=ud_guest $relink_reason"
+        echo "$diff"
+        echo "link_ud_guest: input stamp mismatch; refusing to call this satisfied (verify-only)." >&2
+        exit 2
+    fi
+    echo "ud_guest relink $relink_reason"
+    echo "$diff"
+elif [ "${UD_GUEST_VERIFY_ONLY:-0}" = 1 ]; then
+    echo "CANNOT_UD_GUEST_INPUTS file=ud_guest reason=inputs stamp ABSENT->present"
+    echo "link_ud_guest: no $OUT (verify-only)." >&2
+    exit 2
+fi
+
+echo "==> linking $OUT CC=$CC${relink_reason:+ $relink_reason}"
 # -nostdlib: Linux-hosted Darwin links must not pull host crt. Same as
 # run_bundle_guest.sh / run_tests.sh. clang-18 still passes -syslibroot.
 "$CC" -target "$TRIPLE" -isysroot "$SDK" \
@@ -123,6 +225,7 @@ mkdir -p "$(dirname "$OUT")"
   -Wl,-rpath,/usr/lib/swift -Wl,-rpath,@loader_path \
   "${INPUTS[@]}" "${DYLIBS[@]}" \
   -o "$OUT"
+ud_write_inputs
 
 # ---------------------------------------------------------------------------
 # THE CHECK THIS SCRIPT EXISTS FOR. Every input must be OLDER than the output.

--- a/foundation-macho/scripts/test_build_cftest_harness.sh
+++ b/foundation-macho/scripts/test_build_cftest_harness.sh
@@ -78,136 +78,164 @@ fi
 rm -rf "$fix"
 
 echo "== input stamp: matching reused=1, stale stub list CANNOT, object sha relink"
-SYS=${SYS:-$(cd "$FM/.." && pwd)/scratch/sysroot_fe4-x86_64}
-if [ ! -d "$SYS/usr/include" ]; then
-    die_test "x86 sysroot missing; cannot run harness stamp fixtures"
+HW=$(mktemp -d /tmp/cftest-stamp.XXXXXX)
+mkdir -p "$HW/cfobjc/obj" "$HW/nscfobj" "$HW/lib" \
+    "$HW/sdk/usr/lib" "$HW/sdk/usr/include"
+emit_tbd() {
+    local dest=$1 install=$2
+    mkdir -p "$(dirname "$dest")"
+    cat >"$dest" <<EOF
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos ]
+install-name:    '$install'
+current-version: 1
+compatibility-version: 1
+exports:
+  - targets:   [ x86_64-macos ]
+    symbols:   [
+                  '_dummy_tbd',
+               ]
+...
+EOF
+}
+emit_tbd "$HW/sdk/usr/lib/libSystem.B.tbd" "/usr/lib/libSystem.B.dylib"
+ln -sfn libSystem.B.tbd "$HW/sdk/usr/lib/libSystem.tbd"
+emit_tbd "$HW/sdk/usr/lib/libobjc.A.tbd" "/usr/lib/libobjc.A.dylib"
+ln -sfn libobjc.A.tbd "$HW/sdk/usr/lib/libobjc.tbd"
+mkdir -p "$HW/sdk/usr/include/objc"
+cat >"$HW/sdk/usr/include/objc/NSObject.h" <<'EOF'
+#ifndef _TEST_NSOBJECT_H_
+#define _TEST_NSOBJECT_H_
+typedef struct objc_class *Class;
+typedef struct objc_object { Class isa; } *id;
+typedef struct objc_selector *SEL;
+@interface NSObject
++ (void)initialize;
+- (void)doesNotRecognizeSelector:(SEL)s;
+@end
+#endif
+EOF
+TRIPLE=x86_64-apple-macos13.0
+echo 'int cfobjc_probe=1;' | clang-18 -target "$TRIPLE" -c -o "$HW/cfobjc/obj/CFString.o" -x c -
+echo 'int nscf_probe=1;' | clang-18 -target "$TRIPLE" -c -o "$HW/nscfobj/NSCFConstantString.o" -x c -
+: > "$HW/expect-func.txt"
+: > "$HW/expect-data.txt"
+
+run_h() {
+    W="$HW" SDK="$HW/sdk" LIB="$HW/lib" \
+        CFOBJC_OBJ="$HW/cfobjc/obj" NSCF_OBJ="$HW/nscfobj" \
+        R="$FM" PROBE_SRC="$FM/tests/probe_sysctl.c" \
+        CFTEST_EXPECT_FUNC="$HW/expect-func.txt" \
+        CFTEST_EXPECT_DATA="$HW/expect-data.txt" \
+        TRIPLE="$TRIPLE" \
+        LLD_BIN=/usr/lib/llvm-18/bin \
+        "$@" bash "$H"
+}
+
+set +e
+first=$(run_h 2>&1)
+first_st=$?
+set -e
+if [ "$first_st" -eq 0 ] && echo "$first" | grep -q 'libCFTest relinked' \
+    && [ -f "$HW/lib/libCFTest.dylib" ] \
+    && [ -f "$HW/lib/libCFTest.dylib.inputs" ]
+then
+    ok "first harness run relinks and writes libCFTest.dylib.inputs"
 else
-    HW=$(mktemp -d /tmp/cftest-stamp.XXXXXX)
-    mkdir -p "$HW/cfobjc/obj" "$HW/nscfobj" "$HW/lib" "$HW/sdk/usr/lib" "$HW/sdk/usr/include"
-    # Use the real x86 sysroot for -isysroot / tbds; keep W's sdk/ for layout.
-    echo 'int cfobjc_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$HW/cfobjc/obj/CFString.o" -x c -
-    echo 'int nscf_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$HW/nscfobj/NSCFConstantString.o" -x c -
-    : > "$HW/expect-func.txt"
-    : > "$HW/expect-data.txt"
-
-    run_h() {
-        W="$HW" SDK="$SYS" LIB="$HW/lib" \
-            CFOBJC_OBJ="$HW/cfobjc/obj" NSCF_OBJ="$HW/nscfobj" \
-            R="$FM" PROBE_SRC="$FM/tests/probe_sysctl.c" \
-            CFTEST_EXPECT_FUNC="$HW/expect-func.txt" \
-            CFTEST_EXPECT_DATA="$HW/expect-data.txt" \
-            TRIPLE=x86_64-apple-macos13.0 \
-            LLD_BIN=/usr/lib/llvm-18/bin \
-            "$@" bash "$H"
-    }
-
-    set +e
-    first=$(run_h 2>&1)
-    first_st=$?
-    set -e
-    if [ "$first_st" -eq 0 ] && echo "$first" | grep -q 'libCFTest relinked' \
-        && [ -f "$HW/lib/libCFTest.dylib" ] \
-        && [ -f "$HW/lib/libCFTest.dylib.inputs" ]
-    then
-        ok "first harness run relinks and writes libCFTest.dylib.inputs"
-    else
-        die_test "first harness run exit $first_st: $first"
-    fi
-    grep -q '^obj:cfobjc/CFString.o=' "$HW/lib/libCFTest.dylib.inputs" \
-        && grep -q '^obj:nscfobj/NSCFConstantString.o=' "$HW/lib/libCFTest.dylib.inputs" \
-        && grep -q '^obj:cfstubs.o=' "$HW/lib/libCFTest.dylib.inputs" \
-        && grep -q '^stub-func-active=' "$HW/lib/libCFTest.dylib.inputs" \
-        && grep -q '^tbd:libSystem=' "$HW/lib/libCFTest.dylib.inputs" \
-        && grep -q '^tbd:libobjc=' "$HW/lib/libCFTest.dylib.inputs" \
-        && grep -q '^argv=' "$HW/lib/libCFTest.dylib.inputs" \
-        && ok "stamp records objects, stub-set, tbds, argv" \
-        || die_test "stamp contents: $(tr '\n' ' ' < "$HW/lib/libCFTest.dylib.inputs")"
-
-    old_sha=$(sha256sum "$HW/lib/libCFTest.dylib" | awk '{print $1}')
-    set +e
-    second=$(run_h 2>&1)
-    second_st=$?
-    set -e
-    new_sha=$(sha256sum "$HW/lib/libCFTest.dylib" | awk '{print $1}')
-    if [ "$second_st" -eq 0 ] && echo "$second" | grep -q 'libCFTest reused=1 stamp=' \
-        && [ "$old_sha" = "$new_sha" ]
-    then
-        ok "matching stamp is reused=1 (dylib sha unchanged)"
-    else
-        die_test "second harness run exit $second_st sha $old_sha->$new_sha: $second"
-    fi
-
-    set +e
-    v_ok=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
-    v_ok_st=$?
-    set -e
-    if [ "$v_ok_st" -eq 0 ] && echo "$v_ok" | grep -q 'libCFTest reused=1 stamp='; then
-        ok "verify-only matching stamp is reused=1"
-    else
-        die_test "verify-only match exit $v_ok_st: $v_ok"
-    fi
-
-    # Regenerated stub list, old dylib: CANNOT in verify-only.
-    touch -d '2020-01-01 00:00:00 UTC' "$HW/lib/libCFTest.dylib"
-    touch "$HW/stub-func-active.txt"
-    set +e
-    stale=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
-    stale_st=$?
-    set -e
-    if [ "$stale_st" -eq 2 ] \
-        && echo "$stale" | grep -q '^CANNOT_CFTEST_STALE ' \
-        && echo "$stale" | grep -q 'stub-func-active.txt=' \
-        && echo "$stale" | grep -q 'libCFTest.dylib=' \
-        && echo "$stale" | grep -qv 'reused=1'
-    then
-        ok "stale dylib + fresh stub list is CANNOT_CFTEST_STALE (verify-only, not satisfied)"
-    else
-        die_test "stale stub list verify-only exit $stale_st: $stale"
-    fi
-
-    # Same stale pair without verify-only must relink, not reuse.
-    set +e
-    relink_stale=$(run_h 2>&1)
-    relink_stale_st=$?
-    set -e
-    if [ "$relink_stale_st" -eq 0 ] && echo "$relink_stale" | grep -q 'libCFTest relinked' \
-        && echo "$relink_stale" | grep -qv 'reused=1'
-    then
-        ok "stale dylib + fresh stub list relinks (not reused)"
-    else
-        die_test "stale stub list relink exit $relink_stale_st: $relink_stale"
-    fi
-
-    # Changed object sha → reason=inputs obj:… old->new
-    echo 'int cfobjc_probe=2;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$HW/cfobjc/obj/CFString.o" -x c -
-    set +e
-    chg=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
-    chg_st=$?
-    set -e
-    if [ "$chg_st" -eq 2 ] \
-        && echo "$chg" | grep -q 'reason=inputs obj:cfobjc/CFString.o ' \
-        && echo "$chg" | grep -q 'CANNOT_CFTEST_INPUTS'
-    then
-        ok "changed object sha is reason=inputs obj:cfobjc/CFString.o (verify-only)"
-    else
-        die_test "changed object verify-only exit $chg_st: $chg"
-    fi
-    set +e
-    chg_link=$(run_h 2>&1)
-    chg_link_st=$?
-    set -e
-    if [ "$chg_link_st" -eq 0 ] && echo "$chg_link" | grep -q 'reason=inputs obj:cfobjc/CFString.o ' \
-        && echo "$chg_link" | grep -q 'libCFTest relinked'
-    then
-        ok "changed object sha relinks with reason=inputs obj:cfobjc/CFString.o"
-    else
-        die_test "changed object relink exit $chg_link_st: $chg_link"
-    fi
-    rm -rf "$HW"
+    die_test "first harness run exit $first_st: $first"
 fi
+grep -q '^obj:cfobjc/CFString.o=' "$HW/lib/libCFTest.dylib.inputs" \
+    && grep -q '^obj:nscfobj/NSCFConstantString.o=' "$HW/lib/libCFTest.dylib.inputs" \
+    && grep -q '^obj:cfstubs.o=' "$HW/lib/libCFTest.dylib.inputs" \
+    && grep -q '^stub-func-active=' "$HW/lib/libCFTest.dylib.inputs" \
+    && grep -q '^tbd:libSystem=' "$HW/lib/libCFTest.dylib.inputs" \
+    && grep -q '^tbd:libobjc=' "$HW/lib/libCFTest.dylib.inputs" \
+    && grep -q '^argv=' "$HW/lib/libCFTest.dylib.inputs" \
+    && ok "stamp records objects, stub-set, tbds, argv" \
+    || die_test "stamp contents: $(tr '\n' ' ' < "$HW/lib/libCFTest.dylib.inputs")"
+
+old_sha=$(sha256sum "$HW/lib/libCFTest.dylib" | awk '{print $1}')
+set +e
+second=$(run_h 2>&1)
+second_st=$?
+set -e
+new_sha=$(sha256sum "$HW/lib/libCFTest.dylib" | awk '{print $1}')
+if [ "$second_st" -eq 0 ] && echo "$second" | grep -q 'libCFTest reused=1 stamp=' \
+    && [ "$old_sha" = "$new_sha" ]
+then
+    ok "matching stamp is reused=1 (dylib sha unchanged)"
+else
+    die_test "second harness run exit $second_st sha $old_sha->$new_sha: $second"
+fi
+
+set +e
+v_ok=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
+v_ok_st=$?
+set -e
+if [ "$v_ok_st" -eq 0 ] && echo "$v_ok" | grep -q 'libCFTest reused=1 stamp='; then
+    ok "verify-only matching stamp is reused=1"
+else
+    die_test "verify-only match exit $v_ok_st: $v_ok"
+fi
+
+# Regenerated stub list, old dylib: CANNOT in verify-only.
+touch -d '2020-01-01 00:00:00 UTC' "$HW/lib/libCFTest.dylib"
+touch "$HW/stub-func-active.txt"
+set +e
+stale=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
+stale_st=$?
+set -e
+if [ "$stale_st" -eq 2 ] \
+    && echo "$stale" | grep -q '^CANNOT_CFTEST_STALE ' \
+    && echo "$stale" | grep -q 'stub-func-active.txt=' \
+    && echo "$stale" | grep -q 'libCFTest.dylib=' \
+    && echo "$stale" | grep -qv 'reused=1'
+then
+    ok "stale dylib + fresh stub list is CANNOT_CFTEST_STALE (verify-only, not satisfied)"
+else
+    die_test "stale stub list verify-only exit $stale_st: $stale"
+fi
+
+# Same stale pair without verify-only must relink, not reuse.
+set +e
+relink_stale=$(run_h 2>&1)
+relink_stale_st=$?
+set -e
+if [ "$relink_stale_st" -eq 0 ] && echo "$relink_stale" | grep -q 'libCFTest relinked' \
+    && echo "$relink_stale" | grep -qv 'reused=1'
+then
+    ok "stale dylib + fresh stub list relinks (not reused)"
+else
+    die_test "stale stub list relink exit $relink_stale_st: $relink_stale"
+fi
+
+# Changed object sha → reason=inputs obj:… old->new
+echo 'int cfobjc_probe=2;' | clang-18 -target "$TRIPLE" -c -o "$HW/cfobjc/obj/CFString.o" -x c -
+set +e
+chg=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
+chg_st=$?
+set -e
+if [ "$chg_st" -eq 2 ] \
+    && echo "$chg" | grep -q 'reason=inputs obj:cfobjc/CFString.o ' \
+    && echo "$chg" | grep -q 'CANNOT_CFTEST_INPUTS'
+then
+    ok "changed object sha is reason=inputs obj:cfobjc/CFString.o (verify-only)"
+else
+    die_test "changed object verify-only exit $chg_st: $chg"
+fi
+set +e
+chg_link=$(run_h 2>&1)
+chg_link_st=$?
+set -e
+if [ "$chg_link_st" -eq 0 ] && echo "$chg_link" | grep -q 'reason=inputs obj:cfobjc/CFString.o ' \
+    && echo "$chg_link" | grep -q 'libCFTest relinked'
+then
+    ok "changed object sha relinks with reason=inputs obj:cfobjc/CFString.o"
+else
+    die_test "changed object relink exit $chg_link_st: $chg_link"
+fi
+rm -rf "$HW"
 
 echo "test_build_cftest_harness: pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/foundation-macho/scripts/test_build_cftest_harness.sh
+++ b/foundation-macho/scripts/test_build_cftest_harness.sh
@@ -34,6 +34,11 @@ fi
 expect_grep 'check_cftest_stubs.sh' "$H" "harness invokes the stub pin"
 expect_grep 'CANNOT_CFTEST_STUBS' "$H" "harness names CANNOT_CFTEST_STUBS"
 expect_grep 'cftest-stub-func-active.txt' "$H" "harness names the committed func pin"
+expect_grep 'libCFTest.dylib.inputs' "$H" "harness writes an input stamp next to the dylib"
+expect_grep 'reused=1 stamp=' "$H" "matching stamp prints reused=1 stamp="
+expect_grep 'reason=inputs' "$H" "stamp mismatch prints reason=inputs"
+expect_grep 'CANNOT_CFTEST_STALE' "$H" "stub list newer than dylib is CANNOT_CFTEST_STALE"
+expect_grep 'CFTEST_VERIFY_ONLY' "$H" "verify-only refuses instead of relinking"
 
 echo "== matching fixture is OK"
 fix=$(mktemp -d /tmp/cftest-stubs-ok.XXXXXX)
@@ -71,6 +76,138 @@ else
     die_test "differing fixture got exit $bad_st: $bad_out"
 fi
 rm -rf "$fix"
+
+echo "== input stamp: matching reused=1, stale stub list CANNOT, object sha relink"
+SYS=${SYS:-$(cd "$FM/.." && pwd)/scratch/sysroot_fe4-x86_64}
+if [ ! -d "$SYS/usr/include" ]; then
+    die_test "x86 sysroot missing; cannot run harness stamp fixtures"
+else
+    HW=$(mktemp -d /tmp/cftest-stamp.XXXXXX)
+    mkdir -p "$HW/cfobjc/obj" "$HW/nscfobj" "$HW/lib" "$HW/sdk/usr/lib" "$HW/sdk/usr/include"
+    # Use the real x86 sysroot for -isysroot / tbds; keep W's sdk/ for layout.
+    echo 'int cfobjc_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$HW/cfobjc/obj/CFString.o" -x c -
+    echo 'int nscf_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$HW/nscfobj/NSCFConstantString.o" -x c -
+    : > "$HW/expect-func.txt"
+    : > "$HW/expect-data.txt"
+
+    run_h() {
+        W="$HW" SDK="$SYS" LIB="$HW/lib" \
+            CFOBJC_OBJ="$HW/cfobjc/obj" NSCF_OBJ="$HW/nscfobj" \
+            R="$FM" PROBE_SRC="$FM/tests/probe_sysctl.c" \
+            CFTEST_EXPECT_FUNC="$HW/expect-func.txt" \
+            CFTEST_EXPECT_DATA="$HW/expect-data.txt" \
+            TRIPLE=x86_64-apple-macos13.0 \
+            LLD_BIN=/usr/lib/llvm-18/bin \
+            "$@" bash "$H"
+    }
+
+    set +e
+    first=$(run_h 2>&1)
+    first_st=$?
+    set -e
+    if [ "$first_st" -eq 0 ] && echo "$first" | grep -q 'libCFTest relinked' \
+        && [ -f "$HW/lib/libCFTest.dylib" ] \
+        && [ -f "$HW/lib/libCFTest.dylib.inputs" ]
+    then
+        ok "first harness run relinks and writes libCFTest.dylib.inputs"
+    else
+        die_test "first harness run exit $first_st: $first"
+    fi
+    grep -q '^obj:cfobjc/CFString.o=' "$HW/lib/libCFTest.dylib.inputs" \
+        && grep -q '^obj:nscfobj/NSCFConstantString.o=' "$HW/lib/libCFTest.dylib.inputs" \
+        && grep -q '^obj:cfstubs.o=' "$HW/lib/libCFTest.dylib.inputs" \
+        && grep -q '^stub-func-active=' "$HW/lib/libCFTest.dylib.inputs" \
+        && grep -q '^tbd:libSystem=' "$HW/lib/libCFTest.dylib.inputs" \
+        && grep -q '^tbd:libobjc=' "$HW/lib/libCFTest.dylib.inputs" \
+        && grep -q '^argv=' "$HW/lib/libCFTest.dylib.inputs" \
+        && ok "stamp records objects, stub-set, tbds, argv" \
+        || die_test "stamp contents: $(tr '\n' ' ' < "$HW/lib/libCFTest.dylib.inputs")"
+
+    old_sha=$(sha256sum "$HW/lib/libCFTest.dylib" | awk '{print $1}')
+    set +e
+    second=$(run_h 2>&1)
+    second_st=$?
+    set -e
+    new_sha=$(sha256sum "$HW/lib/libCFTest.dylib" | awk '{print $1}')
+    if [ "$second_st" -eq 0 ] && echo "$second" | grep -q 'libCFTest reused=1 stamp=' \
+        && [ "$old_sha" = "$new_sha" ]
+    then
+        ok "matching stamp is reused=1 (dylib sha unchanged)"
+    else
+        die_test "second harness run exit $second_st sha $old_sha->$new_sha: $second"
+    fi
+
+    set +e
+    v_ok=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
+    v_ok_st=$?
+    set -e
+    if [ "$v_ok_st" -eq 0 ] && echo "$v_ok" | grep -q 'libCFTest reused=1 stamp='; then
+        ok "verify-only matching stamp is reused=1"
+    else
+        die_test "verify-only match exit $v_ok_st: $v_ok"
+    fi
+
+    # Regenerated stub list, old dylib: CANNOT in verify-only.
+    touch -d '2020-01-01 00:00:00 UTC' "$HW/lib/libCFTest.dylib"
+    touch "$HW/stub-func-active.txt"
+    set +e
+    stale=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
+    stale_st=$?
+    set -e
+    if [ "$stale_st" -eq 2 ] \
+        && echo "$stale" | grep -q '^CANNOT_CFTEST_STALE ' \
+        && echo "$stale" | grep -q 'stub-func-active.txt=' \
+        && echo "$stale" | grep -q 'libCFTest.dylib=' \
+        && echo "$stale" | grep -qv 'reused=1'
+    then
+        ok "stale dylib + fresh stub list is CANNOT_CFTEST_STALE (verify-only, not satisfied)"
+    else
+        die_test "stale stub list verify-only exit $stale_st: $stale"
+    fi
+
+    # Same stale pair without verify-only must relink, not reuse.
+    set +e
+    relink_stale=$(run_h 2>&1)
+    relink_stale_st=$?
+    set -e
+    if [ "$relink_stale_st" -eq 0 ] && echo "$relink_stale" | grep -q 'libCFTest relinked' \
+        && echo "$relink_stale" | grep -qv 'reused=1'
+    then
+        ok "stale dylib + fresh stub list relinks (not reused)"
+    else
+        die_test "stale stub list relink exit $relink_stale_st: $relink_stale"
+    fi
+
+    # Changed object sha → reason=inputs obj:… old->new
+    echo 'int cfobjc_probe=2;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$HW/cfobjc/obj/CFString.o" -x c -
+    set +e
+    chg=$(CFTEST_VERIFY_ONLY=1 run_h 2>&1)
+    chg_st=$?
+    set -e
+    if [ "$chg_st" -eq 2 ] \
+        && echo "$chg" | grep -q 'reason=inputs obj:cfobjc/CFString.o ' \
+        && echo "$chg" | grep -q 'CANNOT_CFTEST_INPUTS'
+    then
+        ok "changed object sha is reason=inputs obj:cfobjc/CFString.o (verify-only)"
+    else
+        die_test "changed object verify-only exit $chg_st: $chg"
+    fi
+    set +e
+    chg_link=$(run_h 2>&1)
+    chg_link_st=$?
+    set -e
+    if [ "$chg_link_st" -eq 0 ] && echo "$chg_link" | grep -q 'reason=inputs obj:cfobjc/CFString.o ' \
+        && echo "$chg_link" | grep -q 'libCFTest relinked'
+    then
+        ok "changed object sha relinks with reason=inputs obj:cfobjc/CFString.o"
+    else
+        die_test "changed object relink exit $chg_link_st: $chg_link"
+    fi
+    rm -rf "$HW"
+fi
 
 echo "test_build_cftest_harness: pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/foundation-macho/scripts/test_link_ud_guest.sh
+++ b/foundation-macho/scripts/test_link_ud_guest.sh
@@ -133,6 +133,39 @@ if [ "$st" -eq 0 ] && [ -f "$W/bin/ud_guest" ] \
 else
     die_test "dummy link exit $st (want 0 + X86_64 Mach-O). log=$(tr '\n' ' ' < "$log")"
 fi
+if [ -f "$W/bin/ud_guest.inputs" ] && grep -q '^cftest=' "$W/bin/ud_guest.inputs" \
+    && grep -q '^argv=' "$W/bin/ud_guest.inputs" \
+    && grep -q '^obj:fe/runner.o=' "$W/bin/ud_guest.inputs"
+then
+    ok "link writes bin/ud_guest.inputs (objects, libCFTest sha, argv)"
+else
+    die_test "missing ud_guest.inputs after link"
+fi
+
+set +e
+W="$W" SDK="$SDK" OUT="$W/bin/ud_guest" LLD_BIN=/usr/lib/llvm-18/bin \
+    bash "$S" >"$log" 2>&1
+st2=$?
+set -e
+if [ "$st2" -eq 0 ] && grep -q 'ud_guest reused=1 stamp=' "$log"; then
+    ok "matching ud_guest stamp is reused=1"
+else
+    die_test "second link exit $st2 (want reused=1). log=$(tr '\n' ' ' < "$log")"
+fi
+
+echo 'int main(void){return 1;}' | clang-18 -target "$TRIPLE" -c -o "$W/fe/runner.o" -x c -
+set +e
+W="$W" SDK="$SDK" OUT="$W/bin/ud_guest" LLD_BIN=/usr/lib/llvm-18/bin \
+    bash "$S" >"$log" 2>&1
+st3=$?
+set -e
+if [ "$st3" -eq 0 ] && grep -q 'reason=inputs obj:fe/runner.o ' "$log" \
+    && grep -q 'ud_guest relink' "$log"
+then
+    ok "changed runner.o relinks with reason=inputs obj:fe/runner.o"
+else
+    die_test "changed-object link exit $st3. log=$(tr '\n' ' ' < "$log")"
+fi
 
 echo "test_link_ud_guest: pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -262,17 +262,29 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    fetch/compile is `CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib`. The
    harness then derives the stub set and compares it to
    `docs/cf-census/cftest-stub-func-active.txt` / `cftest-stub-data.txt`
-   (218 func + 2 data, `libCFTest relinked (220 stubbed)`). A mismatch is
+   (214 func + 2 data, `libCFTest relinked (216 stubbed)`). A mismatch is
    its own line `ENV_PREPARE cftest-stubs CANNOT_CFTEST_STUBS
    reason=count=N first=a,b,c,d,e …` and ud-guest does **not** link.
+   Reuse of `lib/libCFTest.dylib` is keyed on `lib/libCFTest.dylib.inputs`
+   written at link time (sha256 of every linked object, the stub-set files,
+   the libSystem/libobjc tbds, and the linker argv) — never on a present
+   dylib whose sibling stub text files match the pin, and never on
+   existence. Matching stamp prints `reused=1 stamp=<sha>`. Mismatch
+   relinks with `reason=inputs <key> old->new`. If `stub-func-active.txt`
+   is newer than the dylib, that is `CANNOT_CFTEST_STALE` naming both
+   mtimes, never `satisfied` (`CFTEST_VERIFY_ONLY=1` refuses instead of
+   relinking). `bin/ud_guest.inputs` is the same rule for the guest
+   (objects + libCFTest sha + argv).
    Will not invent a stub dylib. `UD_CFTEST_DYLIB=` still stages a provided
-   x86 dylib when no leftover stub lists are next to the work tree.
+   x86 dylib as an explicit override.
    After a successful link, before `run_ud_guest.sh`, phase2 copies
    `scratch/ud-guest-x86_64/lib/libCFTest.dylib` into
    `scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib` (the arm64
    analogue is `build_cftest_harness.sh` copying into `$W/root` when that
    directory exists; `full/scripts/build_full.sh` does **not** stage
-   libCFTest). Prints `ENV_PREPARE libCFTest-run-root … path=… sha256=…`.
+   libCFTest). The copy decision compares source sha256 to destination
+   sha256 and recopies on any difference. Prints
+   `ENV_PREPARE libCFTest-run-root … path=… sha256=…`.
    Never copies onto the CoreFoundation.framework slot (byte-identical
    copy there is the duplicate-image refusal in `run_ud_guest.sh`).
    Then `ud-guest-dispatch` reuses the Reminder/Focus Linux Dispatch host

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -945,18 +945,52 @@ ud_report=$(phase2_try_ud_guest \
         UD_GUEST_BIN=${UD_GUEST_BIN%% *}
         UD_GUEST_W=$W/scratch/ud-guest-x86_64
         export UD_GUEST_BIN UD_GUEST_W
-        note ud-guest-x86 cold-built "$ud_report"
-        UD_GUEST_ITEM_OK=1
         echo "  $ud_report"
-        if [ -f "$UD_GUEST_W/stub-func-active.txt" ]; then
-            stub_n=$(grep -c . "$UD_GUEST_W/stub-func-active.txt" || true)
-            note cftest-stubs satisfied "count=$stub_n"
+        if phase2_cftest_stub_list_stale "$UD_GUEST_W"; then
+            stale_line=$(phase2_cftest_stub_stale_cannot "$UD_GUEST_W")
+            cannot cftest-stubs CFTEST_STALE "${stale_line#CANNOT_CFTEST_STALE }"
+            cannot ud-guest-x86 UD_GUEST_CFTEST_STALE \
+                "stub-func-active.txt is newer than lib/libCFTest.dylib; will not treat this as satisfied. See ENV_PREPARE cftest-stubs."
+        else
+            cftest_log=$UD_GUEST_W/lib/build_cftest_harness.log
+            link_log=$UD_GUEST_W/link_ud_guest.log
+            reuse_note=
+            if [ -f "$cftest_log" ] && grep -q 'libCFTest reused=1 stamp=' "$cftest_log"; then
+                reuse_note=$(grep 'libCFTest reused=1 stamp=' "$cftest_log" | tail -1)
+                echo "  $reuse_note"
+            elif [ -f "$cftest_log" ] && grep -q 'libCFTest relinked ' "$cftest_log"; then
+                echo "  $(grep 'libCFTest relinked ' "$cftest_log" | tail -1)"
+            fi
+            if [ -f "$link_log" ] && grep -q 'ud_guest reused=1 stamp=' "$link_log"; then
+                note ud-guest-x86 satisfied "reused=1 $ud_report"
+            else
+                note ud-guest-x86 cold-built "$ud_report"
+            fi
+            UD_GUEST_ITEM_OK=1
+            if [ -f "$UD_GUEST_W/stub-func-active.txt" ]; then
+                stub_n=$(grep -c . "$UD_GUEST_W/stub-func-active.txt" || true)
+                if [ -n "$reuse_note" ]; then
+                    note cftest-stubs satisfied "count=$stub_n $reuse_note"
+                else
+                    note cftest-stubs satisfied "count=$stub_n"
+                fi
+            fi
         fi
         ;;
     CANNOT_CFTEST_STUBS*)
         cannot cftest-stubs CFTEST_STUBS "${ud_report#CANNOT_CFTEST_STUBS }"
         cannot ud-guest-x86 UD_GUEST_CFTEST_STUBS \
             "libCFTest stub set refused; see ENV_PREPARE cftest-stubs. Will not link ud_guest against it."
+        ;;
+    CANNOT_CFTEST_STALE*)
+        cannot cftest-stubs CFTEST_STALE "${ud_report#CANNOT_CFTEST_STALE }"
+        cannot ud-guest-x86 UD_GUEST_CFTEST_STALE \
+            "stub-func-active.txt is newer than lib/libCFTest.dylib; see ENV_PREPARE cftest-stubs. Will not treat this as satisfied."
+        ;;
+    CANNOT_CFTEST_INPUTS*)
+        cannot cftest-stubs CFTEST_INPUTS "${ud_report#CANNOT_CFTEST_INPUTS }"
+        cannot ud-guest-x86 UD_GUEST_CFTEST_INPUTS \
+            "libCFTest input stamp mismatch; see ENV_PREPARE cftest-stubs. Will not reuse a dylib whose objects/stub-set/tbds/argv drifted."
         ;;
     CANNOT_UD_GUEST_*)
         ud_marker=${ud_report#CANNOT_UD_GUEST_}

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -1585,6 +1585,23 @@ expect_grep 'refusing unsuffixed/arm64 ud-guest work tree' "$UDINC" \
 expect_grep 'export UD_GUEST_BIN' "$PHASE2" "successful link exports UD_GUEST_BIN for rung a"
 expect_grep 'phase2_stage_cftest_into_run_root' "$UDINC" \
     "libCFTest is staged into the run root after link"
+expect_grep 'src_sha' "$UDINC" "run-root stager compares source sha to dest sha"
+expect_grep 'libCFTest.dylib.inputs' "$UDINC" \
+    "ud-guest names the libCFTest input stamp"
+expect_grep 'ud_guest.inputs' "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \
+    "link_ud_guest writes bin/ud_guest.inputs"
+expect_grep 'reused=1 stamp=' "$ROOT/foundation-macho/scripts/build_cftest_harness.sh" \
+    "harness prints reused=1 stamp="
+expect_grep 'reason=inputs' "$ROOT/foundation-macho/scripts/build_cftest_harness.sh" \
+    "harness prints reason=inputs on stamp mismatch"
+expect_grep 'CANNOT_CFTEST_STALE' "$UDINC" \
+    "stub list newer than dylib is CANNOT_CFTEST_STALE"
+expect_grep 'CANNOT_CFTEST_STALE' "$PHASE2" \
+    "phase2 maps CANNOT_CFTEST_STALE to cftest-stubs"
+expect_grep 'phase2_cftest_stub_list_stale' "$PHASE2" \
+    "cftest-stubs satisfied requires the dylib not older than the stub list"
+expect_grep 'never on a present' "$ROOT/scripts/x86/PHASE2.md" \
+    "PHASE2.md documents stamp reuse, not sibling stub files"
 expect_grep 'phase2_stage_cftest_into_run_root' "$PHASE2" \
     "phase2 stages libCFTest after ud-guest link, before rung a"
 expect_grep 'libCFTest-run-root' "$PHASE2" "ENV_PREPARE item names libCFTest-run-root"
@@ -1874,6 +1891,29 @@ if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
             ;;
         *) die_test "identical re-stage got: '$again'" ;;
     esac
+    echo 'int ud_cftest=2;' | clang-18 -target x86_64-apple-macos15.0 \
+        -isysroot "$SYS" -c -o "$UDWORK/cftest2.o" -x c -
+    clang-18 -target x86_64-apple-macos15.0 -isysroot "$SYS" \
+        -fuse-ld=lld -B /usr/lib/llvm-18/bin -nostdlib -dynamiclib \
+        -install_name /usr/lib/libCFTest.dylib \
+        "$UDWORK/cftest2.o" -o "$UDWORK/libCFTest2.dylib" 2>/dev/null \
+        || clang-18 -target x86_64-apple-macos15.0 -isysroot "$SYS" \
+            -fuse-ld=lld -B /usr/lib/llvm-18/bin -dynamiclib \
+            -install_name /usr/lib/libCFTest.dylib \
+            "$UDWORK/cftest2.o" -o "$UDWORK/libCFTest2.dylib"
+    src2=$(sha256sum "$UDWORK/libCFTest2.dylib" | awk '{print $1}')
+    dest1=$(sha256sum "$CFROOT/darwin/usr/lib/libCFTest.dylib" | awk '{print $1}')
+    if [ "$src2" != "$dest1" ]; then
+        changed=$(phase2_stage_cftest_into_run_root "$UDWORK/libCFTest2.dylib" "$CFROOT" || true)
+        case "$changed" in
+            status=cold-built\ path=*sha256=$src2)
+                ok "libCFTest re-stage copies when source sha differs from dest sha"
+                ;;
+            *) die_test "different-sha re-stage got: '$changed' want sha256=$src2" ;;
+        esac
+    else
+        die_test "could not emit a different-sha libCFTest fixture"
+    fi
     mkdir -p "$CFROOT/darwin/System/Library/Frameworks/CoreFoundation.framework"
     cp -f "$UDWORK/libCFTest.dylib" \
         "$CFROOT/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
@@ -1886,6 +1926,93 @@ if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
     esac
     rm -rf "$CFROOT"
     unset UD_CFTEST_DYLIB
+
+    echo "== libCFTest reuse is stamp-keyed, not sibling stub files"
+    mkdir -p "$wt/cfobjc/obj" "$wt/nscfobj" "$wt/lib"
+    echo 'int cfobjc_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$wt/cfobjc/obj/CFString.o" -x c -
+    echo 'int nscf_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$wt/nscfobj/NSCFConstantString.o" -x c -
+    cp "$ROOT/foundation-macho/docs/cf-census/cftest-stub-func-active.txt" \
+        "$wt/stub-func-active.txt"
+    cp "$ROOT/foundation-macho/docs/cf-census/cftest-stub-data.txt" \
+        "$wt/stub-data.txt"
+    rm -f "$wt/lib/libCFTest.dylib.inputs"
+    # dest from UD_CFTEST_DYLIB is present; stub files match the pin.
+    pin_sha=$(sha256sum "$wt/lib/libCFTest.dylib" | awk '{print $1}')
+    pin_report=$(phase2_ud_guest_ensure_cftest "$wt" "$ROOT" "$SYS" || true)
+    pin_sha_after=$(sha256sum "$wt/lib/libCFTest.dylib" | awk '{print $1}')
+    case "$pin_report" in
+        ''|status=satisfied*)
+            die_test "pin-matching stub files reused the dylib without an input stamp: '$pin_report'"
+            ;;
+        CANNOT_*)
+            if [ "$pin_sha" = "$pin_sha_after" ]; then
+                ok "pin-matching stub files without .inputs do not reuse (got $pin_report)"
+            else
+                die_test "pin-without-stamp mutated dest sha $pin_sha->$pin_sha_after report=$pin_report"
+            fi
+            ;;
+        *)
+            die_test "pin-without-stamp got: '$pin_report'"
+            ;;
+    esac
+
+    mkdir -p "$wt/stub-mtime/lib"
+    echo dylib > "$wt/stub-mtime/lib/libCFTest.dylib"
+    echo stubs > "$wt/stub-mtime/stub-func-active.txt"
+    touch -d '2020-01-01 00:00:00 UTC' "$wt/stub-mtime/lib/libCFTest.dylib"
+    touch "$wt/stub-mtime/stub-func-active.txt"
+    if phase2_cftest_stub_list_stale "$wt/stub-mtime"; then
+        stale_line=$(phase2_cftest_stub_stale_cannot "$wt/stub-mtime")
+        case "$stale_line" in
+            CANNOT_CFTEST_STALE\ file=libCFTest.dylib\ stub-func-active.txt=*\ libCFTest.dylib=*)
+                ok "stub list newer than dylib is CANNOT_CFTEST_STALE naming both mtimes"
+                ;;
+            *) die_test "stale-cannot line: $stale_line" ;;
+        esac
+    else
+        die_test "stub_list_stale did not detect newer stub-func-active.txt"
+    fi
+
+    echo "== ensure_cftest matching stamp is reused=1"
+    STAMPW=$(mktemp -d /tmp/phase2-cftest-stamp.XXXXXX)
+    mkdir -p "$STAMPW/cfobjc/obj" "$STAMPW/nscfobj" "$STAMPW/lib"
+    echo 'int cfobjc_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$STAMPW/cfobjc/obj/CFString.o" -x c -
+    echo 'int nscf_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
+        -isysroot "$SYS" -c -o "$STAMPW/nscfobj/NSCFConstantString.o" -x c -
+    : > "$STAMPW/expect-func.txt"
+    : > "$STAMPW/expect-data.txt"
+    set +e
+    h1=$(W="$STAMPW" SDK="$SYS" LIB="$STAMPW/lib" \
+        CFOBJC_OBJ="$STAMPW/cfobjc/obj" NSCF_OBJ="$STAMPW/nscfobj" \
+        R="$ROOT/foundation-macho" \
+        PROBE_SRC="$ROOT/foundation-macho/tests/probe_sysctl.c" \
+        CFTEST_EXPECT_FUNC="$STAMPW/expect-func.txt" \
+        CFTEST_EXPECT_DATA="$STAMPW/expect-data.txt" \
+        TRIPLE=x86_64-apple-macos13.0 LLD_BIN=/usr/lib/llvm-18/bin \
+        bash "$ROOT/foundation-macho/scripts/build_cftest_harness.sh" 2>&1)
+    h1_st=$?
+    set -e
+    if [ "$h1_st" -ne 0 ] || [ ! -f "$STAMPW/lib/libCFTest.dylib.inputs" ]; then
+        die_test "stamp fixture harness exit $h1_st: $h1"
+    else
+        stamp_sha=$(sha256sum "$STAMPW/lib/libCFTest.dylib" | awk '{print $1}')
+        reused=$(phase2_ud_guest_ensure_cftest "$STAMPW" "$ROOT" "$SYS" || true)
+        stamp_sha2=$(sha256sum "$STAMPW/lib/libCFTest.dylib" | awk '{print $1}')
+        case "$reused" in
+            status=satisfied*\ reused=1\ stamp=*)
+                if [ "$stamp_sha" = "$stamp_sha2" ]; then
+                    ok "ensure_cftest matching stamp is reused=1 (sha unchanged)"
+                else
+                    die_test "reused=1 but sha changed $stamp_sha->$stamp_sha2"
+                fi
+                ;;
+            *) die_test "ensure_cftest stamp reuse got: '$reused'" ;;
+        esac
+    fi
+    rm -rf "$STAMPW"
 else
     die_test "could not emit an x86 libCFTest.dylib fixture"
 fi

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -1714,6 +1714,43 @@ expect_not_grep 'Operator: stage CF+FE objects, link_ud_guest.sh, then re-run' \
 echo "== ud-guest-x86 refusal + staging resolution"
 UDWORK=$(mktemp -d /tmp/phase2-ud-guest.XXXXXX)
 SYS=${SYS:-$ROOT/scratch/sysroot_fe4-x86_64}
+if [ ! -d "$SYS/usr/include" ]; then
+    SYS=$UDWORK/fake-x86-sdk
+    mkdir -p "$SYS/usr/include" "$SYS/usr/lib"
+    emit_tbd() {
+        local dest=$1 install=$2
+        cat >"$dest" <<EOF
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos ]
+install-name:    '$install'
+current-version: 1
+compatibility-version: 1
+exports:
+  - targets:   [ x86_64-macos ]
+    symbols:   [ '_dummy_tbd' ]
+...
+EOF
+    }
+    emit_tbd "$SYS/usr/lib/libSystem.B.tbd" "/usr/lib/libSystem.B.dylib"
+    ln -sfn libSystem.B.tbd "$SYS/usr/lib/libSystem.tbd"
+    emit_tbd "$SYS/usr/lib/libobjc.A.tbd" "/usr/lib/libobjc.A.dylib"
+    ln -sfn libobjc.A.tbd "$SYS/usr/lib/libobjc.tbd"
+    mkdir -p "$SYS/usr/include/objc"
+    cat >"$SYS/usr/include/objc/NSObject.h" <<'EOF'
+#ifndef _TEST_NSOBJECT_H_
+#define _TEST_NSOBJECT_H_
+typedef struct objc_class *Class;
+typedef struct objc_object { Class isa; } *id;
+typedef struct objc_selector *SEL;
+@interface NSObject
++ (void)initialize;
+- (void)doesNotRecognizeSelector:(SEL)s;
+@end
+#endif
+EOF
+    echo "NOTE: scratch/sysroot_fe4-x86_64 absent; dummy Mach-O fixtures use $SYS"
+fi
 # shellcheck source=common.inc
 . "$COMMON"
 
@@ -1930,9 +1967,9 @@ if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
     echo "== libCFTest reuse is stamp-keyed, not sibling stub files"
     mkdir -p "$wt/cfobjc/obj" "$wt/nscfobj" "$wt/lib"
     echo 'int cfobjc_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$wt/cfobjc/obj/CFString.o" -x c -
+        -c -o "$wt/cfobjc/obj/CFString.o" -x c -
     echo 'int nscf_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$wt/nscfobj/NSCFConstantString.o" -x c -
+        -c -o "$wt/nscfobj/NSCFConstantString.o" -x c -
     cp "$ROOT/foundation-macho/docs/cf-census/cftest-stub-func-active.txt" \
         "$wt/stub-func-active.txt"
     cp "$ROOT/foundation-macho/docs/cf-census/cftest-stub-data.txt" \
@@ -1979,9 +2016,9 @@ if phase2_is_x86_macho "$UDWORK/libCFTest.dylib"; then
     STAMPW=$(mktemp -d /tmp/phase2-cftest-stamp.XXXXXX)
     mkdir -p "$STAMPW/cfobjc/obj" "$STAMPW/nscfobj" "$STAMPW/lib"
     echo 'int cfobjc_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$STAMPW/cfobjc/obj/CFString.o" -x c -
+        -c -o "$STAMPW/cfobjc/obj/CFString.o" -x c -
     echo 'int nscf_probe=1;' | clang-18 -target x86_64-apple-macos13.0 \
-        -isysroot "$SYS" -c -o "$STAMPW/nscfobj/NSCFConstantString.o" -x c -
+        -c -o "$STAMPW/nscfobj/NSCFConstantString.o" -x c -
     : > "$STAMPW/expect-func.txt"
     : > "$STAMPW/expect-data.txt"
     set +e

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -11,6 +11,12 @@
 #     foundation-macho/docs/cf-census/cftest-stub-{func-active,data}.txt;
 #     a mismatch is CANNOT_CFTEST_STUBS (own ENV_PREPARE line) and does
 #     not proceed to link_ud_guest.sh.
+#   libCFTest reuse is keyed on lib/libCFTest.dylib.inputs (object shas +
+#     stub-set files + libSystem/libobjc tbds + linker argv), never on a
+#     present dylib whose sibling stub text files match the pin. A
+#     stub-func-active.txt newer than the dylib is CANNOT_CFTEST_STALE
+#     naming both mtimes, never satisfied. ud_guest reuse is
+#     bin/ud_guest.inputs (objects + libCFTest sha + argv).
 #   after link, before run: stage that dylib into
 #     scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib
 #     (arm64 analogue: build_cftest_harness.sh -> $W/root; not build_full.sh)
@@ -617,39 +623,102 @@ phase2_ud_guest_format_stub_cannot() {
         "${count:-0}" "$first" "$extra" "$miss"
 }
 
+phase2_cftest_mtime_iso() {
+    if [ -e "$1" ]; then
+        date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
+    else
+        printf 'ABSENT\n'
+    fi
+}
+
+# stub-func-active.txt newer than lib/libCFTest.dylib means the list was
+# regenerated without a relink. Never satisfied.
+phase2_cftest_stub_list_stale() {
+    local ud_w=$1
+    local dylib=$ud_w/lib/libCFTest.dylib
+    local stubs=$ud_w/stub-func-active.txt
+    [ -f "$dylib" ] && [ -f "$stubs" ] && [ "$stubs" -nt "$dylib" ]
+}
+
+phase2_cftest_stub_stale_cannot() {
+    local ud_w=$1
+    printf 'CANNOT_CFTEST_STALE file=libCFTest.dylib stub-func-active.txt=%s libCFTest.dylib=%s\n' \
+        "$(phase2_cftest_mtime_iso "$ud_w/stub-func-active.txt")" \
+        "$(phase2_cftest_mtime_iso "$ud_w/lib/libCFTest.dylib")"
+}
+
+phase2_ud_guest_run_cftest_harness() {
+    local ud_w=$1 repo=$2 sys=$3 cf=${4:-}
+    local dest=$ud_w/lib/libCFTest.dylib
+    local linker=$repo/foundation-macho/scripts/build_cftest_harness.sh
+    local log=$ud_w/lib/build_cftest_harness.log
+    local st
+    mkdir -p "$ud_w/lib" "$ud_w/nscfobj"
+    set +e
+    W="$ud_w" \
+        SDK="$sys" \
+        CF="${cf:-$ud_w/cfobjc/src}" \
+        CF_FALLBACK="${cf:-$ud_w/cf}" \
+        LIB="$ud_w/lib" \
+        CFOBJC_OBJ="$ud_w/cfobjc/obj" \
+        NSCF_OBJ="$ud_w/nscfobj" \
+        R="$repo/foundation-macho" \
+        PROBE_SRC="$repo/foundation-macho/tests/probe_sysctl.c" \
+        TRIPLE=x86_64-apple-macos13.0 \
+        LLD_BIN=/usr/lib/llvm-18/bin \
+        bash "$linker" >"$log" 2>&1
+    st=$?
+    set -e
+    if grep -q '^CANNOT_CFTEST_STUBS ' "$log"; then
+        phase2_ud_guest_format_stub_cannot "$(grep '^CANNOT_CFTEST_STUBS ' "$log" | tail -1)"
+        return 1
+    fi
+    if grep -q '^CANNOT_CFTEST_STALE ' "$log"; then
+        grep '^CANNOT_CFTEST_STALE ' "$log" | tail -1
+        return 1
+    fi
+    if grep -q '^CANNOT_CFTEST_INPUTS ' "$log"; then
+        grep '^CANNOT_CFTEST_INPUTS ' "$log" | tail -1
+        return 1
+    fi
+    if [ "$st" -ne 0 ] || [ ! -f "$dest" ] || ! phase2_is_x86_macho "$dest"; then
+        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+            "build_cftest_harness.sh exit $st (committed CF linker; objects from build_cfobjc.sh) log=$log. Will not invent a stub dylib."
+        return 1
+    fi
+    if phase2_cftest_stub_list_stale "$ud_w"; then
+        phase2_cftest_stub_stale_cannot "$ud_w"
+        return 1
+    fi
+    if grep -q 'libCFTest reused=1 stamp=' "$log"; then
+        printf 'status=satisfied %s\n' \
+            "$(grep 'libCFTest reused=1 stamp=' "$log" | tail -1)"
+    elif grep -q 'libCFTest relinked ' "$log"; then
+        printf 'status=cold-built %s\n' \
+            "$(grep 'libCFTest relinked ' "$log" | tail -1)"
+    fi
+}
+
 phase2_ud_guest_ensure_cftest() {
     local ud_w=$1 repo=$2
     local sys=${3:-$ud_w/fe/sysroot}
     local dest=$ud_w/lib/libCFTest.dylib
-    local found recipe linker cf icu log st checker stub_line
+    local found recipe linker cf icu log st
     mkdir -p "$ud_w/lib"
-    found=$(phase2_ud_guest_find_x86_dylib libCFTest.dylib \
-        "${UD_CFTEST_DYLIB:-}" \
-        "$dest" \
-        "$repo/scratch/ud-guest-x86_64/lib/libCFTest.dylib" \
-        || true)
-    checker=$repo/foundation-macho/scripts/check_cftest_stubs.sh
-    # Reuse a present dylib only when:
-    #   * stub pin files exist and match (the 80-object / 220-stub set), or
-    #   * no stub pin files exist (UD_CFTEST_DYLIB test dummy / override
-    #     without leftover stub lists).
-    # A leftover 143-name stub-func-active.txt must not count as satisfied.
-    if [ -n "$found" ]; then
-        if [ -f "$ud_w/stub-func-active.txt" ] && [ -f "$ud_w/stub-data.txt" ] \
-            && [ -f "$checker" ]
-        then
-            stub_line=$(bash "$checker" "$ud_w/stub-func-active.txt" "$ud_w/stub-data.txt" || true)
-            case "$stub_line" in
-                CFTEST_STUBS_OK*)
-                    [ "$found" = "$dest" ] || cp -a "$found" "$dest"
-                    return 0
-                    ;;
-            esac
-            # Mismatch: rebuild through the recipe. Do not reuse.
-        else
+    # Explicit override only. A present dest (or a copy from another scratch
+    # tree) is not reusable just because sibling stub text files match the
+    # pin — those files can be regenerated while the dylib stays the 143-stub
+    # build. UD_CFTEST_DYLIB is the test dummy / operator-provided Mach-O.
+    if [ -n "${UD_CFTEST_DYLIB:-}" ]; then
+        found=$(phase2_ud_guest_find_x86_dylib libCFTest.dylib \
+            "$UD_CFTEST_DYLIB" || true)
+        if [ -n "$found" ]; then
             [ "$found" = "$dest" ] || cp -a "$found" "$dest"
             return 0
         fi
+        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+            "UD_CFTEST_DYLIB=$UD_CFTEST_DYLIB is not an x86_64 Mach-O. Will not invent a stub dylib."
+        return 1
     fi
 
     recipe=$repo/foundation-macho/scripts/build_cfobjc.sh
@@ -663,6 +732,19 @@ phase2_ud_guest_ensure_cftest() {
         phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
             "no x86_64 Mach-O. missing committed CF linker $linker. Will not invent a stub dylib."
         return 1
+    fi
+
+    # Objects already on disk: the harness stamp decides reuse vs relink.
+    # Do not skip this just because dest + stub pin files exist.
+    if [ -d "$ud_w/cfobjc/obj" ] && [ -n "$(find "$ud_w/cfobjc/obj" -maxdepth 1 -name '*.o' -print -quit 2>/dev/null)" ]; then
+        if [ ! -d "$sys/usr/include" ]; then
+            phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
+                "no x86_64 Mach-O. Darwin sysroot missing at $sys (need usr/include). Committed recipe is foundation-macho/scripts/build_cfobjc.sh; committed CF linker is foundation-macho/scripts/build_cftest_harness.sh. Will not invent a stub dylib."
+            return 1
+        fi
+        phase2_ud_guest_run_cftest_harness "$ud_w" "$repo" "$sys" \
+            "${ud_w}/cfobjc/src"
+        return $?
     fi
 
     if ! phase2_ud_guest_ensure_cf_checkout "$ud_w" "$repo"; then
@@ -711,31 +793,7 @@ phase2_ud_guest_ensure_cftest() {
         return 1
     fi
 
-    log=$ud_w/lib/build_cftest_harness.log
-    set +e
-    W="$ud_w" \
-        SDK="$sys" \
-        CF="$ud_w/cfobjc/src" \
-        CF_FALLBACK="$cf" \
-        LIB="$ud_w/lib" \
-        CFOBJC_OBJ="$ud_w/cfobjc/obj" \
-        NSCF_OBJ="$ud_w/nscfobj" \
-        R="$repo/foundation-macho" \
-        PROBE_SRC="$repo/foundation-macho/tests/probe_sysctl.c" \
-        TRIPLE=x86_64-apple-macos13.0 \
-        LLD_BIN=/usr/lib/llvm-18/bin \
-        bash "$linker" >"$log" 2>&1
-    st=$?
-    set -e
-    if grep -q '^CANNOT_CFTEST_STUBS ' "$log"; then
-        phase2_ud_guest_format_stub_cannot "$(grep '^CANNOT_CFTEST_STUBS ' "$log" | tail -1)"
-        return 1
-    fi
-    if [ "$st" -ne 0 ] || [ ! -f "$dest" ] || ! phase2_is_x86_macho "$dest"; then
-        phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
-            "build_cftest_harness.sh exit $st (committed CF linker; objects from build_cfobjc.sh) log=$log. Will not invent a stub dylib."
-        return 1
-    fi
+    phase2_ud_guest_run_cftest_harness "$ud_w" "$repo" "$sys" "$cf"
 }
 
 phase2_ud_guest_link() {
@@ -754,6 +812,10 @@ phase2_ud_guest_link() {
     st=$?
     set -e
     if [ "$st" -ne 0 ] || [ ! -f "$out" ]; then
+        if grep -q '^CANNOT_UD_GUEST_INPUTS ' "$log" 2>/dev/null; then
+            grep '^CANNOT_UD_GUEST_INPUTS ' "$log" | tail -1
+            return 1
+        fi
         # Spill to the work-tree root (same rule as the swiftc logs). Do not
         # flatten ld64 text onto the CANNOT line — the inputs listing alone
         # buries the diagnostic.
@@ -809,19 +871,27 @@ phase2_stage_cftest_into_run_root() {
     local src=$1 dest_root=$2
     local dest=$dest_root/darwin/usr/lib/libCFTest.dylib
     local cf_slot=$dest_root/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
-    local sha a b already=0
+    local src_sha dest_sha a b already=0
     if [ ! -f "$src" ] || ! phase2_is_x86_macho "$src"; then
         printf 'CANNOT_UD_GUEST_LIBCFTEST file=libCFTest.dylib reason=no x86 Mach-O to stage into run root src=%s\n' \
             "${src:-empty}"
         return 1
     fi
     mkdir -p "$(dirname "$dest")"
-    if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+    src_sha=$(sha256sum "$src" | awk '{print $1}')
+    if [ -f "$dest" ]; then
+        dest_sha=$(sha256sum "$dest" | awk '{print $1}')
+    else
+        dest_sha=ABSENT
+    fi
+    if [ "$src_sha" = "$dest_sha" ]; then
         already=1
     else
         cp -f "$src" "$dest"
+        dest_sha=$(sha256sum "$dest" | awk '{print $1}')
     fi
-    sha=$(sha256sum "$dest" | awk '{print $1}')
+    # Decision uses the sha already printed on the ENV_PREPARE line, not
+    # existence / cmp of a dest that may be a copy of a stale source.
     if [ -f "$cf_slot" ]; then
         a=$(md5sum "$cf_slot" | awk '{print $1}')
         b=$(md5sum "$dest" | awk '{print $1}')
@@ -832,9 +902,9 @@ phase2_stage_cftest_into_run_root() {
         fi
     fi
     if [ "$already" -eq 1 ]; then
-        printf 'status=satisfied path=%s sha256=%s\n' "$dest" "$sha"
+        printf 'status=satisfied path=%s sha256=%s\n' "$dest" "$dest_sha"
     else
-        printf 'status=cold-built path=%s sha256=%s\n' "$dest" "$sha"
+        printf 'status=cold-built path=%s sha256=%s\n' "$dest" "$dest_sha"
     fi
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Measurement (x86 box, main `faa7db01`)

After PR #68 (ICU required, 80-object set, stub pin) and the pin correction (214), phase2 printed `ENV_PREPARE cftest-stubs satisfied count=214` — and the UserDefaults guest still died on `STUB CALLED: CFStringCreateWithBytes`. Measured:

```
06:57:54 c3b6d411bfca 1531824 scratch/ud-guest-x86_64/lib/libCFTest.dylib          <- the 143-stub build from BEFORE ICU
08:00:13 c3b6d411bfca 1531824 scratch/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib
08:00:13 c3b6d411bfca 1531824 scratch/ud-guest-x86_64/runroot/darwin/usr/lib/libCFTest.dylib
ENV_PREPARE libCFTest-run-root satisfied path=…/mrroot_full-x86_64/darwin/usr/lib/libCFTest.dylib sha256=c3b6d411…
llvm-nm -g --defined-only lib/libCFTest.dylib | grep -c _CFStringCreateWithBytes  -> 0
grep -c CFStringCreateWithBytes stub-func-active.txt                              -> 0   (the stub LIST was regenerated; the DYLIB was not)
```

Three reuse rules each keyed on the wrong thing:

1. `ensure_cftest` reused a present `lib/libCFTest.dylib` when the sibling stub text files matched the pin — the text files were regenerated by the compare step, the dylib was not relinked.
2. `phase2_stage_cftest_into_run_root` reported `satisfied` when the destination existed with the same sha as the (stale) source.
3. `bin/ud_guest` was reused by existence too.

Same class as PR #65 (loader reused by existence) and PR #66 (run-root loader copy refreshed after rung a).

## Stamp contents

`lib/libCFTest.dylib.inputs` is written at link time:

```
argv=<sha256 of the linker argv>
obj:cfobjc/<name>.o=<sha256>     # the 80 cfobjc objects
obj:nscfobj/<name>.o=<sha256>    # nscf
obj:probe_sysctl.o=<sha256>
obj:cfstubs.o=<sha256>
stub-data=<sha256>
stub-func-active=<sha256>
tbd:libSystem=<sha256>
tbd:libobjc=<sha256>
```

Reuse only when a freshly computed stamp equals that file. Otherwise print `reason=inputs <key> old->new` and relink. Matching stamp prints `reused=1 stamp=<sha256 of the inputs file>`.

`bin/ud_guest.inputs` is the same rule for the guest: object shas, `cftest=<libCFTest sha>`, linker argv.

If `stub-func-active.txt` is newer than `lib/libCFTest.dylib`, that is `CANNOT_CFTEST_STALE` naming both mtimes, never `satisfied`. Verify-only (`CFTEST_VERIFY_ONLY=1`) refuses instead of relinking.

Run-root staging compares source sha256 to destination sha256 and copies on any difference (the sha it already printed is now the decision).

## Operator command

```bash
bash x86_stage_inputs_phase2.sh
```

Expect:

- first run after this fix: `libCFTest relinked (216 stubbed)` (214 func + 2 data; `CFStringCreateWithBytes` is not in the stub set — it comes from `CFString.o`)
- second run, unchanged inputs: `reused=1 stamp=<…>`
- rung a past `CFStringCreateWithBytes` (that symbol is defined in the relinked dylib, not a loud stub)

## Tests (this VM)

- `bash foundation-macho/scripts/test_build_cftest_harness.sh` — **pass=19 fail=0** (matching stamp `reused=1`, stale stub list `CANNOT_CFTEST_STALE` in verify-only then relink, changed `obj:cfobjc/CFString.o` prints `reason=inputs … old->new`)
- `bash foundation-macho/scripts/test_link_ud_guest.sh` — **pass=12 fail=0** (`bin/ud_guest.inputs` written; second run `reused=1`; changed `runner.o` relinks with `reason=inputs obj:fe/runner.o`)
- `bash scripts/x86/test_phase2.sh` — stamp cases passed: pin-matching sibling stub files without `.inputs` do not reuse; stub list newer than dylib is `CANNOT_CFTEST_STALE` naming both mtimes; `ensure_cftest` matching stamp is `reused=1`; run-root copy when source sha differs from dest sha. Pre-existing environment holes on this VM (no `scratch/sysroot_fe4-x86_64` / x86 mrroot) are unchanged.

Scope is `scripts/x86/ud_guest.inc`, `scripts/x86/phase2.sh` / `PHASE2.md`, `foundation-macho/scripts/build_cftest_harness.sh` / `link_ud_guest.sh` / `check_cftest_stubs.sh` and their tests. `machorun/` and `uikit/` untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-647a5ad6-6b27-449c-a0f8-db76d0f6e06a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-647a5ad6-6b27-449c-a0f8-db76d0f6e06a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

