### PR TITLE
stamp.inc + ops: stop grading stale bytes; one cycle, one SSM runner, one premerge

### DIFF
--- a/env/contract.json
+++ b/env/contract.json
@@ -49,6 +49,12 @@
     "execution": "arm64-ec2-authority",
     "macos_oracle": "local-only"
   },
+  "transfer": {
+    "s3_bucket": "openuikit-linux-builder-transfer-00da4d9ca172eb1ff",
+    "s3_prefix": "git-bundles",
+    "s3_region": "us-west-2",
+    "notes": "Operator git bundles for SSM. Bucket measured from ops/campaigns/2026-09-01-fwseed-r1 sourceInfo URLs."
+  },
   "hosts": {
     "cursor-x86_64": {
       "arch": ["x86_64"],
@@ -69,6 +75,19 @@
       "arch": ["aarch64", "arm64"],
       "os": "Linux",
       "role": "execution-authority",
+      "instance_id": "i-00da4d9ca172eb1ff",
+      "tree": "/opt/openuikit/verify-20260902/openuikit",
+      "expected_cannot": [
+        "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS",
+        "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS"
+      ]
+    },
+    "ec2-x86_64": {
+      "arch": ["x86_64"],
+      "os": "Linux",
+      "role": "x86-verify",
+      "instance_id": "i-0a2e25f3895c819b3",
+      "tree": "/opt/openuikit/x86-verify/openuikit",
       "expected_cannot": [
         "CURSOR_ENV_CANNOT_STAGE_XCODE_DARWIN_OVERLAYS",
         "CURSOR_ENV_CANNOT_STAGE_SIMRUNTIME_OVERLAY_DYLIBS"

--- a/full/scripts/build_full.sh
+++ b/full/scripts/build_full.sh
@@ -29,6 +29,8 @@ set -euo pipefail
 W=${W:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}
 # shellcheck source=../../scripts/vendor_tree.sh
 . "$W/scripts/vendor_tree.sh"
+# shellcheck source=../../scripts/x86/stamp.inc
+. "$W/scripts/x86/stamp.inc"
 die() {
     echo "build_full: $*" >&2
     exit 2
@@ -260,24 +262,29 @@ esac
 # crashed taken against a loader predating machorun's malloc_type fix (0f39750,
 # "the 46 scenes it was smashing"). HALF A ROOT FROM ONE VERSION AND HALF FROM
 # ANOTHER READS AS A REAL RESULT.
-# Restage when the loader OR any base runtime input is newer than its copy.
+# Restage when the loader OR any base runtime input's CONTENT changes.
 # Measured 2026-09-03 (x86_64, main 3ed87cab): the BASE root's libswiftcompat
 # was rebuilt at 11:47 from the current source, but mrroot_full kept the 08:33
 # copy because only the loader's mtime was consulted; FoundationEssentials
 # then linked against a shim that no longer matched arm64's.
-base_runtime_newer() {
+# Existence and -nt are not a key: stamp_key hashes the loader + compat +
+# overlay dylibs (except libswiftCore, which is staged separately).
+base_runtime_key() {
     local f
-    [ -d "$ROOTDIR" ] || return 0
-    [ "$MACHORUN/build/machorun" -nt "$ROOTDIR/machorun" ] && return 0
-    [ "$BASE_RUNTIME_SOURCE/darwin/usr/lib/libswiftcompat.dylib" -nt "$ROOTDIR/darwin/usr/lib/libswiftcompat.dylib" ] && return 0
+    set -- "$MACHORUN/build/machorun" \
+        "$BASE_RUNTIME_SOURCE/darwin/usr/lib/libswiftcompat.dylib"
     for f in "$BASE_RUNTIME_SOURCE/darwin/usr/lib/swift/"*.dylib; do
         [ -e "$f" ] || continue
         [ "$(basename "$f")" = libswiftCore.dylib ] && continue
-        [ "$f" -nt "$ROOTDIR/darwin/usr/lib/swift/$(basename "$f")" ] && return 0
+        set -- "$@" "$f"
     done
-    return 1
+    stamp_key "$ROOTDIR/machorun" "$@"
 }
-if base_runtime_newer; then
+_base_runtime_stamp_key=$(base_runtime_key)
+if stamp_reuse "$ROOTDIR/machorun" "$_base_runtime_stamp_key"; then
+    echo "build_full: guest root reused stamp=$(stamp_short "$_base_runtime_stamp_key")" >&2
+else
+    stamp_rebuild_reason "$ROOTDIR/machorun" "$_base_runtime_stamp_key"
     echo "== staging guest root from $MACHORUN"
     mkdir -p "$ROOTDIR/darwin/usr/lib/swift"
     cp "$MACHORUN/build/machorun" "$ROOTDIR/machorun"
@@ -303,6 +310,8 @@ if base_runtime_newer; then
         esac
         cp "$d" "$ROOTDIR/darwin/usr/lib/"
     done
+    chmod a+x "$ROOTDIR/machorun" || true
+    stamp_write "$ROOTDIR/machorun" "$_base_runtime_stamp_key"
 fi
 
 # Synchronise every runtime independently of the root-staging condition above.

--- a/scripts/env/test_contract.py
+++ b/scripts/env/test_contract.py
@@ -79,7 +79,28 @@ class ContractLockTests(unittest.TestCase):
             "69f4fe8214a22a06ec841d425e443d51f8646b6b",
         )
 
-    def test_ud_guest_x86_demands_pinned_corelibs_foundation(self) -> None:
+    def test_execution_hosts_name_instance_and_tree(self) -> None:
+        hosts = load_contract(ROOT)["hosts"]
+        self.assertEqual(
+            hosts["ec2-aarch64"]["instance_id"], "i-00da4d9ca172eb1ff"
+        )
+        self.assertEqual(
+            hosts["ec2-aarch64"]["tree"],
+            "/opt/openuikit/verify-20260902/openuikit",
+        )
+        self.assertEqual(
+            hosts["ec2-x86_64"]["instance_id"], "i-0a2e25f3895c819b3"
+        )
+        self.assertEqual(
+            hosts["ec2-x86_64"]["tree"],
+            "/opt/openuikit/x86-verify/openuikit",
+        )
+        transfer = load_contract(ROOT)["transfer"]
+        self.assertEqual(
+            transfer["s3_bucket"],
+            "openuikit-linux-builder-transfer-00da4d9ca172eb1ff",
+        )
+        self.assertEqual(transfer["s3_prefix"], "git-bundles")
         row = checkouts_by_id(load_contract(ROOT))["swift-corelibs-foundation"]
         self.assertEqual(row["commit"], "f3a7a34302317a95665bf4ff1a62ee1b459c1695")
         self.assertEqual(row["tree"], "2f9136f253a51406f2bcb0a612bcb6a9eba03570")

--- a/scripts/ops/common.inc
+++ b/scripts/ops/common.inc
@@ -1,0 +1,61 @@
+# scripts/ops/common.inc -- sourced by run_box.sh / x86_cycle.sh / premerge.sh
+if [ -n "${OPENUIKIT_OPS_COMMON_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+OPENUIKIT_OPS_COMMON_INC=1
+
+ops_root() {
+    CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P
+}
+
+ops_aws() {
+    if [ -n "${OPENUIKIT_AWS:-}" ]; then
+        "$OPENUIKIT_AWS" "$@"
+    else
+        aws "$@"
+    fi
+}
+
+ops_gh() {
+    if [ -n "${OPENUIKIT_GH:-}" ]; then
+        "$OPENUIKIT_GH" "$@"
+    else
+        gh "$@"
+    fi
+}
+
+ops_contract_get() {
+    python3 - "$1" "$2" <<'PY'
+import json, sys
+cur = json.load(open(sys.argv[1], encoding="utf-8"))
+for part in sys.argv[2].split("."):
+    if isinstance(cur, list):
+        cur = cur[int(part)]
+    else:
+        cur = cur[part]
+if isinstance(cur, (dict, list)):
+    json.dump(cur, sys.stdout)
+    sys.stdout.write("\n")
+else:
+    print(cur)
+PY
+}
+
+ops_host_arch() {
+    case "$1" in
+        arm64|aarch64) printf 'ec2-aarch64\n' ;;
+        x86|x86_64) printf 'ec2-x86_64\n' ;;
+        *) printf 'ops: unknown arch %s (arm64|x86)\n' "$1" >&2; return 2 ;;
+    esac
+}
+
+ops_comment() {
+    # SSM Comment max 100 chars.
+    python3 -c 'import sys; s=sys.argv[1]; sys.stdout.write(s[:100])' "$1"
+}
+
+ops_extract_result_lines() {
+    grep -E \
+        'BUILD_OK|GATE_B|GATE_ONBOARDING|RUNG_SCOREBOARD|STAGE |CANNOT_|pass [0-9]+ fail|difftest|PREMERGE |GUEST SCOREBOARD' \
+        || true
+}

--- a/scripts/ops/premerge.sh
+++ b/scripts/ops/premerge.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Merge-gate the operator has been running by hand per PR.
+#
+#   scripts/ops/premerge.sh <pr-number>
+#
+# Worktree the PR merged with origin/main, run scripts/env/test_contract.py,
+# advance the machorun/uikit vendor pin (sed the three files, commit
+# "Advance the machorun vendor pin…") when those subtrees changed, run
+# scripts/test_vendor_tree.sh in that case, run test scripts named in the PR
+# body, print a one-line verdict.
+set -euo pipefail
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+# shellcheck source=common.inc
+. "$HERE/common.inc"
+ROOT=$(ops_root)
+
+usage() {
+    echo "usage: scripts/ops/premerge.sh <pr-number>" >&2
+    exit 2
+}
+[ $# -eq 1 ] || usage
+PR=$1
+case "$PR" in
+    *[!0-9]*) usage ;;
+esac
+
+json=$(ops_gh pr view "$PR" --json number,title,body,baseRefName)
+body=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["body"] or "")' <<<"$json")
+
+WT=${OPENUIKIT_PREMERGE_WORKDIR:-}
+OWN_WT=0
+SKIP_GIT=${OPENUIKIT_PREMERGE_SKIP_GIT:-0}
+
+if [ "$SKIP_GIT" = 1 ]; then
+    [ -n "$WT" ] || { echo "premerge: OPENUIKIT_PREMERGE_WORKDIR required with SKIP_GIT" >&2; exit 2; }
+else
+    if [ -z "$WT" ]; then
+        WT=$(mktemp -d /tmp/openuikit-premerge-$PR.XXXXXX)
+        OWN_WT=1
+    fi
+    cleanup() {
+        if [ "$OWN_WT" -eq 1 ]; then
+            git -C "$ROOT" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
+        fi
+    }
+    trap cleanup EXIT
+    git -C "$ROOT" fetch origin main
+    git -C "$ROOT" fetch origin "pull/$PR/head:premerge-pr-$PR"
+    if [ "$OWN_WT" -eq 1 ]; then
+        git -C "$ROOT" worktree add --detach "$WT" origin/main
+    fi
+    git -C "$WT" merge --no-edit "premerge-pr-$PR" \
+        || git -C "$WT" merge --no-edit "FETCH_HEAD"
+fi
+
+fail=0
+notes=
+
+run() {
+    local label=$1
+    shift
+    echo "== premerge: $label" >&2
+    if ( cd "$WT" && "$@" ); then
+        notes="${notes:+$notes,}ok:$label"
+        return 0
+    fi
+    fail=$((fail + 1))
+    notes="${notes:+$notes,}FAIL:$label"
+    return 1
+}
+
+run test_contract python3 scripts/env/test_contract.py || true
+
+changed=${OPENUIKIT_PREMERGE_CHANGED:-}
+if [ -z "$changed" ]; then
+    changed=$(git -C "$WT" diff --name-only origin/main...HEAD || git -C "$WT" diff --name-only origin/main || true)
+fi
+machorun_uikit=0
+echo "$changed" | grep -q '^machorun/' && machorun_uikit=1
+echo "$changed" | grep -q '^uikit/' && machorun_uikit=1
+
+if [ "$machorun_uikit" -eq 1 ]; then
+    live_mr=$(git -C "$WT" rev-parse HEAD:machorun)
+    live_uk=$(git -C "$WT" rev-parse HEAD:uikit)
+    pin_mr=$(sed -n 's/^EXPECTED_INREPO_MACHORUN_TREE=//p' "$WT/scripts/vendor_pins.sh")
+    pin_uk=$(sed -n 's/^EXPECTED_INREPO_UIKIT_TREE=//p' "$WT/scripts/vendor_pins.sh")
+    if [ "$live_mr" != "$pin_mr" ] || [ "$live_uk" != "$pin_uk" ]; then
+        echo "== premerge: advancing vendor pins machorun $pin_mr->$live_mr uikit $pin_uk->$live_uk" >&2
+        python3 - "$WT/scripts/vendor_pins.sh" "$live_mr" "$live_uk" <<'PY'
+from pathlib import Path
+import re, sys
+path, mr, uk = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+text = re.sub(r"^EXPECTED_INREPO_MACHORUN_TREE=.*$", "EXPECTED_INREPO_MACHORUN_TREE=" + mr, text, count=1, flags=re.M)
+text = re.sub(r"^EXPECTED_INREPO_UIKIT_TREE=.*$", "EXPECTED_INREPO_UIKIT_TREE=" + uk, text, count=1, flags=re.M)
+path.write_text(text, encoding="utf-8")
+PY
+        python3 - "$WT/env/contract.json" "$live_mr" "$live_uk" <<'PY'
+import json, sys
+path, mr, uk = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.loads(open(path, encoding="utf-8").read())
+for row in data["checkouts"]:
+    if row["id"] == "machorun-inrepo":
+        row["tree"] = mr
+    if row["id"] == "uikit-inrepo":
+        row["tree"] = uk
+open(path, "w", encoding="utf-8").write(json.dumps(data, indent=2) + "\n")
+PY
+        python3 - "$WT/scripts/env/test_contract.py" "$live_mr" "$live_uk" <<'PY'
+from pathlib import Path
+import re, sys
+path, mr, uk = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+text = re.sub(
+    r'(checkouts\["machorun-inrepo"\]\["tree"\],\s*\n\s*")([0-9a-f]+)(")',
+    r"\g<1>" + mr + r"\g<3>",
+    text,
+    count=1,
+)
+text = re.sub(
+    r'(checkouts\["uikit-inrepo"\]\["tree"\],\s*\n\s*")([0-9a-f]+)(")',
+    r"\g<1>" + uk + r"\g<3>",
+    text,
+    count=1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+        if [ "$SKIP_GIT" != 1 ]; then
+            git -C "$WT" add scripts/vendor_pins.sh env/contract.json scripts/env/test_contract.py
+            git -C "$WT" commit -m "Advance the machorun vendor pin and env contract to the merged tree"
+        fi
+        notes="${notes:+$notes,}pin-advanced"
+    fi
+    run test_vendor_tree bash scripts/test_vendor_tree.sh || true
+fi
+
+# PR body names its own test scripts. Run those that exist in the worktree.
+while IFS= read -r script; do
+    [ -n "$script" ] || continue
+    [ -f "$WT/$script" ] || continue
+    case "$script" in
+        *.py) run "pr:$script" python3 "$script" || true ;;
+        *.sh) run "pr:$script" bash "$script" || true ;;
+        *) run "pr:$script" "$script" || true ;;
+    esac
+done < <(python3 -c '
+import re, sys
+body = sys.stdin.read()
+seen = []
+for m in re.finditer(r"(?:bash\s+)?((?:scripts|full)/[\w./-]*test[\w./-]*(?:\.sh|\.py))", body):
+    p = m.group(1)
+    if p not in seen:
+        seen.append(p)
+        print(p)
+' <<<"$body")
+
+if [ "$fail" -eq 0 ]; then
+    printf 'PREMERGE pr=%s verdict=PASS notes=%s\n' "$PR" "${notes:-none}"
+    exit 0
+fi
+printf 'PREMERGE pr=%s verdict=FAIL notes=%s\n' "$PR" "${notes:-none}"
+exit 1

--- a/scripts/ops/run_box.sh
+++ b/scripts/ops/run_box.sh
@@ -147,7 +147,10 @@ sys.exit(0 if not cmds else 2)' <<<"$in_progress" || {
 
 BUNDLE=${OPENUIKIT_BUNDLE_FILE:-$ROOT/scratch/openuikit-$SHA.bundle}
 mkdir -p "$(dirname "$BUNDLE")"
-git -C "$ROOT" bundle create "$BUNDLE" "$SHA"
+# git bundle wants a ref, not a raw sha (git 2.53: rc=128 for a bare
+# object id). Pin a temporary ref at the sha; the box fetches refs/ops/bundle.
+git -C "$ROOT" update-ref refs/ops/bundle "$SHA"
+git -C "$ROOT" bundle create "$BUNDLE" refs/ops/bundle
 ops_aws s3 cp "$BUNDLE" "$bundle_s3" --region "$REGION"
 
 cmd_id=$(ops_aws ssm send-command \

--- a/scripts/ops/run_box.sh
+++ b/scripts/ops/run_box.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Operator runner: replace hand-typed SSM chains.
+#
+#   scripts/ops/run_box.sh [--dry-run] <arm64|x86> <verify|onboarding|cycle> [main-sha]
+#
+# Run from the operator Mac. Builds a git bundle, uploads it to the S3 prefix
+# in env/contract.json, refuses to launch when the instance has any InProgress
+# command (server-side --filters key=Status,value=InProgress), caps the SSM
+# comment at 100 chars, waits with get-command-invocation, and prints the
+# grep-extracted result lines (BUILD_OK, difftest pass/fail, GATE_B /
+# GATE_ONBOARDING, RUNG_SCOREBOARD, CANNOT, STAGE).
+set -euo pipefail
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+# shellcheck source=common.inc
+. "$HERE/common.inc"
+ROOT=$(ops_root)
+CONTRACT=$ROOT/env/contract.json
+
+DRY=0
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY=1
+    shift
+fi
+
+usage() {
+    echo "usage: scripts/ops/run_box.sh [--dry-run] <arm64|x86> <verify|onboarding|cycle> [main-sha]" >&2
+    exit 2
+}
+
+[ $# -ge 2 ] || usage
+ARCH=$1
+MODE=$2
+SHA=${3:-}
+
+case "$ARCH" in
+    arm64|aarch64|x86|x86_64) ;;
+    *) usage ;;
+esac
+case "$MODE" in
+    verify|onboarding|cycle) ;;
+    *) usage ;;
+esac
+
+HOST=$(ops_host_arch "$ARCH")
+INSTANCE=$(ops_contract_get "$CONTRACT" "hosts.$HOST.instance_id")
+TREE=$(ops_contract_get "$CONTRACT" "hosts.$HOST.tree")
+BUCKET=$(ops_contract_get "$CONTRACT" transfer.s3_bucket)
+PREFIX=$(ops_contract_get "$CONTRACT" transfer.s3_prefix)
+REGION=$(ops_contract_get "$CONTRACT" transfer.s3_region)
+
+if [ -z "$SHA" ]; then
+    SHA=$(git -C "$ROOT" rev-parse HEAD)
+fi
+
+COMMENT=$(ops_comment "openuikit $ARCH $MODE $SHA")
+
+bundle_key="$PREFIX/${SHA}.bundle"
+bundle_s3="s3://$BUCKET/$bundle_key"
+
+remote_cmd() {
+    case "$MODE" in
+        cycle)
+            cat <<EOF
+set -eu
+cd $TREE
+export OPENUIKIT_BUNDLE_URI='$bundle_s3'
+export OPENUIKIT_SHA='$SHA'
+export OPENUIKIT_S3_REGION='$REGION'
+bash scripts/ops/x86_cycle.sh $TREE
+EOF
+            ;;
+        verify)
+            cat <<EOF
+set -eu
+cd $TREE
+aws s3 cp '$bundle_s3' /tmp/openuikit-$SHA.bundle --region $REGION
+git fetch /tmp/openuikit-$SHA.bundle '$SHA'
+git checkout --force '$SHA'
+python3 scripts/env/prepare.py
+sh machorun/scripts/build.sh
+sh machorun/scripts/difftest.sh
+echo BUILD_OK
+if bash full/swiftui/build_focus_widget_guest.sh; then
+  echo GATE_B_PASS
+else
+  echo GATE_B_FAIL
+  exit 2
+fi
+EOF
+            ;;
+        onboarding)
+            cat <<EOF
+set -eu
+cd $TREE
+aws s3 cp '$bundle_s3' /tmp/openuikit-$SHA.bundle --region $REGION
+git fetch /tmp/openuikit-$SHA.bundle '$SHA'
+git checkout --force '$SHA'
+python3 scripts/env/prepare.py
+if bash full/swiftui/build_focus_onboarding_guest.sh; then
+  echo GATE_ONBOARDING_PASS
+else
+  echo GATE_ONBOARDING_FAIL
+  exit 2
+fi
+EOF
+            ;;
+    esac
+}
+
+build_document() {
+    OPS_COMMENT=$COMMENT OPS_INSTANCE=$INSTANCE OPS_COMMANDS=$(remote_cmd) python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "DocumentName": "AWS-RunShellScript",
+    "Comment": os.environ["OPS_COMMENT"][:100],
+    "InstanceIds": [os.environ["OPS_INSTANCE"]],
+    "Parameters": {
+        "commands": [os.environ["OPS_COMMANDS"]],
+        "executionTimeout": ["14400"],
+    },
+}, indent=2))
+PY
+}
+
+DOCUMENT=$(build_document)
+
+if [ "$DRY" -eq 1 ]; then
+    echo "$DOCUMENT"
+    exit 0
+fi
+
+# Refuse to launch when the box has any InProgress command. Server-side
+# filter only — never the unfiltered listing (that listing is how an
+# InProgress command was missed).
+in_progress=$(ops_aws ssm list-commands \
+    --instance-id "$INSTANCE" \
+    --filters key=Status,value=InProgress \
+    --region "$REGION" \
+    --output json)
+python3 -c 'import json,sys; d=json.load(sys.stdin); cmds=d.get("Commands") or d.get("commands") or [];
+sys.exit(0 if not cmds else 2)' <<<"$in_progress" || {
+    echo "run_box: refusing to launch: $INSTANCE has InProgress command(s)" >&2
+    echo "$in_progress" >&2
+    exit 2
+}
+
+BUNDLE=${OPENUIKIT_BUNDLE_FILE:-$ROOT/scratch/openuikit-$SHA.bundle}
+mkdir -p "$(dirname "$BUNDLE")"
+git -C "$ROOT" bundle create "$BUNDLE" "$SHA"
+ops_aws s3 cp "$BUNDLE" "$bundle_s3" --region "$REGION"
+
+cmd_id=$(ops_aws ssm send-command \
+    --cli-input-json "$DOCUMENT" \
+    --region "$REGION" \
+    --query 'Command.CommandId' \
+    --output text)
+
+echo "run_box: sent $cmd_id comment=${#COMMENT} chars (cap 100) instance=$INSTANCE"
+
+# Wait. Stub aws may return immediately.
+status=Pending
+out=""
+tries=0
+while [ "$tries" -lt 360 ]; do
+    out=$(ops_aws ssm get-command-invocation \
+        --command-id "$cmd_id" \
+        --instance-id "$INSTANCE" \
+        --region "$REGION" \
+        --output json || true)
+    status=$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("Status") or d.get("status") or "Unknown")' <<<"$out" 2>/dev/null || printf 'Unknown\n')
+    case "$status" in
+        Success|Failed|Cancelled|TimedOut) break ;;
+    esac
+    tries=$((tries + 1))
+    sleep 5
+done
+
+python3 -c 'import json,sys; d=json.load(sys.stdin); sys.stdout.write(d.get("StandardOutputContent") or d.get("stdout") or "")' <<<"$out" \
+    | ops_extract_result_lines
+python3 -c 'import json,sys; d=json.load(sys.stdin); sys.stderr.write(d.get("StandardErrorContent") or d.get("stderr") or "")' <<<"$out" \
+    | ops_extract_result_lines >&2 || true
+
+[ "$status" = Success ]

--- a/scripts/ops/test_ops.sh
+++ b/scripts/ops/test_ops.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Tests for scripts/ops/{run_box,x86_cycle,premerge}.sh against stub AWS/gh.
+set -euo pipefail
+ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)
+pass=0
+fail=0
+ok() { echo "PASS: $*"; pass=$((pass + 1)); }
+die_test() { echo "FAIL: $*" >&2; fail=$((fail + 1)); }
+
+STUBDIR=$(mktemp -d /tmp/ops-stub.XXXXXX)
+cleanup() { rm -rf "$STUBDIR"; }
+trap cleanup EXIT
+
+cat > "$STUBDIR/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$@" >> "${OPENUIKIT_AWS_LOG}"
+cmd=$1
+sub=${2:-}
+shift 2 || true
+case "$cmd $sub" in
+    "ssm list-commands")
+        if ! printf '%s\n' "$@" | grep -q 'key=Status,value=InProgress'; then
+            echo '{"error":"unfiltered listing forbidden"}' >&2
+            exit 2
+        fi
+        if [ "${OPENUIKIT_STUB_INPROGRESS:-0}" = 1 ]; then
+            echo '{"Commands":[{"CommandId":"cmd-busy","Status":"InProgress"}]}'
+        else
+            echo '{"Commands":[]}'
+        fi
+        ;;
+    "s3 cp")
+        echo "upload $*" >&2
+        ;;
+    "ssm send-command")
+        echo "cmd-stub-1"
+        ;;
+    "ssm get-command-invocation")
+        python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "Status": "Success",
+    "StandardOutputContent": os.environ.get(
+        "OPENUIKIT_STUB_STDOUT",
+        "STAGE prepare status=rebuilt key=abc123def456 product=/opt/openuikit/x86-verify/openuikit sha256=deadbeefcafe\n"
+        "RUNG_SCOREBOARD a=PASS/smoke 14/14  b=PASS  c=PASS\n"
+        "GATE_B_PASS\n"
+        "pass 69 fail 0\n"
+        "BUILD_OK\n",
+    ),
+    "StandardErrorContent": "",
+}))
+PY
+        ;;
+    *)
+        echo "aws stub: unknown $cmd $sub $*" >&2
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$STUBDIR/aws"
+
+REALGIT=$(command -v git)
+cat > "$STUBDIR/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = -C ] && [ "\${3:-}" = bundle ]; then
+    mkdir -p "\$(dirname "\$5")"
+    cp "$STUBDIR/tiny.bundle" "\$5"
+    exit 0
+fi
+exec "$REALGIT" "\$@"
+EOF
+chmod +x "$STUBDIR/git"
+mkdir -p "$STUBDIR/empty.git"
+"$REALGIT" -C "$STUBDIR" init -q empty.git
+"$REALGIT" -C "$STUBDIR/empty.git" -c user.email=t@t -c user.name=t commit --allow-empty -qm init
+"$REALGIT" -C "$STUBDIR/empty.git" bundle create "$STUBDIR/tiny.bundle" HEAD
+export PATH="$STUBDIR:$PATH"
+
+export OPENUIKIT_AWS=$STUBDIR/aws
+export OPENUIKIT_AWS_LOG=$STUBDIR/aws.log
+export GIT_AUTHOR_NAME=ops-test
+export GIT_AUTHOR_EMAIL=ops-test@example.com
+export GIT_COMMITTER_NAME=ops-test
+export GIT_COMMITTER_EMAIL=ops-test@example.com
+
+echo "== run_box --dry-run prints the SSM document"
+doc=$(bash "$ROOT/scripts/ops/run_box.sh" --dry-run x86 cycle HEAD)
+if printf '%s\n' "$doc" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["DocumentName"]=="AWS-RunShellScript"; assert len(d["Comment"])<=100; assert d["InstanceIds"]==["i-0a2e25f3895c819b3"]; cmds=d["Parameters"]["commands"][0]; assert "x86_cycle.sh" in cmds; assert "OPENUIKIT_BUNDLE_URI" in cmds; assert "OPENUIKIT_S3_REGION" in cmds; assert "git checkout" not in cmds'; then
+    ok "x86 cycle dry-run document names instance and x86_cycle.sh"
+else
+    die_test "x86 cycle dry-run document: $(printf '%s' "$doc" | head -c 400)"
+fi
+
+doc=$(bash "$ROOT/scripts/ops/run_box.sh" --dry-run arm64 verify HEAD)
+if printf '%s\n' "$doc" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["InstanceIds"]==["i-00da4d9ca172eb1ff"]; c=d["Parameters"]["commands"][0]; assert "difftest.sh" in c; assert "GATE_B_PASS" in c'; then
+    ok "arm64 verify dry-run document names authority instance and GATE_B_PASS"
+else
+    die_test "arm64 verify dry-run: $(printf '%s' "$doc" | head -c 400)"
+fi
+
+echo "== run_box refuses InProgress (server-side filter)"
+: > "$OPENUIKIT_AWS_LOG"
+export OPENUIKIT_STUB_INPROGRESS=1
+if bash "$ROOT/scripts/ops/run_box.sh" x86 cycle HEAD >"$STUBDIR/out" 2>"$STUBDIR/err"; then
+    die_test "InProgress should refuse"
+else
+    grep -q InProgress "$STUBDIR/err" && ok "InProgress refuse names Status" \
+        || die_test "err=$(cat "$STUBDIR/err")"
+fi
+unset OPENUIKIT_STUB_INPROGRESS
+grep -q 'key=Status,value=InProgress' "$OPENUIKIT_AWS_LOG" \
+    && ok "list-commands uses server-side InProgress filter" \
+    || die_test "aws log=$(cat "$OPENUIKIT_AWS_LOG")"
+if grep -q 'list-commands' "$OPENUIKIT_AWS_LOG" && ! grep 'list-commands' "$OPENUIKIT_AWS_LOG" | grep -q 'key=Status,value=InProgress'; then
+    die_test "unfiltered list-commands was used"
+fi
+unset OPENUIKIT_STUB_INPROGRESS
+
+echo "== run_box success extracts STAGE / scoreboard / GATE_B"
+: > "$OPENUIKIT_AWS_LOG"
+export OPENUIKIT_BUNDLE_FILE=$STUBDIR/tiny.bundle
+out=$(bash "$ROOT/scripts/ops/run_box.sh" x86 cycle HEAD 2>"$STUBDIR/err" || true)
+echo "$out" | grep -q 'STAGE prepare' && ok "run_box greps STAGE lines" \
+    || die_test "out=$(echo "$out" | head -20) err=$(head -20 "$STUBDIR/err")"
+echo "$out" | grep -q 'RUNG_SCOREBOARD' && ok "run_box greps RUNG_SCOREBOARD" \
+    || die_test "missing RUNG_SCOREBOARD in $out"
+echo "$out" | grep -q 'GATE_B_PASS' && ok "run_box greps GATE_B_PASS" \
+    || die_test "missing GATE_B"
+echo "$out" | grep -q 'pass 69 fail 0' && ok "run_box greps difftest pass 69 fail 0" \
+    || die_test "missing pass/fail"
+echo "$out" | grep -q 'BUILD_OK' && ok "run_box greps BUILD_OK" \
+    || die_test "missing BUILD_OK"
+
+echo "== comment cap 100"
+python3 -c 'import json,sys; json.load(open("/dev/null"))' 2>/dev/null || true
+doc=$(bash "$ROOT/scripts/ops/run_box.sh" --dry-run x86 cycle "$(python3 -c 'print("a"*200)')")
+python3 -c 'import json,sys; d=json.load(sys.stdin); assert len(d["Comment"])<=100' <<<"$doc" \
+    && ok "SSM comment capped at 100" \
+    || die_test "comment too long"
+
+echo "== x86_cycle --dry-run"
+cyc=$(bash "$ROOT/scripts/ops/x86_cycle.sh" --dry-run)
+echo "$cyc" | grep -q 'STAGE fetch_bundle status=planned' && ok "cycle dry-run STAGE fetch_bundle" \
+    || die_test "$cyc"
+echo "$cyc" | grep -q 'STAGE overlays status=planned' && ok "cycle dry-run STAGE overlays" \
+    || die_test "no overlays stage"
+echo "$cyc" | grep -q 'overlays after tbd' && ok "cycle dry-run states tbd-before-overlays reason" \
+    || die_test "missing order reason"
+grep -q 's3://\*)' "$ROOT/scripts/ops/x86_cycle.sh" \
+    && grep -q 'ops_aws s3 cp' "$ROOT/scripts/ops/x86_cycle.sh" \
+    && ok "cycle fetches s3:// via ops_aws s3 cp (not urllib)" \
+    || die_test "x86_cycle.sh missing s3 fetch path"
+echo "$cyc" | grep -q 'SWIFTCORE_OVERLAYS=1' && ok "cycle dry-run quotes PR64 overlay argv" \
+    || die_test "missing overlay argv"
+# order: tbd line before overlays line
+python3 - <<PY
+import sys
+text = """$cyc"""
+assert text.index("STAGE tbd") < text.index("STAGE overlays"), text
+print("order ok")
+PY
+ok "cycle dry-run tbd before overlays"
+
+echo "== x86_cycle stub"
+cyc=$(OPENUIKIT_CYCLE_STUB=1 bash "$ROOT/scripts/ops/x86_cycle.sh")
+echo "$cyc" | grep -c '^STAGE ' | grep -qx 8 && ok "cycle stub emits 8 STAGE lines" \
+    || die_test "STAGE count=$(echo "$cyc" | grep -c '^STAGE ')"
+echo "$cyc" | grep -q 'RUNG_SCOREBOARD' && ok "cycle stub quotes scoreboard" \
+    || die_test "$cyc"
+echo "$cyc" | grep -q 'positive board' && ok "cycle stub quotes positive persist board" \
+    || die_test "missing positive board"
+
+echo "== premerge"
+cat > "$STUBDIR/gh" <<'EOF'
+#!/usr/bin/env bash
+python3 - <<'PY'
+import json
+print(json.dumps({
+    "number": 99,
+    "title": "stamp",
+    "body": "Run bash scripts/x86/test_stamp.sh and python3 scripts/env/test_contract.py",
+    "baseRefName": "main",
+}))
+PY
+EOF
+chmod +x "$STUBDIR/gh"
+export OPENUIKIT_GH=$STUBDIR/gh
+FAKE=$STUBDIR/premerge-tree
+mkdir -p "$FAKE/scripts/env" "$FAKE/scripts/x86" "$FAKE/env"
+# Minimal tree that pin-advance can edit and that named tests can run.
+cp "$ROOT/scripts/vendor_pins.sh" "$FAKE/scripts/vendor_pins.sh"
+cp "$ROOT/env/contract.json" "$FAKE/env/contract.json"
+cp "$ROOT/scripts/env/test_contract.py" "$FAKE/scripts/env/test_contract.py"
+# Named PR test: a tiny passing script.
+mkdir -p "$FAKE/scripts/x86"
+printf '#!/bin/sh\necho stamp-ok\nexit 0\n' > "$FAKE/scripts/x86/test_stamp.sh"
+chmod +x "$FAKE/scripts/x86/test_stamp.sh"
+# test_contract.py needs the real repo; skip by replacing with a stub in the fake tree.
+printf '#!/usr/bin/env python3\nprint("contract-ok")\n' > "$FAKE/scripts/env/test_contract.py"
+printf '#!/bin/sh\necho vendor-ok\n' > "$FAKE/scripts/test_vendor_tree.sh"
+chmod +x "$FAKE/scripts/test_vendor_tree.sh"
+# Pin advance needs git rev-parse HEAD:machorun. Make a tiny git repo with those trees.
+mkdir -p "$FAKE/machorun" "$FAKE/uikit"
+printf 'x\n' > "$FAKE/machorun/f"
+printf 'y\n' > "$FAKE/uikit/f"
+git -C "$FAKE" init -q
+git -C "$FAKE" add machorun uikit scripts env
+git -C "$FAKE" commit -qm 'fake trees'
+verdict=$(
+    OPENUIKIT_PREMERGE_SKIP_GIT=1 \
+    OPENUIKIT_PREMERGE_WORKDIR=$FAKE \
+    OPENUIKIT_PREMERGE_CHANGED=$'machorun/f\n' \
+    bash "$ROOT/scripts/ops/premerge.sh" 99 2>"$STUBDIR/premerge.err" || true
+)
+echo "$verdict" | grep -q 'PREMERGE pr=99 verdict=PASS' && ok "premerge PASS verdict" \
+    || die_test "verdict=$verdict err=$(cat "$STUBDIR/premerge.err")"
+echo "$verdict" | grep -q pin-advanced && ok "premerge advanced the vendor pin" \
+    || die_test "no pin-advanced in $verdict"
+grep -q "$(git -C "$FAKE" rev-parse HEAD:machorun)" "$FAKE/scripts/vendor_pins.sh" \
+    && ok "vendor_pins.sh sed/python advanced HEAD:machorun" \
+    || die_test "pin file=$(cat "$FAKE/scripts/vendor_pins.sh")"
+
+echo
+echo "test_ops: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/ops/x86_cycle.sh
+++ b/scripts/ops/x86_cycle.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# One x86 cycle, in the right order, on the box.
+#
+#   bash scripts/ops/x86_cycle.sh [--dry-run] [tree]
+#
+# Replaces the operator files /tmp/x86_stage_inputs_phase2.sh and
+# /tmp/x86_overlays_phase2.sh. phase2.sh stays the rung runner.
+#
+# Order is load-bearing. Overlay ninja before phase2 regenerated the darwin
+# .tbds left a machorun surface change "undefined" for one more cycle
+# (ssm_x86both, 2026-09-03). TBD first, then overlays, then roots, then rungs.
+#
+# Do not wrap children in an ERR trap that swallows their log: print the
+# child's log path and tail it on failure.
+set -eu
+# No `pipefail` ERR trap. Child logs must stay on stderr/stdout.
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+# shellcheck source=common.inc
+. "$HERE/common.inc"
+ROOT=$(ops_root)
+# shellcheck source=../x86/stamp.inc
+. "$ROOT/scripts/x86/stamp.inc"
+
+DRY=0
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY=1
+    shift
+fi
+
+TREE=${1:-}
+if [ -z "$TREE" ]; then
+    TREE=$(ops_contract_get "$ROOT/env/contract.json" hosts.ec2-x86_64.tree)
+fi
+
+BUNDLE_URI=${OPENUIKIT_BUNDLE_URI:-}
+SHA=${OPENUIKIT_SHA:-}
+STUB=${OPENUIKIT_CYCLE_STUB:-0}
+S3_REGION=${OPENUIKIT_S3_REGION:-}
+
+OVERLAY_CMD='NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift bash swiftcore-macho/scripts/build_stdlib.sh'
+
+stage_names() {
+    printf '%s\n' \
+        fetch_bundle \
+        checkout \
+        prepare \
+        tbd \
+        sysroot \
+        overlays \
+        roots \
+        phase2
+}
+
+if [ "$DRY" -eq 1 ]; then
+    echo "x86_cycle dry-run tree=$TREE sha=${SHA:-HEAD} bundle=${BUNDLE_URI:-unset}"
+    echo "order: fetch_bundle -> checkout -> prepare -> tbd -> sysroot -> overlays -> roots -> phase2"
+    echo "overlays after tbd (ssm_x86both inverted this and left undefineds for one cycle)"
+    echo "overlay: $OVERLAY_CMD"
+    n=0
+    while IFS= read -r name; do
+        n=$((n + 1))
+        printf 'STAGE %s status=planned key=dry-run product=%s sha256=dry-run\n' \
+            "$name" "$TREE"
+    done < <(stage_names)
+    echo "RUNG_SCOREBOARD a=planned b=planned c=planned (positive boards quoted by phase2, not the negative control)"
+    exit 0
+fi
+
+run_logged() {
+    local name=$1 log=$2
+    shift 2
+    echo "== $name: $*" >&2
+    if "$@" >"$log" 2>&1; then
+        return 0
+    fi
+    rc=$?
+    echo "x86_cycle: $name failed rc=$rc log=$log (child log follows, not hidden by ERR trap)" >&2
+    tail -n 80 "$log" >&2 || true
+    return "$rc"
+}
+
+emit_stage() {
+    local name=$1 status=$2 product=$3
+    local key
+    key=$(printf '%s\n' "$name" "$product" "${SHA:-}" | sha256sum | awk '{print $1}')
+    stamp_stage_line "$name" "$status" "$key" "$product"
+}
+
+# Child logs print reused=1 / rebuilt reason= to stderr (captured in the log).
+status_from_log() {
+    local log=$1
+    if [ -f "$log" ] && grep -q 'reused=1 stamp=' "$log" && ! grep -q 'rebuilt reason=' "$log"; then
+        printf 'reused\n'
+        return 0
+    fi
+    printf 'rebuilt\n'
+}
+
+if [ "$STUB" = 1 ]; then
+    mkdir -p "$TREE" 2>/dev/null || TREE=$(mktemp -d /tmp/x86-cycle-stub.XXXXXX)
+    while IFS= read -r name; do
+        emit_stage "$name" reused "$TREE"
+    done < <(stage_names)
+    echo "RUNG_SCOREBOARD a=PASS/smoke 14/14 (stub)  b=PASS/widget+onboarding  c=PASS/windows=1 turns=3 paced=true"
+    echo "GUEST SCOREBOARD port 579/579 (positive board; not the negative control)"
+    exit 0
+fi
+
+cd "$TREE"
+LOGDIR=${OPENUIKIT_CYCLE_LOGDIR:-$TREE/scratch/x86-cycle-logs}
+mkdir -p "$LOGDIR"
+
+# 1. fetch bundle. s3:// goes through aws (the operator prefix in
+# env/contract.json); http(s) is the urllib fallback. urllib cannot speak S3.
+if [ -z "$S3_REGION" ]; then
+    S3_REGION=$(ops_contract_get "$ROOT/env/contract.json" transfer.s3_region)
+fi
+if [ -n "$BUNDLE_URI" ]; then
+    bundle=$LOGDIR/openuikit.bundle
+    fetch_rc=0
+    case "$BUNDLE_URI" in
+        s3://*)
+            run_logged fetch_bundle "$LOGDIR/fetch.log" \
+                ops_aws s3 cp "$BUNDLE_URI" "$bundle" --region "$S3_REGION" \
+                || fetch_rc=$?
+            ;;
+        *)
+            run_logged fetch_bundle "$LOGDIR/fetch.log" \
+                python3 -c 'import sys,urllib.request; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])' \
+                    "$BUNDLE_URI" "$bundle" \
+                || fetch_rc=$?
+            ;;
+    esac
+    if [ "$fetch_rc" -eq 0 ]; then
+        emit_stage fetch_bundle rebuilt "$bundle"
+    else
+        emit_stage fetch_bundle cannot "$bundle"
+        exit 2
+    fi
+else
+    emit_stage fetch_bundle reused "$TREE/.git"
+fi
+
+# 2. checkout
+if [ -n "$SHA" ]; then
+    if [ -n "${bundle:-}" ] && [ -f "${bundle:-}" ]; then
+        git bundle verify "$bundle" >/dev/null
+        git fetch "$bundle" "$SHA"
+    fi
+    if git checkout --force "$SHA"; then
+        emit_stage checkout rebuilt "$TREE"
+    else
+        emit_stage checkout cannot "$TREE"
+        exit 2
+    fi
+else
+    emit_stage checkout reused "$TREE"
+fi
+
+# 3. prepare.py (loader/darwin/tbd through stamps)
+if run_logged prepare "$LOGDIR/prepare.log" python3 "$TREE/scripts/env/prepare.py"; then
+    emit_stage prepare "$(status_from_log "$LOGDIR/prepare.log")" "$TREE/machorun/build/machorun"
+else
+    emit_stage prepare cannot "$TREE/machorun/build/machorun"
+    exit 2
+fi
+
+# 4. build.sh tbd must be clean (after darwin, before overlays)
+if run_logged tbd "$LOGDIR/tbd.log" sh "$TREE/machorun/scripts/build.sh" tbd; then
+    emit_stage tbd "$(status_from_log "$LOGDIR/tbd.log")" "$TREE/machorun/sdk/usr/lib/libSystem.tbd"
+else
+    emit_stage tbd cannot "$TREE/machorun/sdk/usr/lib/libSystem.tbd"
+    exit 2
+fi
+
+# 5. stage sysroot
+if run_logged sysroot "$LOGDIR/sysroot.log" \
+    bash "$TREE/scripts/x86/stage_fe_sysroot.sh"; then
+    emit_stage sysroot "$(status_from_log "$LOGDIR/sysroot.log")" "$TREE/scratch/sysroot_fe4-x86_64"
+else
+    emit_stage sysroot cannot "$TREE/scratch/sysroot_fe4-x86_64"
+    exit 2
+fi
+
+# 6. overlays AFTER tbd. PR #64 argv. Child log is tailed on failure.
+# shellcheck disable=SC2086
+if run_logged overlays "$LOGDIR/overlays.log" \
+    env NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 \
+        SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift \
+        bash "$TREE/swiftcore-macho/scripts/build_stdlib.sh"; then
+    emit_stage overlays "$(status_from_log "$LOGDIR/overlays.log")" "$TREE/swiftcore-macho/artifacts/swift-macosx/x86_64"
+else
+    emit_stage overlays cannot "$TREE/swiftcore-macho/artifacts/swift-macosx/x86_64"
+    exit 2
+fi
+
+# 7. stage roots happens inside phase2; call it out so the scoreboard names it
+emit_stage roots rebuilt "$TREE/scratch/mrroot-x86_64"
+
+# 8. phase2 rungs. Quote POSITIVE boards (phase2 already does; do not tail -1
+# the persist log past NEGATIVE CONTROL).
+if run_logged phase2 "$LOGDIR/phase2.log" \
+    bash "$TREE/scripts/x86/phase2.sh" "$TREE"; then
+    emit_stage phase2 "$(status_from_log "$LOGDIR/phase2.log")" "$TREE"
+else
+    emit_stage phase2 cannot "$TREE"
+    grep -E 'RUNG_SCOREBOARD|GUEST SCOREBOARD|CANNOT_' "$LOGDIR/phase2.log" || true
+    exit 2
+fi
+grep -E 'RUNG_SCOREBOARD|GUEST SCOREBOARD|ENV_PREPARE_SUMMARY|CANNOT_' \
+    "$LOGDIR/phase2.log" || true
+exit 0

--- a/scripts/ops/x86_cycle.sh
+++ b/scripts/ops/x86_cycle.sh
@@ -146,7 +146,13 @@ fi
 if [ -n "$SHA" ]; then
     if [ -n "${bundle:-}" ] && [ -f "${bundle:-}" ]; then
         git bundle verify "$bundle" >/dev/null
-        git fetch "$bundle" "$SHA"
+        # run_box.sh pins the sha at refs/ops/bundle (git bundle needs a ref);
+        # fetch that ref and insist it is the sha the operator named.
+        git fetch "$bundle" refs/ops/bundle
+        [ "$(git rev-parse FETCH_HEAD)" = "$SHA" ] || {
+            echo "x86_cycle: bundle ref is $(git rev-parse FETCH_HEAD), expected $SHA" >&2
+            exit 2
+        }
     fi
     if git checkout --force "$SHA"; then
         emit_stage checkout rebuilt "$TREE"

--- a/scripts/x86/PHASE2.md
+++ b/scripts/x86/PHASE2.md
@@ -33,11 +33,16 @@ Operator restage of real inputs (Focus_Widget.bundle + Reminder inventory)
 then this runner:
 
 ```bash
-bash x86_stage_inputs_phase2.sh
+bash scripts/ops/x86_cycle.sh /opt/openuikit/x86-verify/openuikit
 ```
 
-(`x86_stage_inputs_phase2.sh` lives on the operator box; it sets
-`FOCUS_WIDGET_BUNDLE` and invokes `bash scripts/x86/phase2.sh`.)
+(`scripts/ops/x86_cycle.sh` is the committed replacement for the operator
+files `/tmp/x86_stage_inputs_phase2.sh` and `/tmp/x86_overlays_phase2.sh`.
+Order: fetch → checkout → prepare.py → `build.sh tbd` clean → sysroot →
+overlays (`SWIFTCORE_OVERLAYS=1` argv from PR #64) → roots → phase2 rungs.
+Overlays after tbd, because overlay-before-tbd left a machorun surface
+change undefined for one more cycle. From the operator Mac:
+`scripts/ops/run_box.sh x86 cycle`.)
 
 Do not edit `machorun/` in this phase: `EXPECTED_INREPO_MACHORUN_TREE` is a
 Focus/full-build attestation pin.
@@ -308,7 +313,8 @@ Static tests: `bash scripts/x86/test_phase2.sh`.
    `MRUN=/stage/machorun-bin`). The `== binary` line prints
    `loader=$MRUN sha256=…` of the file about to be exec'd. Before rung a,
    phase2 copies `$MACHORUN/build/machorun` onto `$MRROOT/machorun` when
-   newer (the same `-nt` rule `build_full.sh` uses for rungs b/c); the
+   the stamp key (loader content) mismatches — the same `stamp.inc` rule
+   `build_full.sh` uses for rungs b/c; the
    mrroot-x86 "satisfied" path otherwise leaves a stale loader in place.
    `link_ud_guest.sh` stays the only ud_guest linker. Any other
    missing piece is `CANNOT_UD_GUEST_<FILE> file=<basename>`. On success the

--- a/scripts/x86/common.inc
+++ b/scripts/x86/common.inc
@@ -18,6 +18,8 @@ _phase2_tree=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 . "$_phase2_tree/full/dispatch/swift_linux_lib.inc"
 PHASE2_REPO=$_phase2_tree
 unset _phase2_tree
+# shellcheck source=stamp.inc
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/stamp.inc"
 
 phase2_prepare() {
     printf 'ENV_PREPARE %s %s\n' "$1" "$2"
@@ -1349,10 +1351,15 @@ phase2_fill_x86_loud_abort_stubs() {
     local work=$dest/shim-work
     local log=$work/build_runtime_shims.log
     mkdir -p "$fw/Foundation.framework" "$fw/CoreFoundation.framework" "$work"
-    if phase2_is_x86_macho "$fw/Foundation.framework/Foundation" \
-        && phase2_is_x86_macho "$fw/CoreFoundation.framework/CoreFoundation"; then
+    local stub_key
+    stub_key=$(stamp_key "$fw/Foundation.framework/Foundation" \
+        "$repo/scripts/build_runtime_shims.sh" \
+        "$sys" "${TARGET:-x86_64-apple-macos15.0}")
+    if stamp_reuse "$fw/Foundation.framework/Foundation" "$stub_key" \
+        && stamp_reuse "$fw/CoreFoundation.framework/CoreFoundation" "$stub_key"; then
         return 0
     fi
+    stamp_rebuild_reason "$fw/Foundation.framework/Foundation" "$stub_key"
     rm -f "$fw/Foundation.framework/Foundation" \
         "$fw/CoreFoundation.framework/CoreFoundation"
     set +e
@@ -1373,6 +1380,11 @@ phase2_fill_x86_loud_abort_stubs() {
     fi
     if ! phase2_is_x86_macho "$fw/CoreFoundation.framework/CoreFoundation"; then
         rm -f "$fw/CoreFoundation.framework/CoreFoundation"
+    fi
+    if phase2_is_x86_macho "$fw/Foundation.framework/Foundation" \
+        && phase2_is_x86_macho "$fw/CoreFoundation.framework/CoreFoundation"; then
+        stamp_write "$fw/Foundation.framework/Foundation" "$stub_key"
+        stamp_write "$fw/CoreFoundation.framework/CoreFoundation" "$stub_key"
     fi
 }
 
@@ -1420,16 +1432,16 @@ phase2_fill_x86_libswiftcompat() {
     # changed at 09:25, so FoundationEssentials bound strtod_l/strtof_l from
     # libSystem on x86_64 while arm64 bound them from libswiftcompat and the
     # link-map inventory diverged.
-    local stamp=$out.source-sha256 want
-    want=$(cat "$src_dir/swiftcompat.c" "$src_dir/shim.cpp" "$repo/swiftcore-macho/scripts/build_compat.sh" 2>/dev/null | sha256sum | awk '{print $1}')
-    if phase2_is_x86_macho "$out" && [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$want" ]; then
-        echo "phase2: libswiftcompat reused=1 source-sha256=${want:0:12}" >&2
+    local want
+    want=$(stamp_key "$out" \
+        "$src_dir/swiftcompat.c" \
+        "$src_dir/shim.cpp" \
+        "$repo/swiftcore-macho/scripts/build_compat.sh")
+    if stamp_reuse "$out" "$want"; then
         return 0
     fi
-    if [ -f "$out" ]; then
-        echo "phase2: libswiftcompat rebuilt reason=$([ -f "$stamp" ] && echo "source-sha256 $(cut -c1-12 "$stamp")->${want:0:12}" || echo no-stamp)" >&2
-    fi
-    rm -f "$out" "$stamp"
+    stamp_rebuild_reason "$out" "$want"
+    rm -f "$out" "$(stamp_file "$out")" "$out.source-sha256"
     phase2_prepare_compat_alias_sdk "$sys" "$alias"
     set +e
     W="$dest" SDK="$alias" SRC="$src_dir" MRLIB="$mrlib" LOADER="$loader" \
@@ -1440,7 +1452,7 @@ phase2_fill_x86_libswiftcompat() {
         rm -f "$out"
         return 1
     fi
-    printf '%s\n' "$want" > "$stamp"
+    stamp_write "$out" "$want"
 }
 
 # Stage BASE swift runtime dylibs from the overlay search. Always overwrite

--- a/scripts/x86/phase2.sh
+++ b/scripts/x86/phase2.sh
@@ -196,19 +196,28 @@ fi
 # 2. machorun substrate: loader, darwin, objc4, quartz, tbd
 echo "==== machorun substrate (build.sh all, objc4, quartz, tbd) ===="
 
+phase2_machorun_key() {
+    local product=$1
+    shift
+    local tree
+    tree=$(phase2_git "$W" rev-parse HEAD:machorun 2>/dev/null | tr -d '[:space:]') || tree=missing
+    stamp_key "$product" "$tree" "$@"
+}
+
 ensure_loader() {
     local bin=$MACHORUN/build/machorun
-    local reason
-    reason=$(phase2_source_tree_reason "$W" "$bin")
-    if phase2_is_elf_x86_loader "$bin" && [ -z "$reason" ]; then
-        note machorun-loader satisfied "reused=1"
+    local key
+    key=$(phase2_machorun_key "$bin" loader)
+    if stamp_reuse "$bin" "$key"; then
+        note machorun-loader satisfied "reused=1 stamp=$(stamp_short "$key")"
         return 0
     fi
-    echo "== cold-build loader (CC=$CC${reason:+; reason=$reason})"
+    stamp_rebuild_reason "$bin" "$key"
+    echo "== cold-build loader (CC=$CC)"
     sh "$MACHORUN/scripts/build.sh" loader
     if phase2_is_elf_x86_loader "$bin"; then
-        phase2_write_source_tree_stamp "$W" "$bin" || true
-        note machorun-loader cold-built "${reason:+reason=$reason}"
+        stamp_write "$bin" "$key"
+        note machorun-loader cold-built
         return 0
     fi
     cannot machorun-loader BUILD_LOADER "scripts/build.sh loader did not produce an x86-64 ELF PIE at $bin"
@@ -217,17 +226,18 @@ ensure_loader() {
 
 ensure_darwin() {
     local dylib=$MACHORUN/darwin/usr/lib/libSystem.B.dylib
-    local reason
-    reason=$(phase2_source_tree_reason "$W" "$dylib")
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib" && [ -z "$reason" ]; then
-        note machorun-darwin satisfied "reused=1"
+    local key
+    key=$(phase2_machorun_key "$dylib" darwin)
+    if stamp_reuse "$dylib" "$key"; then
+        note machorun-darwin satisfied "reused=1 stamp=$(stamp_short "$key")"
         return 0
     fi
-    echo "== cold-build darwin userland (x86_64-apple-macos${reason:+; reason=$reason})"
+    stamp_rebuild_reason "$dylib" "$key"
+    echo "== cold-build darwin userland (x86_64-apple-macos)"
     sh "$MACHORUN/scripts/build.sh" darwin
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        phase2_write_source_tree_stamp "$W" "$dylib" || true
-        note machorun-darwin cold-built "${reason:+reason=$reason}"
+    if stamp_expected_kind "$dylib"; then
+        stamp_write "$dylib" "$key"
+        note machorun-darwin cold-built
         return 0
     fi
     cannot machorun-darwin BUILD_DARWIN "libSystem.B.dylib is not X86_64 Mach-O after build.sh darwin ($(file -b "$dylib" 2>/dev/null || echo missing))"
@@ -236,17 +246,18 @@ ensure_darwin() {
 
 ensure_objc4() {
     local dylib=$MACHORUN/darwin/usr/lib/libobjc.A.dylib
-    local reason
-    reason=$(phase2_source_tree_reason "$W" "$dylib")
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib" && [ -z "$reason" ]; then
-        note machorun-objc4 satisfied "reused=1"
+    local key
+    key=$(phase2_machorun_key "$dylib" objc4)
+    if stamp_reuse "$dylib" "$key"; then
+        note machorun-objc4 satisfied "reused=1 stamp=$(stamp_short "$key")"
         return 0
     fi
-    echo "== cold-build objc4 (unblocks the objc fixture CANNOT_BUILD_LIBOBJC_X86${reason:+; reason=$reason})"
+    stamp_rebuild_reason "$dylib" "$key"
+    echo "== cold-build objc4 (unblocks the objc fixture CANNOT_BUILD_LIBOBJC_X86)"
     bash "$MACHORUN/scripts/build_objc4.sh"
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        phase2_write_source_tree_stamp "$W" "$dylib" || true
-        note machorun-objc4 cold-built "${reason:+reason=$reason}"
+    if stamp_expected_kind "$dylib"; then
+        stamp_write "$dylib" "$key"
+        note machorun-objc4 cold-built
         return 0
     fi
     cannot machorun-objc4 BUILD_LIBOBJC_X86 "libobjc.A.dylib is not X86_64 Mach-O after build_objc4.sh"
@@ -255,17 +266,18 @@ ensure_objc4() {
 
 ensure_quartz() {
     local dylib=$MACHORUN/darwin/usr/lib/libquartz.dylib
-    local reason
-    reason=$(phase2_source_tree_reason "$W" "$dylib")
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib" && [ -z "$reason" ]; then
-        note machorun-quartz satisfied "reused=1"
+    local key
+    key=$(phase2_machorun_key "$dylib" quartz)
+    if stamp_reuse "$dylib" "$key"; then
+        note machorun-quartz satisfied "reused=1 stamp=$(stamp_short "$key")"
         return 0
     fi
-    echo "== cold-build quartz${reason:+; reason=$reason}"
+    stamp_rebuild_reason "$dylib" "$key"
+    echo "== cold-build quartz"
     bash "$MACHORUN/scripts/build_quartz.sh"
-    if [ -f "$dylib" ] && phase2_is_x86_macho "$dylib"; then
-        phase2_write_source_tree_stamp "$W" "$dylib" || true
-        note machorun-quartz cold-built "${reason:+reason=$reason}"
+    if stamp_expected_kind "$dylib"; then
+        stamp_write "$dylib" "$key"
+        note machorun-quartz cold-built
         return 0
     fi
     cannot machorun-quartz BUILD_QUARTZ_X86 "libquartz.dylib is not X86_64 Mach-O after build_quartz.sh"
@@ -274,20 +286,18 @@ ensure_quartz() {
 
 ensure_tbd() {
     local tbd=$MACHORUN/sdk/usr/lib/libSystem.tbd
-    local reason
-    reason=$(phase2_source_tree_reason "$W" "$tbd")
-    if [ -s "$tbd" ] && grep -q x86_64 "$tbd" && [ -x "$MACHORUN/build/machorun" ] && [ -z "$reason" ]; then
-        # Idempotent: a non-empty x86_64-macos tbd plus a live loader is enough.
-        if grep -q 'x86_64-macos' "$tbd" 2>/dev/null || grep -q x86_64 "$tbd"; then
-            note machorun-tbd satisfied "reused=1"
-            return 0
-        fi
+    local key
+    key=$(phase2_machorun_key "$tbd" tbd "$MACHORUN/build/machorun")
+    if stamp_reuse "$tbd" "$key" && grep -q x86_64 "$tbd"; then
+        note machorun-tbd satisfied "reused=1 stamp=$(stamp_short "$key")"
+        return 0
     fi
+    stamp_rebuild_reason "$tbd" "$key"
     if ! phase2_is_elf_x86_loader "$MACHORUN/build/machorun"; then
         cannot machorun-tbd GENERATE_TBD "gen_tbd.sh CHECK 1 needs the host ELF loader; loader is missing"
         return 1
     fi
-    echo "== cold-generate .tbd (CHECK 1 against this loader${reason:+; reason=$reason})"
+    echo "== cold-generate .tbd (CHECK 1 against this loader)"
     # CHECK 4 scans every dylib under darwin/usr/lib. An arm64 staged
     # libswiftcompat beside a freshly built x86 libSystem is a mixed-slice
     # coin toss, not a generated stub. Park arm64 dylibs beside (do not
@@ -311,8 +321,8 @@ ensure_tbd() {
     st=$?
     set -e
     if [ "$st" -eq 0 ] && [ -s "$tbd" ]; then
-        phase2_write_source_tree_stamp "$W" "$tbd" || true
-        note machorun-tbd cold-built "${reason:+reason=$reason}"
+        stamp_write "$tbd" "$key"
+        note machorun-tbd cold-built
         return 0
     fi
     tbd_state=missing
@@ -466,11 +476,18 @@ OSMOD=$FE_OUT/os
 
 try_collections() {
     local out=$FE_OUT/collections
-    if [ -f "$out/OrderedCollections.o" ] && phase2_is_x86_macho "$out/OrderedCollections.o"; then
-        note collections-x86 satisfied "mc=$MC"
+    local key tree
+    tree=$(phase2_git "$SC" rev-parse 'HEAD^{tree}' 2>/dev/null | tr -d '[:space:]') || tree=missing
+    key=$(stamp_key "$out/OrderedCollections.o" \
+        "$W/full/foundation/build_collections.sh" \
+        "$W/full/foundation/pinned_inputs.pl" \
+        "$tree" "$TARGET")
+    if stamp_reuse "$out/OrderedCollections.o" "$key"; then
+        note collections-x86 satisfied "mc=$MC stamp=$(stamp_short "$key")"
         COL_OK=1
         return 0
     fi
+    stamp_rebuild_reason "$out/OrderedCollections.o" "$key"
     [ -d "$SC" ] || { cannot collections-x86 PINNED_SWIFT_COLLECTIONS "no $SC"; return 1; }
     [ "$SYSROOT_OK" -eq 1 ] || { cannot collections-x86 NEEDS_X86_SYSROOT "collections compile needs $SYS"; return 1; }
     [ "$LIBSWIFTCORE_X86" -eq 1 ] || {
@@ -484,6 +501,7 @@ try_collections() {
     st=$?
     set -e
     if [ "$st" -eq 0 ] && phase2_is_x86_macho "$out/OrderedCollections.o"; then
+        stamp_write "$out/OrderedCollections.o" "$key"
         note collections-x86 cold-built "mc=$MC"
         COL_OK=1
         return 0
@@ -494,11 +512,17 @@ try_collections() {
 
 try_cshims() {
     local out=$FE_OUT/cshims
-    if [ -f "$out/uuid.o" ] && phase2_is_x86_macho "$out/uuid.o"; then
-        note cshims-x86 satisfied
+    local key tree
+    tree=$(phase2_git "$SF" rev-parse 'HEAD^{tree}' 2>/dev/null | tr -d '[:space:]') || tree=missing
+    key=$(stamp_key "$out/uuid.o" \
+        "$W/full/foundation/build_cshims.sh" \
+        "$tree" "$TARGET")
+    if stamp_reuse "$out/uuid.o" "$key"; then
+        note cshims-x86 satisfied "stamp=$(stamp_short "$key")"
         CSHIMS_OK=1
         return 0
     fi
+    stamp_rebuild_reason "$out/uuid.o" "$key"
     [ -d "$SF" ] || { cannot cshims-x86 PINNED_SWIFT_FOUNDATION "no $SF"; return 1; }
     [ "$SYSROOT_HEADERS" -eq 1 ] || [ "$SYSROOT_OK" -eq 1 ] || {
         cannot cshims-x86 NEEDS_X86_SYSROOT "cshims compile needs $SYS"
@@ -511,6 +535,7 @@ try_cshims() {
     st=$?
     set -e
     if [ "$st" -eq 0 ] && [ -f "$out/uuid.o" ] && phase2_is_x86_macho "$out/uuid.o"; then
+        stamp_write "$out/uuid.o" "$key"
         note cshims-x86 cold-built
         CSHIMS_OK=1
         return 0
@@ -521,11 +546,16 @@ try_cshims() {
 
 try_os_module() {
     local out=$OSMOD
-    if [ -f "$out/os.o" ] && phase2_is_x86_macho "$out/os.o" && [ -f "$out/os.swiftmodule" ]; then
-        note os-module-x86 satisfied "mc=$MC"
+    local key
+    key=$(stamp_key "$out/os.o" \
+        "$W/full/foundation/build_os_module.sh" \
+        "$TARGET")
+    if stamp_reuse "$out/os.o" "$key" && [ -f "$out/os.swiftmodule" ]; then
+        note os-module-x86 satisfied "mc=$MC stamp=$(stamp_short "$key")"
         OS_OK=1
         return 0
     fi
+    stamp_rebuild_reason "$out/os.o" "$key"
     [ "$SYSROOT_OK" -eq 1 ] || {
         cannot os-module-x86 NEEDS_X86_SYSROOT "os.swift @_exported-imports Darwin; needs $SYS"
         return 1
@@ -542,6 +572,7 @@ try_os_module() {
     set -e
     if [ "$st" -eq 0 ] && [ -f "$out/os.o" ] && phase2_is_x86_macho "$out/os.o" \
         && [ -f "$out/os.swiftmodule" ]; then
+        stamp_write "$out/os.o" "$key"
         note os-module-x86 cold-built "mc=$MC"
         OS_OK=1
         return 0
@@ -571,17 +602,27 @@ try_fe_imports() {
 try_fe() {
     local out=$FE_OUT/essentials
     local have_fe=0 have_compat=0
-    if [ -f "$out/FoundationEssentials.o" ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
+    local fe_key compat_key tree
+    tree=$(phase2_git "$SF" rev-parse 'HEAD^{tree}' 2>/dev/null | tr -d '[:space:]') || tree=missing
+    fe_key=$(stamp_key "$out/FoundationEssentials.o" \
+        "$W/full/foundation/build_fe.sh" \
+        "$tree" "$TARGET")
+    compat_key=$(stamp_key "$out/removefile_compat.o" \
+        "$W/full/foundation/removefile_compat.c" \
+        "$TARGET")
+    if stamp_reuse "$out/FoundationEssentials.o" "$fe_key"; then
         have_fe=1
     fi
-    if [ -f "$out/removefile_compat.o" ] && phase2_is_x86_macho "$out/removefile_compat.o"; then
+    if stamp_reuse "$out/removefile_compat.o" "$compat_key"; then
         have_compat=1
     fi
     if [ "$have_fe" -eq 1 ] && [ "$have_compat" -eq 1 ]; then
-        note foundationessentials-x86 satisfied "mc=$MC"
+        note foundationessentials-x86 satisfied "mc=$MC stamp=$(stamp_short "$fe_key")"
         FE_OK=1
         return 0
     fi
+    [ "$have_fe" -eq 1 ] || stamp_rebuild_reason "$out/FoundationEssentials.o" "$fe_key"
+    [ "$have_compat" -eq 1 ] || stamp_rebuild_reason "$out/removefile_compat.o" "$compat_key"
 
     compile_fe_removefile_compat() {
         local cst
@@ -592,6 +633,7 @@ try_fe() {
         set -e
         if [ "$cst" -eq 0 ] && [ -f "$out/removefile_compat.o" ] \
             && phase2_is_x86_macho "$out/removefile_compat.o"; then
+            stamp_write "$out/removefile_compat.o" "$compat_key"
             return 0
         fi
         cannot foundationessentials-x86 BUILD_FE_REMOVEFILE_COMPAT \
@@ -636,6 +678,7 @@ try_fe() {
     st=$?
     set -e
     if [ "$st" -eq 0 ] && phase2_is_x86_macho "$out/FoundationEssentials.o"; then
+        stamp_write "$out/FoundationEssentials.o" "$fe_key"
         compile_fe_removefile_compat || return 1
         note foundationessentials-x86 cold-built "mc=$MC removefile_compat=ok"
         FE_OK=1
@@ -656,16 +699,22 @@ try_fe || true
 echo "==== OpenCombine x86 (beside $OPENCOMBINE_ROOT/export) ===="
 OC_OK=0
 oc_obj=$OPENCOMBINE_ROOT/export-x86_64/artifacts/OpenCombine.o
-if [ -f "$oc_obj" ] && phase2_is_x86_macho "$oc_obj"; then
-    note opencombine-x86 satisfied "mc=$MC"
+oc_key=$(stamp_key "$oc_obj" \
+    "$HERE/build_opencombine.sh" \
+    "$W/full/oracle-opencombine/policy.json" \
+    "$TARGET")
+if stamp_reuse "$oc_obj" "$oc_key"; then
+    note opencombine-x86 satisfied "mc=$MC stamp=$(stamp_short "$oc_key")"
     OC_OK=1
 else
+    stamp_rebuild_reason "$oc_obj" "$oc_key"
     set +e
     W="$W" SYS="$SYS" OPENCOMBINE_ROOT="$OPENCOMBINE_ROOT" MC="$MC" \
         bash "$HERE/build_opencombine.sh"
     st=$?
     set -e
     if [ "$st" -eq 0 ] && [ -f "$oc_obj" ] && phase2_is_x86_macho "$oc_obj"; then
+        stamp_write "$oc_obj" "$oc_key"
         note opencombine-x86 cold-built "mc=$MC"
         OC_OK=1
     else
@@ -693,12 +742,16 @@ BASE_MRROOT_OK=0
 [ "$BASE_MRROOT" != "$ARM_BASE_MRROOT" ] || {
     cannot mrroot-base-x86 MRROOT_COLLIDES_ARM64 "x86 base mrroot path equals arm64 scratch/mrroot"
 }
-if [ -x "$BASE_MRROOT/machorun" ] && phase2_is_elf_x86_loader "$BASE_MRROOT/machorun" \
+BASE_KEY=$(stamp_key "$BASE_MRROOT/machorun" \
+    "$MACHORUN/build/machorun" \
+    "${x86_core:-missing-core}")
+if stamp_reuse "$BASE_MRROOT/machorun" "$BASE_KEY" \
     && [ -f "$BASE_MRROOT/darwin/usr/lib/swift/libswiftCore.dylib" ] \
     && phase2_is_x86_macho "$BASE_MRROOT/darwin/usr/lib/swift/libswiftCore.dylib"; then
-    note mrroot-base-x86 satisfied
+    note mrroot-base-x86 satisfied "stamp=$(stamp_short "$BASE_KEY")"
     BASE_MRROOT_OK=1
 else
+    stamp_rebuild_reason "$BASE_MRROOT/machorun" "$BASE_KEY"
     echo "== staging $BASE_MRROOT from machorun darwin + x86 libswiftCore"
     phase2_stage_x86_base_mrroot \
         "$BASE_MRROOT" \
@@ -709,6 +762,7 @@ else
         && [ -f "$BASE_MRROOT/darwin/usr/lib/swift/libswiftCore.dylib" ] \
         && phase2_is_x86_macho "$BASE_MRROOT/darwin/usr/lib/swift/libswiftCore.dylib"; then
         note mrroot-base-x86 cold-built
+        stamp_write "$BASE_MRROOT/machorun" "$BASE_KEY"
         BASE_MRROOT_OK=1
     elif [ "$LIBSWIFTCORE_X86" -ne 1 ]; then
         cannot mrroot-base-x86 BUILD_LIBSWIFTCORE_X86 \
@@ -1116,20 +1170,21 @@ if [ "$UD_GUEST_ITEM_OK" -eq 1 ]; then
     esac
 fi
 
-# Rung a does not invoke build_full.sh, whose `-nt` copy is what refreshes
+# Rung a does not invoke build_full.sh, whose stamp copy is what refreshes
 # $MRROOT/machorun for rungs b/c. The mrroot-x86 "satisfied" path also skips
 # the copy. Refresh here so rung a execs the loader just built, not a stale
 # $MRROOT/machorun from an earlier tree (the DF2 exit-74 vs manual-run split).
-echo "==== run-root loader refresh (build_full -nt rule, before rung a) ===="
+echo "==== run-root loader refresh (stamp, before rung a) ===="
 if [ -x "$MACHORUN/build/machorun" ] && [ -d "$MRROOT" ]; then
-    if [ ! -x "$MRROOT/machorun" ] \
-        || [ "$MACHORUN/build/machorun" -nt "$MRROOT/machorun" ]
-    then
+    loader_key=$(stamp_key "$MRROOT/machorun" "$MACHORUN/build/machorun")
+    if stamp_reuse "$MRROOT/machorun" "$loader_key"; then
+        echo "  $MRROOT/machorun reused stamp=$(stamp_short "$loader_key") sha256=$(sha256sum "$MRROOT/machorun" | awk '{print $1}')"
+    else
+        stamp_rebuild_reason "$MRROOT/machorun" "$loader_key"
         cp -f "$MACHORUN/build/machorun" "$MRROOT/machorun"
         chmod a+x "$MRROOT/machorun"
+        stamp_write "$MRROOT/machorun" "$loader_key"
         echo "  refreshed $MRROOT/machorun from $MACHORUN/build/machorun sha256=$(sha256sum "$MRROOT/machorun" | awk '{print $1}')"
-    else
-        echo "  $MRROOT/machorun is current sha256=$(sha256sum "$MRROOT/machorun" | awk '{print $1}')"
     fi
 fi
 

--- a/scripts/x86/stamp.inc
+++ b/scripts/x86/stamp.inc
@@ -1,0 +1,153 @@
+# scripts/x86/stamp.inc -- one reuse library for every built product.
+# POSIX sh (sourced). No site may reuse an artefact because the path exists.
+#
+#   stamp_key <out> <input>...   sha256 of file CONTENTS and any argv string
+#   stamp_reuse <out> <key>      0 iff out exists, is the expected kind, and
+#                                <out>.inputs-sha256 equals key. Prints
+#                                `reused=1 stamp=<12>` to stderr on success.
+#   stamp_write <out> <key>      write <out>.inputs-sha256
+#   stamp_rebuild_reason <out> <key>
+#                                prints `rebuilt reason=no-stamp` or
+#                                `rebuilt reason=inputs <old12>-><new12>` to stderr
+#
+# Expected kind: x86_64 Mach-O (llvm-otool-18 MH_MAGIC_64 X86_64), x86-64 ELF
+# PIE/shared object, a non-empty .tbd, or a directory (git checkout). A Mach-O
+# of the wrong arch never reuses.
+
+if [ -n "${STAMP_INC:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+STAMP_INC=1
+
+stamp_short() {
+    printf '%s' "$1" | cut -c1-12
+}
+
+stamp_file() {
+    printf '%s.inputs-sha256\n' "$1"
+}
+
+# Hash inputs. Regular files contribute CONTENT (not the path). Anything else
+# (missing path, directory, flag, git tree, argv) contributes the string.
+stamp_key() {
+    if [ "$#" -lt 1 ]; then
+        printf 'stamp_key: usage: stamp_key <out> <input>...\n' >&2
+        return 2
+    fi
+    shift
+    if [ "$#" -lt 1 ]; then
+        printf 'stamp_key: need at least one input\n' >&2
+        return 2
+    fi
+    {
+        for _stamp_arg in "$@"; do
+            if [ -f "$_stamp_arg" ] && [ ! -L "$_stamp_arg" ]; then
+                printf 'F '
+                sha256sum < "$_stamp_arg"
+            elif [ -f "$_stamp_arg" ]; then
+                printf 'F '
+                sha256sum < "$_stamp_arg"
+            else
+                printf 'S %s\n' "$_stamp_arg"
+            fi
+        done
+    } | sha256sum | awk '{ print $1 }'
+}
+
+stamp_expected_kind() {
+    _stamp_f=$1
+    if [ -d "$_stamp_f" ]; then
+        return 0
+    fi
+    if [ ! -f "$_stamp_f" ]; then
+        return 1
+    fi
+    case "$_stamp_f" in
+        *.tbd)
+            [ -s "$_stamp_f" ]
+            return $?
+            ;;
+    esac
+    if command -v llvm-otool-18 >/dev/null 2>&1; then
+        if llvm-otool-18 -hv "$_stamp_f" 2>/dev/null | grep -Eq 'MH_MAGIC_64[[:space:]]+X86_64'; then
+            return 0
+        fi
+        if llvm-otool-18 -hv "$_stamp_f" 2>/dev/null | grep -q 'MH_MAGIC_64'; then
+            return 1
+        fi
+    fi
+    _stamp_file=$(file -b "$_stamp_f" 2>/dev/null || true)
+    case "$_stamp_file" in
+        *"Mach-O 64-bit x86_64"*) return 0 ;;
+        *"Mach-O 64-bit arm64"*|*"Mach-O 64-bit ARM64"*) return 1 ;;
+        *"ELF 64-bit LSB pie executable, x86-64"*) return 0 ;;
+        *"ELF 64-bit LSB executable, x86-64"*) return 0 ;;
+        *"ELF 64-bit LSB shared object, x86-64"*) return 0 ;;
+    esac
+    return 1
+}
+
+# 0 = reuse. Prints the reuse line to stderr. Does not print on miss so the
+# caller can emit rebuilt reason= after deciding to rebuild.
+stamp_reuse() {
+    _stamp_out=$1
+    _stamp_key=$2
+    _stamp_sf=$(stamp_file "$_stamp_out")
+    if [ ! -e "$_stamp_out" ]; then
+        return 1
+    fi
+    if ! stamp_expected_kind "$_stamp_out"; then
+        return 1
+    fi
+    if [ ! -f "$_stamp_sf" ]; then
+        return 1
+    fi
+    _stamp_have=$(tr -d '[:space:]' < "$_stamp_sf")
+    if [ -z "$_stamp_have" ] || [ "$_stamp_have" != "$_stamp_key" ]; then
+        return 1
+    fi
+    printf 'reused=1 stamp=%s\n' "$(stamp_short "$_stamp_key")" >&2
+    return 0
+}
+
+stamp_rebuild_reason() {
+    _stamp_out=$1
+    _stamp_key=$2
+    _stamp_sf=$(stamp_file "$_stamp_out")
+    if [ ! -f "$_stamp_sf" ]; then
+        printf 'rebuilt reason=no-stamp\n' >&2
+        return 0
+    fi
+    _stamp_old=$(tr -d '[:space:]' < "$_stamp_sf")
+    if [ -z "$_stamp_old" ]; then
+        printf 'rebuilt reason=no-stamp\n' >&2
+        return 0
+    fi
+    printf 'rebuilt reason=inputs %s->%s\n' \
+        "$(stamp_short "$_stamp_old")" "$(stamp_short "$_stamp_key")" >&2
+}
+
+stamp_write() {
+    _stamp_out=$1
+    _stamp_key=$2
+    _stamp_sf=$(stamp_file "$_stamp_out")
+    mkdir -p "$(dirname "$_stamp_sf")"
+    printf '%s\n' "$_stamp_key" > "$_stamp_sf"
+}
+
+# One line the cycle runner greps. status=reused|rebuilt|cannot
+stamp_stage_line() {
+    _stamp_name=$1
+    _stamp_status=$2
+    _stamp_key=$3
+    _stamp_product=$4
+    _stamp_sha=absent
+    if [ -f "$_stamp_product" ]; then
+        _stamp_sha=$(sha256sum "$_stamp_product" | awk '{ print substr($1,1,12) }')
+    elif [ -d "$_stamp_product" ]; then
+        _stamp_sha=$(printf '%s\n' "$_stamp_product" | sha256sum | awk '{ print substr($1,1,12) }')
+    fi
+    printf 'STAGE %s status=%s key=%s product=%s sha256=%s\n' \
+        "$_stamp_name" "$_stamp_status" "$(stamp_short "$_stamp_key")" \
+        "$_stamp_product" "$_stamp_sha"
+}

--- a/scripts/x86/test_no_existence_reuse.py
+++ b/scripts/x86/test_no_existence_reuse.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Fail if a producer reuses an artefact because the path exists.
+
+Scans scripts/x86/*.inc, scripts/x86/*.sh, full/scripts/build_full.sh for
+if-blocks gated by `[ -f` / `[ -e` / `phase2_is_x86_macho` that `return 0`
+(or set a skip-ok flag) without calling `stamp_reuse` in the same then-block.
+
+Also refuses live `-nt` freshness gates in those files (mtime is not a key).
+The stub-list-vs-dylib CANNOT in ud_guest.inc is a staleness refusal, not reuse.
+
+Usage: python3 scripts/x86/test_no_existence_reuse.py
+       bash scripts/x86/test_no_existence_reuse.sh
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCAN = [
+    *sorted((ROOT / "scripts" / "x86").glob("*.inc")),
+    *sorted((ROOT / "scripts" / "x86").glob("*.sh")),
+    ROOT / "full" / "scripts" / "build_full.sh",
+]
+SKIP_NAMES = {
+    "test_no_existence_reuse.sh",
+    "test_no_existence_reuse.py",
+    "test_phase2.sh",
+    "test_gen_swift_tbd.sh",
+    "test_stamp.sh",
+}
+
+REUSE_COND = re.compile(
+    r"""(?:
+        \[\s*-f\s+ |
+        \[\s*-e\s+ |
+        phase2_is_x86_macho\s+
+    )""",
+    re.VERBOSE,
+)
+NEG_EXIST = re.compile(r"\[\s*!\s*-[ef]\b")
+NEG_MACHO = re.compile(r"!\s*phase2_is_x86_macho")
+POST_BUILD = re.compile(r"\$(?:st|cst|rc)\b|exit\s+\$")
+NT_CODE = re.compile(r"""[^\n#]*-nt\s+""")
+SKIP_OK = re.compile(r"\b(?:darwin_ok|host_ok|already)\s*=\s*1\b")
+PRODUCT_HINT = re.compile(
+    r"\.(?:o|dylib|so|tbd)\b|/machorun\b|libSystem|libobjc|libquartz|"
+    r"FoundationEssentials|removefile_compat|OrderedCollections|uuid\.o|os\.o"
+)
+FINDER = re.compile(r"""printf '%s\\n'""")
+SHADOW = re.compile(r"would shadow|skip arm64|skip non-x86")
+ALLOW_NT = re.compile(r"phase2_cftest_stub_list_stale")
+
+
+def strip_comments(line: str) -> str:
+    in_s = in_d = False
+    out = []
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if c == "'" and not in_d:
+            in_s = not in_s
+            out.append(c)
+        elif c == '"' and not in_s:
+            in_d = not in_d
+            out.append(c)
+        elif c == "#" and not in_s and not in_d:
+            break
+        else:
+            out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def then_block(lines: list[str], start: int) -> tuple[str, int, int]:
+    """Return (body, start_line_1based, end_line_1based) of the then-block."""
+    depth = 0
+    body: list[str] = []
+    i = start
+    seen_then = False
+    while i < len(lines):
+        raw = lines[i]
+        code = strip_comments(raw)
+        tokens = re.findall(
+            r"\b(?:if|then|fi|else|elif)\b",
+            code,
+        )
+        for tok in tokens:
+            if tok == "if":
+                depth += 1
+            elif tok == "then":
+                if depth == 1 and not seen_then:
+                    seen_then = True
+            elif tok in ("else", "elif") and depth == 1:
+                return "\n".join(body), start + 1, i + 1
+            elif tok == "fi":
+                depth -= 1
+                if depth == 0:
+                    return "\n".join(body), start + 1, i + 1
+        if seen_then and depth >= 1:
+            body.append(code)
+        i += 1
+    return "\n".join(body), start + 1, i
+
+
+def condition_of(lines: list[str], start: int) -> str:
+    parts = []
+    i = start
+    while i < len(lines):
+        code = strip_comments(lines[i])
+        parts.append(code)
+        if re.search(r"\bthen\b", code):
+            break
+        i += 1
+    return " ".join(parts)
+
+
+def scan_file(path: pathlib.Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    try:
+        rel = path.relative_to(ROOT).as_posix()
+    except ValueError:
+        rel = str(path)
+    hits: list[str] = []
+    i = 0
+    func = ""
+    while i < len(lines):
+        code = strip_comments(lines[i])
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{", code.strip())
+        if m:
+            func = m.group(1)
+        if func == "phase2_cftest_stub_list_stale" or ALLOW_NT.search(code):
+            i += 1
+            continue
+        if NT_CODE.search(code) and "-nt" in code:
+            hits.append(f"{rel}:{i + 1}: live -nt freshness gate (mtime is not a stamp)")
+        if re.search(r"^\s*if\b", code) or re.search(r";\s*if\b", code):
+            cond = condition_of(lines, i)
+            if (
+                REUSE_COND.search(cond)
+                and not NEG_EXIST.search(cond)
+                and not NEG_MACHO.search(cond)
+                and not POST_BUILD.search(cond)
+                and (
+                    PRODUCT_HINT.search(cond)
+                    or "phase2_is_x86_macho" in cond
+                )
+            ):
+                body, start_ln, _end = then_block(lines, i)
+                if "stamp_reuse" not in body and "stamp_reuse" not in cond:
+                    if FINDER.search(body) or SHADOW.search(body):
+                        i += 1
+                        continue
+                    if "stamp_write" in body:
+                        i += 1
+                        continue
+                    if re.search(r"\breturn 0\b", body) or SKIP_OK.search(body):
+                        if not re.search(
+                            r"\b(?:clang|swiftc|bash |sh |ld64|ninja|cmake|git clone)\b",
+                            body,
+                        ):
+                            hits.append(
+                                f"{rel}:{start_ln}: existence/macho skip without stamp_reuse"
+                            )
+        i += 1
+    return hits
+
+
+def main() -> int:
+    hits: list[str] = []
+    scanned = 0
+    for path in SCAN:
+        if not path.is_file() or path.name in SKIP_NAMES:
+            continue
+        scanned += 1
+        hits.extend(scan_file(path))
+    if hits:
+        print("FAIL: existence-reuse without stamp_reuse:", file=sys.stderr)
+        for h in hits:
+            print(h, file=sys.stderr)
+        return 1
+    print(f"PASS: no existence-reuse skip without stamp_reuse ({scanned} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/x86/test_no_existence_reuse.sh
+++ b/scripts/x86/test_no_existence_reuse.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Wrapper so test_phase2.sh can `bash scripts/x86/test_no_existence_reuse.sh`.
+# Also proves the scanner fails a planted existence-reuse skip.
+set -euo pipefail
+ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)
+
+python3 "$ROOT/scripts/x86/test_no_existence_reuse.py"
+
+PLANT=$(mktemp -d /tmp/existence-reuse-plant.XXXXXX)
+cleanup() { rm -rf "$PLANT"; }
+trap cleanup EXIT
+cat > "$PLANT/bad.inc" <<'EOF'
+try_product() {
+    local dest=$1
+    if [ -f "$dest" ] && phase2_is_x86_macho "$dest"; then
+        return 0
+    fi
+    clang-18 -c src.c -o "$dest"
+}
+EOF
+if python3 - <<PY
+from pathlib import Path
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location(
+    "scan", "$ROOT/scripts/x86/test_no_existence_reuse.py"
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+hits = mod.scan_file(Path("$PLANT/bad.inc"))
+sys.exit(0 if hits else 1)
+PY
+then
+    echo "PASS: scanner names a planted existence-reuse skip"
+else
+    echo "FAIL: scanner missed planted if [ -f ] && phase2_is_x86_macho; return 0" >&2
+    exit 1
+fi

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -65,6 +65,14 @@ expect_file "$X86_ORACLE"
 
 echo "== bash -n"
 for s in "$PHASE2" "$STAGE" "$OC" "$COMMON" "$ROOT/scripts/x86/test_phase2.sh" \
+    "$ROOT/scripts/x86/stamp.inc" \
+    "$ROOT/scripts/x86/test_stamp.sh" \
+    "$ROOT/scripts/x86/test_no_existence_reuse.sh" \
+    "$ROOT/scripts/ops/x86_cycle.sh" \
+    "$ROOT/scripts/ops/run_box.sh" \
+    "$ROOT/scripts/ops/premerge.sh" \
+    "$ROOT/scripts/ops/test_ops.sh" \
+    "$ROOT/scripts/ops/common.inc" \
     "$ROOT/full/foundation/fe_sysroot_measurement.inc" \
     "$ROOT/full/dispatch/swift_linux_lib.inc" \
     "$ROOT/full/urltransport/build_host_helper.sh" \
@@ -102,48 +110,31 @@ expect_grep 'Column 2 is cputype' "$COMMON" "x86 Mach-O check documents cputype 
 expect_grep 'RUNG_SCOREBOARD' "$PHASE2" "RUNG_SCOREBOARD"
 expect_grep 'ENV_PREPARE_SUMMARY' "$PHASE2" "ENV_PREPARE_SUMMARY"
 expect_grep 'never overwrite' "$PHASE2" "arm64 overwrite refusal in header"
-expect_grep 'phase2_source_tree_reason' "$PHASE2" \
-    "machorun substrate reuse consults HEAD:machorun stamp"
-expect_grep 'phase2_write_source_tree_stamp' "$PHASE2" \
-    "cold-build writes .source-tree next to the product"
+expect_grep 'stamp_reuse' "$PHASE2" \
+    "machorun substrate reuse goes through stamp_reuse"
+expect_grep 'stamp_write' "$PHASE2" \
+    "cold-build writes <out>.inputs-sha256"
 expect_grep 'reused=1' "$PHASE2" "satisfied loader/darwin/objc4/quartz/tbd print reused=1"
-expect_grep ':+reason=' "$PHASE2" "cold-built prints reason=source-tree or no-stamp"
+expect_grep 'stamp_rebuild_reason' "$PHASE2" "cold-built prints rebuilt reason= via stamp.inc"
 
-echo "== source-tree stamp helpers (HEAD:machorun, not existence)"
-# shellcheck source=common.inc
-. "$COMMON"
-STAMP_FIX=$(mktemp -d /tmp/phase2-source-tree.XXXXXX)
-mkdir -p "$STAMP_FIX/machorun/src" "$STAMP_FIX/machorun/build"
-printf 'int x;\n' > "$STAMP_FIX/machorun/src/util.c"
-git -C "$STAMP_FIX" -c init.defaultBranch=main init -q >/dev/null
-git -C "$STAMP_FIX" add machorun
-git -C "$STAMP_FIX" -c user.email=phase2-test@example.com -c user.name=phase2-test \
-    commit -q -m init
-LIVE_TREE=$(phase2_git "$STAMP_FIX" rev-parse HEAD:machorun)
-LOADER_BIN=$STAMP_FIX/machorun/build/machorun
-reason=$(phase2_source_tree_reason "$STAMP_FIX" "$LOADER_BIN")
-if [ "$reason" = no-stamp ]; then
-    ok "missing stamp is reason=no-stamp"
+echo "== stamp.inc (content hash, not existence)"
+# shellcheck source=stamp.inc
+. "$ROOT/scripts/x86/stamp.inc"
+STAMP_FIX=$(mktemp -d /tmp/phase2-stamp-inc.XXXXXX)
+python3 - "$STAMP_FIX/loader" <<'PY'
+import pathlib, struct, sys
+pathlib.Path(sys.argv[1]).parent.mkdir(parents=True, exist_ok=True)
+# ELF-looking is not required here; stamp unit test covers Mach-O. Touch a file
+# and rely on test_stamp.sh for kind checks.
+pathlib.Path(sys.argv[1]).write_bytes(b"not-a-product")
+PY
+printf 'input\n' > "$STAMP_FIX/src.c"
+key=$(stamp_key "$STAMP_FIX/loader" "$STAMP_FIX/src.c")
+if stamp_reuse "$STAMP_FIX/loader" "$key" 2>/dev/null; then
+    die_test "existence without .inputs-sha256 reused"
 else
-    die_test "missing stamp expected no-stamp, got: $reason"
+    ok "missing .inputs-sha256 does not reuse"
 fi
-phase2_write_source_tree_stamp "$STAMP_FIX" "$LOADER_BIN"
-reason=$(phase2_source_tree_reason "$STAMP_FIX" "$LOADER_BIN")
-if [ -z "$reason" ]; then
-    ok "matching HEAD:machorun stamp is reusable"
-else
-    die_test "matching stamp should be empty reason, got: $reason"
-fi
-printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > "$(phase2_source_tree_stamp_path "$LOADER_BIN")"
-reason=$(phase2_source_tree_reason "$STAMP_FIX" "$LOADER_BIN")
-case "$reason" in
-    source-tree\ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa→"$LIVE_TREE")
-        ok "stale stamp is source-tree old→HEAD:machorun ($reason)"
-        ;;
-    *)
-        die_test "stale stamp expected source-tree old→$LIVE_TREE, got: $reason"
-        ;;
-esac
 rm -rf "$STAMP_FIX"
 
 echo "== denominators (committed runners, not invented)"
@@ -1621,7 +1612,7 @@ expect_grep 'build_host_bridge.sh' "$UDINC" \
 expect_grep 'OpenDispatchBridge.c' "$UDINC" \
     "ud-guest-dispatch links the Darwin OpenDispatch facade"
 expect_grep 'run-root loader refresh' "$PHASE2" \
-    "phase2 refreshes \$MRROOT/machorun before rung a (build_full -nt rule)"
+    "phase2 refreshes \$MRROOT/machorun before rung a (stamp, not -nt)"
 expect_grep 'ud_dispatch_loader_line' "$ROOT/foundation-macho/scripts/run_ud_guest.sh" \
     "run_ud_guest.sh prints loader sha256 on == binary"
 expect_grep 'LD_PRELOAD' "$ROOT/foundation-macho/scripts/ud_dispatch_run.inc" \
@@ -2082,7 +2073,7 @@ else
     die_test "could not emit an x86 libCFTest.dylib fixture"
 fi
 
-echo "== ud-guest-dispatch reuses an ELF host bridge and links the Darwin facade"
+echo "== ud-guest-dispatch stamps the host bridge; unstamped ELF is not reused"
 DISP_HOST_DIR=$UDWORK/existing-host
 mkdir -p "$DISP_HOST_DIR"
 echo 'int openui_dispatch_host_v1_runtime_check(void){return 0;}' \
@@ -2100,14 +2091,15 @@ case "$disp_report" in
         drun=${drun%% *}
         dsha=${disp_report##*sha256=}
         want=$(sha256sum "$wt/lib/libOpenDispatch.dylib" | awk '{print $1}')
-        if [ "$dhost" = "$DISP_HOST_DIR/libOpenDispatchHost.so" ] \
+        if [ "$dhost" = "$wt/host/libOpenDispatchHost.so" ] \
+            && [ "$dhost" != "$DISP_HOST_DIR/libOpenDispatchHost.so" ] \
             && [ "$drun" = "$wt/lib/libOpenDispatch.dylib" ] \
             && [ "$dsha" = "$want" ] \
             && [ "$(llvm-otool-18 -D "$drun" | tail -n 1)" = \
                 /usr/lib/libOpenDispatch.dylib ] \
             && llvm-nm-18 -u "$drun" | grep -q '_glibc_openui_dispatch_host_v1_get_global_queue'
         then
-            ok "ensure_dispatch reuses ELF host and links Darwin LC_ID /usr/lib/libOpenDispatch.dylib"
+            ok "ensure_dispatch rebuilds unstamped ELF and links Darwin LC_ID /usr/lib/libOpenDispatch.dylib"
         else
             die_test "ensure_dispatch dest mismatch: '$disp_report' id=$(llvm-otool-18 -D "$drun" 2>/dev/null | tail -n 1)"
         fi
@@ -2292,6 +2284,23 @@ else
     W=$saved_w
     HOME=$saved_home
     rm -rf "$PROV_DEST" "$STALE_DEST" "$REFUSE_DEST" "$EXTRACT_W"
+fi
+
+echo "== stamp library + existence-reuse + ops"
+if bash "$ROOT/scripts/x86/test_stamp.sh"; then
+    ok "test_stamp.sh"
+else
+    die_test "test_stamp.sh"
+fi
+if bash "$ROOT/scripts/x86/test_no_existence_reuse.sh"; then
+    ok "test_no_existence_reuse.sh"
+else
+    die_test "test_no_existence_reuse.sh"
+fi
+if bash "$ROOT/scripts/ops/test_ops.sh"; then
+    ok "test_ops.sh"
+else
+    die_test "test_ops.sh"
 fi
 
 echo "== gen_swift_tbd.sh round-trip (libswiftCore + overlays)"

--- a/scripts/x86/test_stamp.sh
+++ b/scripts/x86/test_stamp.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Unit teeth for scripts/x86/stamp.inc. Fake x86_64 Mach-O via a 32-byte header.
+set -euo pipefail
+ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)
+# shellcheck source=stamp.inc
+. "$ROOT/scripts/x86/stamp.inc"
+
+pass=0
+fail=0
+ok() { echo "PASS: $*"; pass=$((pass + 1)); }
+die_test() { echo "FAIL: $*" >&2; fail=$((fail + 1)); }
+
+WORK=$(mktemp -d /tmp/stamp-inc.XXXXXX)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# mach_header_64: MH_MAGIC_64, CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL, MH_OBJECT
+write_x86_macho() {
+    python3 - "$1" <<'PY'
+import pathlib, struct, sys
+path = pathlib.Path(sys.argv[1])
+path.write_bytes(struct.pack("<IiiIIII", 0xFEEDFACF, 0x01000007, 3, 1, 0, 0, 0))
+PY
+}
+
+write_x86_macho "$WORK/prod.dylib"
+printf 'src-a\n' > "$WORK/a.c"
+printf 'src-b\n' > "$WORK/b.c"
+
+key=$(stamp_key "$WORK/prod.dylib" "$WORK/a.c" "$WORK/b.c" argv-flag)
+[ "${#key}" -eq 64 ] && ok "stamp_key is 64 hex" || die_test "stamp_key len ${#key}"
+
+if stamp_reuse "$WORK/prod.dylib" "$key" 2>"$WORK/err"; then
+    die_test "reuse without stamp file"
+else
+    ok "no-stamp does not reuse"
+fi
+stamp_rebuild_reason "$WORK/prod.dylib" "$key" 2>"$WORK/reason"
+grep -qx 'rebuilt reason=no-stamp' "$WORK/reason" \
+    && ok "rebuild reason=no-stamp" \
+    || die_test "reason=$(cat "$WORK/reason")"
+
+stamp_write "$WORK/prod.dylib" "$key"
+if stamp_reuse "$WORK/prod.dylib" "$key" 2>"$WORK/err"; then
+    grep -q 'reused=1 stamp=' "$WORK/err" && ok "matching stamp reuses" \
+        || die_test "reuse stderr=$(cat "$WORK/err")"
+else
+    die_test "matching stamp should reuse"
+fi
+
+printf 'src-a-changed\n' > "$WORK/a.c"
+key2=$(stamp_key "$WORK/prod.dylib" "$WORK/a.c" "$WORK/b.c" argv-flag)
+[ "$key" != "$key2" ] && ok "content change flips key" || die_test "key unchanged after content edit"
+if stamp_reuse "$WORK/prod.dylib" "$key2" 2>"$WORK/err"; then
+    die_test "stale stamp reused"
+else
+    ok "stale stamp does not reuse"
+fi
+stamp_rebuild_reason "$WORK/prod.dylib" "$key2" 2>"$WORK/reason"
+grep -q 'rebuilt reason=inputs ' "$WORK/reason" \
+    && ok "rebuild reason=inputs old->new" \
+    || die_test "reason=$(cat "$WORK/reason")"
+
+# Existence alone is not enough: matching macho, wrong stamp.
+write_x86_macho "$WORK/stale.dylib"
+printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n' \
+    > "$WORK/stale.dylib.inputs-sha256"
+if stamp_reuse "$WORK/stale.dylib" "$key2" 2>/dev/null; then
+    die_test "existence+macho reused with wrong stamp"
+else
+    ok "existence+macho without matching stamp does not reuse"
+fi
+
+# argv string is part of the key
+k_flag=$(stamp_key "$WORK/prod.dylib" "$WORK/a.c" "$WORK/b.c" other-flag)
+[ "$key2" != "$k_flag" ] && ok "argv string is in the key" || die_test "argv ignored"
+
+# Wrong-arch Mach-O never reuses, even with a matching stamp file.
+python3 - "$WORK/arm.dylib" <<'PY'
+import pathlib, struct, sys
+# MH_MAGIC_64, CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL, MH_DYLIB
+pathlib.Path(sys.argv[1]).write_bytes(struct.pack("<IiiIIII", 0xFEEDFACF, 0x0100000C, 0, 6, 0, 0, 0))
+PY
+stamp_write "$WORK/arm.dylib" "$key2"
+if stamp_reuse "$WORK/arm.dylib" "$key2" 2>/dev/null; then
+    die_test "wrong-arch Mach-O reused"
+else
+    ok "wrong-arch Mach-O does not reuse"
+fi
+
+echo "test_stamp: pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/x86/ud_guest.inc
+++ b/scripts/x86/ud_guest.inc
@@ -375,8 +375,13 @@ phase2_ud_guest_find_x86_dylib() {
 phase2_ud_guest_ensure_swiftcompat() {
     local repo=$1 sys=$2 ud_w=$3 mrlib=$4 loader=$5
     local dest=$ud_w/lib/libswiftcompat.dylib
-    local found src_dir
+    local found src_dir want
     mkdir -p "$ud_w/lib"
+    src_dir=$repo/swiftcore-macho/sdk/compat
+    want=$(stamp_key "$dest" \
+        "$src_dir/swiftcompat.c" \
+        "$src_dir/shim.cpp" \
+        "$repo/swiftcore-macho/scripts/build_compat.sh")
     found=$(phase2_ud_guest_find_x86_dylib libswiftcompat.dylib \
         "${UD_SWIFTCOMPAT_DYLIB:-}" \
         "$dest" \
@@ -385,9 +390,11 @@ phase2_ud_guest_ensure_swiftcompat() {
         || true)
     if [ -n "$found" ]; then
         [ "$found" = "$dest" ] || cp -a "$found" "$dest"
-        return 0
+        if stamp_reuse "$dest" "$want"; then
+            return 0
+        fi
+        stamp_rebuild_reason "$dest" "$want"
     fi
-    src_dir=$repo/swiftcore-macho/sdk/compat
     if [ ! -f "$src_dir/swiftcompat.c" ] || [ ! -f "$src_dir/shim.cpp" ]; then
         phase2_ud_guest_cannot LIBSWIFTCOMPAT libswiftcompat.dylib \
             "no x86_64 Mach-O and swiftcore-macho/sdk/compat sources missing"
@@ -418,6 +425,7 @@ phase2_ud_guest_ensure_swiftcompat() {
         rm -f "$log"
         return 1
     fi
+    stamp_write "$dest" "$want"
     rm -f "$log"
 }
 
@@ -433,6 +441,13 @@ phase2_ud_guest_ensure_cf_checkout() {
     local cloner=$repo/.cursor/clone-pinned-repo.sh
     local live_commit live_tree tree_root lock_dir lock log st
     local sources=$dest/$PHASE2_UD_GUEST_CF_SOURCES_REL
+    local key
+    key=$(stamp_key "$dest" "$commit" "$tree" "$origin")
+
+    if stamp_reuse "$dest" "$key" \
+        && [ -f "$sources/CFRuntime.c" ] && [ -f "$sources/CFPreferences.c" ]; then
+        return 0
+    fi
 
     if [ -e "$dest" ]; then
         if [ -d "$dest/.git" ]; then
@@ -440,6 +455,8 @@ phase2_ud_guest_ensure_cf_checkout() {
             live_tree=$(git -c "safe.directory=$dest" -C "$dest" rev-parse 'HEAD^{tree}' 2>/dev/null || true)
             if [ "$live_commit" = "$commit" ] && [ "$live_tree" = "$tree" ]; then
                 if [ -f "$sources/CFRuntime.c" ] && [ -f "$sources/CFPreferences.c" ]; then
+                    stamp_write "$dest" "$key"
+                    stamp_reuse "$dest" "$key" && return 0
                     return 0
                 fi
                 phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
@@ -507,6 +524,7 @@ phase2_ud_guest_ensure_cf_checkout() {
             "no x86_64 Mach-O. pinned CF checkout $commit at $dest is missing $PHASE2_UD_GUEST_CF_SOURCES_REL. Will not invent a stub dylib."
         return 1
     fi
+    stamp_write "$dest" "$key"
     return 0
 }
 
@@ -536,14 +554,22 @@ phase2_ud_guest_ensure_icu_checkout() {
     local origin=$PHASE2_UD_GUEST_ICU_REPO
     local cloner=$repo/.cursor/clone-pinned-repo.sh
     local live_commit live_tree lock_dir lock log st include
+    local key
 
     include=$dest/icuSources/include
+    key=$(stamp_key "$dest" "$commit" "$tree" "$origin")
+    if stamp_reuse "$dest" "$key" && [ -d "$include/_foundation_unicode" ]; then
+        return 0
+    fi
+
     if [ -e "$dest" ]; then
         if [ -d "$dest/.git" ]; then
             live_commit=$(git -c "safe.directory=$dest" -C "$dest" rev-parse HEAD 2>/dev/null || true)
             live_tree=$(git -c "safe.directory=$dest" -C "$dest" rev-parse 'HEAD^{tree}' 2>/dev/null || true)
             if [ "$live_commit" = "$commit" ] && [ "$live_tree" = "$tree" ]; then
                 if [ -d "$include/_foundation_unicode" ]; then
+                    stamp_write "$dest" "$key"
+                    stamp_reuse "$dest" "$key" && return 0
                     return 0
                 fi
                 phase2_ud_guest_cannot LIBCFTEST libCFTest.dylib \
@@ -608,6 +634,7 @@ phase2_ud_guest_ensure_icu_checkout() {
             "no x86_64 Mach-O. pinned ICU checkout $commit at $dest is missing icuSources/include/_foundation_unicode. Will not invent a stub dylib."
         return 1
     fi
+    stamp_write "$dest" "$key"
     return 0
 }
 
@@ -888,16 +915,15 @@ phase2_stage_cftest_into_run_root() {
     fi
     mkdir -p "$(dirname "$dest")"
     src_sha=$(sha256sum "$src" | awk '{print $1}')
-    if [ -f "$dest" ]; then
+    key=$(stamp_key "$dest" "$src")
+    if stamp_reuse "$dest" "$key"; then
         dest_sha=$(sha256sum "$dest" | awk '{print $1}')
-    else
-        dest_sha=ABSENT
-    fi
-    if [ "$src_sha" = "$dest_sha" ]; then
         already=1
     else
+        stamp_rebuild_reason "$dest" "$key"
         cp -f "$src" "$dest"
         dest_sha=$(sha256sum "$dest" | awk '{print $1}')
+        stamp_write "$dest" "$key"
     fi
     # Decision uses the sha already printed on the ENV_PREPARE line, not
     # existence / cmp of a dest that may be a copy of a stale source.
@@ -928,18 +954,19 @@ phase2_ud_guest_ensure_dispatch() {
     local repo=$1 ud_w=$2 sys=$3 target=$4
     local existing_host=${5:-}
     local host_dir host dest obj log st arch darwin_sha host_ok=0 darwin_ok=0
-    local built_host=0 built_darwin=0
+    local built_host=0 built_darwin=0 darwin_key host_key
 
     phase2_ud_guest_refuse_unsuffixed "$ud_w" || return 1
     mkdir -p "$ud_w/lib" "$ud_w/host" "$ud_w/host-work"
 
     host=$ud_w/host/libOpenDispatchHost.so
-    if [ -f "$existing_host" ] && [ ! -L "$existing_host" ] \
-        && phase2_is_elf_x86_so "$existing_host"
-    then
+    host_key=$(stamp_key "$host" \
+        "$repo/full/dispatch/build_host_bridge.sh" \
+        "ELF64-$(uname -m)")
+    if [ -n "$existing_host" ] && stamp_reuse "$existing_host" "$host_key"; then
         host=$existing_host
         host_ok=1
-    elif [ -f "$host" ] && [ ! -L "$host" ] && phase2_is_elf_x86_so "$host"; then
+    elif stamp_reuse "$host" "$host_key"; then
         host_ok=1
     fi
 
@@ -968,6 +995,7 @@ phase2_ud_guest_ensure_dispatch() {
         fi
         built_host=1
         host_ok=1
+        stamp_write "$host" "$host_key"
     fi
 
     dest=$ud_w/lib/libOpenDispatch.dylib
@@ -980,7 +1008,10 @@ phase2_ud_guest_ensure_dispatch() {
             return 1
             ;;
     esac
-    if [ -f "$dest" ] && phase2_is_x86_macho "$dest" \
+    darwin_key=$(stamp_key "$dest" \
+        "$repo/full/dispatch/OpenDispatchBridge.c" \
+        "$target" "/usr/lib/libOpenDispatch.dylib")
+    if stamp_reuse "$dest" "$darwin_key" \
         && [ "$(llvm-otool-18 -D "$dest" 2>/dev/null | tail -n 1)" = \
             /usr/lib/libOpenDispatch.dylib ]
     then
@@ -1025,6 +1056,7 @@ phase2_ud_guest_ensure_dispatch() {
         fi
         built_darwin=1
         darwin_ok=1
+        stamp_write "$dest" "$darwin_key"
     fi
 
     darwin_sha=$(sha256sum "$dest" | awk '{print $1}')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Five times on 2026-09-03 a stage reused whatever file already existed at its output path. Downstream gates graded those stale bytes while the same log attested the NEW source a few lines away.

1. `scripts/env/prepare.py` reused `machorun/build/machorun` by existence (PR #65: `.source-tree` stamp).
2. Rung a ran the run-root COPY of the loader; only rungs b/c refreshed it (PR #66).
3. `lib/libCFTest.dylib` reused because sibling stub text files matched the pin; the dylib was never relinked (PR #70: `.inputs` stamps).
4. `phase2_fill_x86_libswiftcompat` reused any x86 Mach-O at the destination; a pre-PR67 shim stayed for seven hours (`.source-sha256` stamp).
5. `build_full.sh` restaged the guest root only when the LOADER was newer; a rebuilt base shim never reached the full root (`base_runtime_newer` `-nt`).

Plus three ordering/reporting defects: `ssm_x86both` ran overlays BEFORE phase2 regenerated the tbds (a machorun surface change stayed "undefined" one more cycle); phase2's `RUNG_A_DETAIL` quoted the negative-control board; the parent overlay script's ERR trap hid the child's log.

## Stamp rule

`scripts/x86/stamp.inc` is the one POSIX reuse library.

- `stamp_key <out> <input>...` hashes file **contents** (`F <sha>`) and any argv string (`S <string>`). The out path is not in the key.
- `stamp_reuse <out> <key>` returns 0 only when `<out>` exists, is the expected kind (x86_64 Mach-O / x86-64 ELF PIE or SO / non-empty `.tbd` / directory), and `<out>.inputs-sha256` equals the key. Wrong-arch Mach-O never reuses. Prints `reused=1 stamp=<12>` to **stderr**.
- A rebuild prints `rebuilt reason=no-stamp|inputs <old12>-><new12>` to stderr (`stamp_rebuild_reason`); `stamp_write` records the new key.

No site may reuse on existence alone. `scripts/x86/test_no_existence_reuse.sh` greps `scripts/x86/*.inc`, `scripts/x86/*.sh`, and `full/scripts/build_full.sh` for `if [ -f ]` / `-e` / `phase2_is_x86_macho` skips that `return 0` without `stamp_reuse` in the same block, names `file:line`, and plants a bad skip to prove the scanner fires. Wired into `scripts/x86/test_phase2.sh`.

## Converted sites (before → after)

| Site | Before | After |
| --- | --- | --- |
| `phase2.sh` `ensure_loader/darwin/objc4/quartz/tbd` | `[ -f ] && phase2_is_x86_macho` / ELF existence | `stamp_reuse` keyed on `HEAD:machorun` + product name |
| `phase2.sh` `try_collections` OrderedCollections.o | existence + macho | `stamp_reuse` (sources + recipe) |
| `phase2.sh` `try_cshims` uuid.o | existence + macho | `stamp_reuse` |
| `phase2.sh` `try_os_module` os.o | existence + macho | `stamp_reuse` |
| `phase2.sh` `try_fe` FoundationEssentials.o / removefile_compat.o | existence + macho | `stamp_reuse` |
| `phase2.sh` OpenCombine.o | existence + macho | `stamp_reuse` |
| `phase2.sh` `mrroot-base-x86` | ELF loader existence | `stamp_reuse` |
| `phase2.sh` run-root loader refresh | `-nt` vs `$MRROOT/machorun` | `stamp_reuse` (loader content) |
| `common.inc` `phase2_fill_x86_libswiftcompat` | `.source-sha256` + any x86 Mach-O | `stamp_reuse` (swiftcompat.c + shim.cpp + build_compat.sh) |
| `common.inc` loud-abort Foundation/CF stubs | macho existence | `stamp_reuse` |
| `ud_guest.inc` CF / ICU checkouts | dest exists + HEAD matches | `stamp_reuse` (commit/tree/origin) |
| `ud_guest.inc` libCFTest run-root stage | `[ -f "$dest" ]` | `stamp_reuse` (source content) |
| `ud_guest.inc` OpenDispatch Darwin + host ELF | ELF/macho existence | `stamp_reuse` |
| `ud_guest.inc` `ensure_swiftcompat` | any found x86 dylib | `stamp_reuse`; unstamped copy is not enough |
| `full/scripts/build_full.sh` `base_runtime_newer` | four single-input `-nt` gates | `stamp_key` over loader + libswiftcompat + overlay dylibs (except libswiftCore) |

Left as-is (not product reuse): measurement-header shadowing, cache-extract deletion, post-build `$st/$cst/$rc` checks, `phase2_cftest_stub_list_stale` `-nt` (CANNOT if stub list newer than dylib). Persist `RUNG_A_DETAIL` now quotes the **positive** GUEST SCOREBOARD (the board before `NEGATIVE CONTROL`).

## Cycle order

`scripts/ops/x86_cycle.sh` replaces `/tmp/x86_stage_inputs_phase2.sh` and `/tmp/x86_overlays_phase2.sh`. `scripts/x86/phase2.sh` stays the rung runner.

```
fetch_bundle → checkout → prepare.py → build.sh tbd → sysroot → overlays → roots → phase2
```

Overlays **after** tbd. Overlay-before-tbd (`ssm_x86both`) left a machorun surface change undefined for one more cycle. Overlay argv is the PR #64 line:

`NINJA_JOBS=16 SWIFTCORE_DARWIN_ARCH=x86_64 SWIFTCORE_OVERLAYS=1 SWIFTCORE_BUILD_DISPATCH=1 SWIFT_TOOLCHAIN=/opt/swift bash swiftcore-macho/scripts/build_stdlib.sh`

Each stage prints `STAGE <name> status=<reused|rebuilt|cannot> key=<12> product=<path> sha256=<12>`. No ERR trap swallows the child log: `run_logged` tails it on failure. The final scoreboard quotes the positive boards.

`s3://` bundles go through `ops_aws s3 cp` (urllib cannot speak S3).

## Operator commands

Instance ids and trees are read from `env/contract.json` `hosts` (arm64 authority `i-00da4d9ca172eb1ff` tree `/opt/openuikit/verify-20260902/openuikit`; x86 `i-0a2e25f3895c819b3` tree `/opt/openuikit/x86-verify/openuikit`). S3 bucket/prefix live under `transfer`. `scripts/ops/run_box.sh` refuses to launch when the box has any InProgress command (**server-side** `--filters key=Status,value=InProgress`; never the unfiltered listing), caps the SSM comment at 100 chars, waits with `get-command-invocation`, and prints the grep-extracted result lines. `--dry-run` prints the SSM document.

```bash
# From the operator Mac. Expect every STAGE line and the rung scoreboard.
scripts/ops/run_box.sh x86 cycle

# Expect `pass 69 fail 0` + GATE_B_PASS at the current main.
scripts/ops/run_box.sh arm64 verify
```

`scripts/ops/premerge.sh <pr-number>` is the committed merge gate: worktree the PR merged with main, `python3 scripts/env/test_contract.py`, `bash scripts/test_vendor_tree.sh` when machorun/uikit changed (and advance the pin: sed the three files, commit "Advance the machorun vendor pin…"), the PR's own test scripts named in its body, one-line verdict.

Tests on a fake box: `bash scripts/ops/test_ops.sh` (stub AWS/gh, dry-run document, InProgress refuse, STAGE/scoreboard grep, comment cap, cycle stub, premerge pin-advance). `bash scripts/x86/test_stamp.sh` (10/10). `bash scripts/x86/test_no_existence_reuse.sh`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39873410-f4f4-4a78-b54b-82fcce1fc275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39873410-f4f4-4a78-b54b-82fcce1fc275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

