### PR TITLE
x86_64 Focus closure: do not require Foundation placeholders

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -1098,6 +1098,7 @@ llvm-otool-18 -hv "$OUT/focus_onboarding_guest" \
 perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 --executable "$OUT/focus_onboarding_guest" \
     --package "$PACKAGE" --guest-root "$RUNROOT" \
+    --arch "$ARCH" \
     > "$AUDIT/runtime-closure.manifest"
 awk -F '\t' '
     $1 == "file" && $2 == "package/libOpenFoundationInternationalization.dylib" {

--- a/full/swiftui/build_focus_package_guest.sh
+++ b/full/swiftui/build_focus_package_guest.sh
@@ -372,6 +372,7 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 \
     --executable "$PROBE_APP/Contents/MacOS/FocusPackageProbe" \
     --package "$PACKAGE" --guest-root "$MRROOT" \
+    --arch "$ARCH" \
     > "$AUDIT/package-runtime-closure.manifest"
 grep -Fqx $'file\tpackage/FocusPackageProbe.framework/FocusPackageProbe\t'\
 "$(hash_file "$PROVIDER/FocusPackageProbe")" \
@@ -430,6 +431,7 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 \
     --executable "$LICENSES_APP/Contents/MacOS/FocusLicensesGuest" \
     --package "$PACKAGE" --guest-root "$MRROOT" \
+    --arch "$ARCH" \
     > "$AUDIT/licenses-runtime-closure.manifest"
 (
     cd "$OUT"
@@ -519,6 +521,7 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 \
     --executable "$PROBE_APP/Contents/MacOS/FocusPackageProbe" \
     --package "$PACKAGE" --guest-root "$MRROOT" \
+    --arch "$ARCH" \
     > "$AUDIT/post-package-runtime-closure.manifest"
 cmp -s "$AUDIT/package-runtime-closure.manifest" \
     "$AUDIT/post-package-runtime-closure.manifest" \
@@ -527,6 +530,7 @@ perl "$W/full/swiftui/focus_widget_guest_attest.pl" closure \
     --otool llvm-otool-18 \
     --executable "$LICENSES_APP/Contents/MacOS/FocusLicensesGuest" \
     --package "$PACKAGE" --guest-root "$MRROOT" \
+    --arch "$ARCH" \
     > "$AUDIT/post-licenses-runtime-closure.manifest"
 cmp -s "$AUDIT/licenses-runtime-closure.manifest" \
     "$AUDIT/post-licenses-runtime-closure.manifest" \

--- a/full/swiftui/build_focus_widget_guest.sh
+++ b/full/swiftui/build_focus_widget_guest.sh
@@ -184,7 +184,8 @@ assert_build_input_inventory() {
 generate_runtime_closure() {
     perl "$ATTEST" closure --otool llvm-otool-18 \
         --executable "$OUT/focus_widget_guest" \
-        --package "$PACKAGE" --guest-root "$MRROOT"
+        --package "$PACKAGE" --guest-root "$MRROOT" \
+        --arch "$ARCH"
 }
 
 assert_runtime_closure() {
@@ -1015,9 +1016,11 @@ MACHORUN="$MACHORUN" bash "$W/scripts/require_fresh_root.sh" "$MRROOT"
 
 # Resolve the executable's complete transitive Mach-O load graph, including
 # re-exports, weak-load declarations, the loader, the root manifest, and the
-# extensionless Foundation/CoreFoundation loud-abort substrate stubs. An
-# ordinary build records it atomically; a resume may only match that prior
-# record. Never overwrite the record from a resume-only invocation.
+# arch-conditional substrate stubs (arm64: Foundation/CoreFoundation
+# loud-abort placeholders named by iOS-simulator overlays; x86_64: none,
+# matching Apple macOS overlays). An ordinary build records it atomically; a
+# resume may only match that prior record. Never overwrite the record from a
+# resume-only invocation.
 if [ "$skip_full_build" != 1 ]; then
     runtime_closure_recording=$(mktemp "$FULL/.focus-widget-runtime-closure.recording.XXXXXX")
     generate_runtime_closure > "$runtime_closure_recording"

--- a/full/swiftui/focus_widget_guest_attest.pl
+++ b/full/swiftui/focus_widget_guest_attest.pl
@@ -5,6 +5,7 @@
 
 use strict;
 use warnings;
+use Cwd qw(abs_path);
 use Digest::SHA qw(sha256_hex);
 use File::Basename qw(dirname basename);
 use Getopt::Long qw(GetOptionsFromArray);
@@ -308,19 +309,43 @@ sub require_runtime_image {
     }
 }
 
+sub inventories_py {
+    my $dir = dirname($0);
+    $dir = abs_path($dir) if defined $dir && $dir ne '';
+    my $path = "$dir/guest_gate_inventories.py";
+    fail("guest_gate_inventories.py is missing next to attest: $path")
+        unless -f $path && !-l $path;
+    return $path;
+}
+
+sub inventory_stub_set {
+    my ($arch, $name) = @_;
+    fail("unsupported closure arch $arch")
+        unless defined($arch) && ($arch eq 'arm64' || $arch eq 'x86_64');
+    my $text = capture_command(
+        'python3', inventories_py(),
+        '--arch', $arch, '--gate', 'widget', '--kind', 'stubs', '--name', $name,
+    );
+    return grep { length } split /\n/, $text;
+}
+
 sub closure_command {
     my (@args) = @_;
-    my ($otool, $executable, $package, $guest_root);
+    my ($otool, $executable, $package, $guest_root, $arch);
     GetOptionsFromArray(
         \@args,
         'otool=s'      => \$otool,
         'executable=s' => \$executable,
         'package=s'    => \$package,
         'guest-root=s' => \$guest_root,
+        'arch=s'       => \$arch,
     ) or fail('invalid closure options');
     fail('closure takes no positional arguments') if @args;
-    fail('closure requires --otool, --executable, --package, and --guest-root')
-        unless defined($otool) && defined($executable) && defined($package) && defined($guest_root);
+    fail('closure requires --otool, --executable, --package, --guest-root, and --arch')
+        unless defined($otool) && defined($executable) && defined($package)
+            && defined($guest_root) && defined($arch);
+    fail("unsupported closure arch $arch")
+        unless $arch eq 'arm64' || $arch eq 'x86_64';
     $executable = normalize_absolute($executable);
     $package = normalize_absolute($package);
     $guest_root = normalize_absolute($guest_root);
@@ -387,12 +412,27 @@ sub closure_command {
     $files{'loader/machorun'} = file_sha256($loader);
     $files{'attestation/guest-root.manifest'} = file_sha256($root_manifest);
 
-    for my $stub (
-        'guest-root/darwin/System/Library/Frameworks/Foundation.framework/Foundation',
-        'guest-root/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation',
-    ) {
-        fail("known substrate stub is absent from recursive closure: $stub")
+    my @expected = inventory_stub_set($arch, 'substrate');
+    my @universe = inventory_stub_set($arch, 'universe');
+    my %expected = map { $_ => 1 } @expected;
+    my %universe = map { $_ => 1 } @universe;
+    my $dump_closure = sub {
+        my $expected_text = @expected
+            ? join('', map { "expected\t$_\n" } @expected)
+            : "expected\t(none)\n";
+        my $listed = join('', map { "file\t$_\n" } sort keys %files);
+        return "arch\t$arch\n$expected_text$listed";
+    };
+    for my $stub (@expected) {
+        fail("known substrate stub is absent from recursive closure: $stub\n"
+            . $dump_closure->())
             unless exists $files{$stub};
+    }
+    for my $label (sort keys %files) {
+        next unless $universe{$label};
+        next if $expected{$label};
+        fail("substrate stub is not in the expected closure set: $label\n"
+            . $dump_closure->());
     }
 
     print "format\tfocus-widget-runtime-closure-v2\n";

--- a/full/swiftui/guest_gate_inventories.py
+++ b/full/swiftui/guest_gate_inventories.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Arch-keyed inventories the Focus widget/onboarding gates assert.
 
-One source for expected_*_loads, expected_*_inputs, package file lists, and
-otool CPU strings. Arm64 tuples are the historical literals (Gate B at
-e93727e0). x86_64 load lists drop the arm64 libswift_errno.dylib autolink
-(libswiftDarwin already carries those binds on macOS); x86_64 input/package
-lists start as the arm64 lists (paths already go through $SYS/$PACKAGE/$FULL
-which carry FULL_OUT_SUFFIX).
+One source for expected_*_loads, expected_*_inputs, package file lists,
+otool CPU strings, and the recursive-closure substrate-stub set. Arm64
+tuples are the historical literals (Gate B at e93727e0). x86_64 load lists
+drop the arm64 libswift_errno.dylib autolink (libswiftDarwin already carries
+those binds on macOS); x86_64 input/package lists start as the arm64 lists
+(paths already go through $SYS/$PACKAGE/$FULL which carry FULL_OUT_SUFFIX).
+x86_64 closure stubs are empty: the cross-built overlays do not LC_LOAD
+Foundation, so the loud-abort placeholders stay out of the walk. Overlay
+autolink is also per-ARCH: ARM64_OVERLAY_AUTOLINK becomes X86_OVERLAY_AUTOLINK
+in place; x86_64 drops ARM64_OVERLAY_AUTOLINK rather than substituting
+DarwinFoundation1.
 
 Operator dumps on the x86_64 EC2 box (FULL_OUT_SUFFIX=-x86_64):
 
@@ -55,7 +60,38 @@ import sys
 
 ARCHES = ("arm64", "x86_64")
 GATES = ("widget", "onboarding")
-KINDS = ("loads", "inputs", "package", "otool-cpu")
+KINDS = ("loads", "inputs", "package", "otool-cpu", "stubs")
+
+# Closure substrate stubs. The attest walks the guest's recursive dylib
+# closure and exact-matches the known Foundation/CoreFoundation loud-abort
+# placeholders against this set. Missing an expected stub fails closed;
+# a universe image that the arch inventory does not list also fails closed.
+#
+# arm64: Apple's iOS-simulator overlays (staged in mrroot_full) declare
+# Foundation.framework/Foundation and CoreFoundation.framework/CoreFoundation
+# in LC_LOAD_DYLIB. Measured 2026-08-28 (foundation-macho census; 2,858 binds
+# across the twelve overlays, 0 attributed to either framework) the four
+# images that name both placeholders and bind none of their symbols are:
+#   libswift_Builtin_float  libswift_RegexParser
+#   libswiftSynchronization libswift_StringProcessing
+# Operator re-measure on the arm64 box:
+#   llvm-otool-18 -L scratch/mrroot_full/darwin/usr/lib/swift/*.dylib
+# x86_64: the twelve overlays are cross-built from source (swiftcore-macho
+# ninja + in-tree shells), like Apple's macOS overlays, and do not load
+# Foundation at all. Measured on committed artifacts:
+#   llvm-objdump-18 --macho --private-headers \
+#     swiftcore-macho/artifacts/swift-macosx/x86_64/*.dylib
+# none of the 13 dylibs name Foundation.framework or CoreFoundation.framework.
+FOUNDATION_STUB = (
+    "guest-root/darwin/System/Library/Frameworks/Foundation.framework/Foundation"
+)
+COREFOUNDATION_STUB = (
+    "guest-root/darwin/System/Library/Frameworks/"
+    "CoreFoundation.framework/CoreFoundation"
+)
+CLOSURE_STUB_UNIVERSE: tuple[str, ...] = (FOUNDATION_STUB, COREFOUNDATION_STUB)
+CLOSURE_STUBS_ARM64: tuple[str, ...] = CLOSURE_STUB_UNIVERSE
+CLOSURE_STUBS_X86_64: tuple[str, ...] = ()
 
 # Apple ld oracle (MacOSX26.1 SDK, x86_64-apple-macos14.0), operator-run:
 #
@@ -647,6 +683,22 @@ def otool_cpu(arch: str) -> str:
         raise ValueError(f"unsupported arch {arch!r}") from exc
 
 
+def stubs(gate: str, name: str, arch: str) -> tuple[str, ...]:
+    """Arch-conditional substrate stubs. `gate` is accepted for the CLI
+    shape; widget and onboarding share one overlay-driven set."""
+    if gate not in GATES:
+        raise KeyError(f"unknown gate {gate!r}")
+    if arch not in ARCHES:
+        raise ValueError(f"unsupported arch {arch!r}")
+    if name == "universe":
+        return CLOSURE_STUB_UNIVERSE
+    if name != "substrate":
+        raise KeyError(f"unknown stubs inventory {name!r}")
+    if arch == "arm64":
+        return CLOSURE_STUBS_ARM64
+    return CLOSURE_STUBS_X86_64
+
+
 def expand(items: tuple[str, ...], binds: dict[str, str]) -> tuple[str, ...]:
     expanded = []
     for item in items:
@@ -684,6 +736,8 @@ def emit(arch: str, gate: str, kind: str, name: str, binds: dict[str, str]) -> s
         return canonical_text(loads(gate, name, arch))
     if kind == "inputs":
         return canonical_text(expand(inputs(gate, name, arch), binds))
+    if kind == "stubs":
+        return canonical_text(stubs(gate, name, arch))
     raise ValueError(f"unknown kind {kind!r}")
 
 
@@ -704,6 +758,8 @@ def check_names(gate: str, kind: str) -> tuple[str, ...]:
         )
     if kind == "otool-cpu":
         return ("otool-cpu",)
+    if kind == "stubs":
+        return ("substrate", "universe")
     raise KeyError(f"unknown kind {kind!r}")
 
 

--- a/full/swiftui/test_focus_onboarding_guest.py
+++ b/full/swiftui/test_focus_onboarding_guest.py
@@ -128,6 +128,7 @@ class FocusOnboardingGuestProofTests(unittest.TestCase):
         self.assertIn("MH_MAGIC_64[[:space:]]+${OTOOL_CPU}", text)
         self.assertIn('actual_id=$(llvm-otool-18 -D', text)
         self.assertIn('focus_widget_guest_attest.pl" closure', text)
+        self.assertIn('--arch "$ARCH"', text)
         self.assertIn('"$MRROOT/machorun"', text)
         self.assertIn("run_machorun_site interaction-path ./focus_onboarding_guest", text)
         self.assertIn("compile the first-party Symbols value model while Foundation is hidden", text)

--- a/full/swiftui/test_focus_package_guest.py
+++ b/full/swiftui/test_focus_package_guest.py
@@ -385,6 +385,7 @@ class FocusPackageGuestProofTests(unittest.TestCase):
         self.assertIn("printf 'widget-bundle-accessor\\t%s\\n'", text)
         self.assertIn("printf 'licenses-bundle-accessor\\t%s\\n'", text)
         self.assertGreaterEqual(text.count('focus_widget_guest_attest.pl" closure'), 4)
+        self.assertGreaterEqual(text.count('--arch "$ARCH"'), 4)
         self.assertIn("package probe recursive runtime closure drifted", text)
         self.assertIn("Licenses recursive runtime closure drifted", text)
         self.assertIn('"$MRROOT/machorun"', text)

--- a/full/swiftui/test_focus_widget_guest.py
+++ b/full/swiftui/test_focus_widget_guest.py
@@ -424,16 +424,25 @@ class FocusWidgetGuestProofTests(unittest.TestCase):
 
     def test_recursive_runtime_closure_includes_extensionless_substrate_stubs(self) -> None:
         helper = ATTEST.read_text()
+        inventory = INVENTORIES_PY.read_text()
         self.assertIn("macho_commands", helper)
         self.assertIn("LC_REEXPORT_DYLIB", helper)
         self.assertIn("LC_LOAD_WEAK_DYLIB", helper)
         self.assertIn("weak-missing", helper)
-        self.assertIn("Foundation.framework/Foundation", helper)
-        self.assertIn("CoreFoundation.framework/CoreFoundation", helper)
+        self.assertIn("Foundation.framework/Foundation", inventory)
+        self.assertIn("CoreFoundation.framework/CoreFoundation", inventory)
+        self.assertIn("CLOSURE_STUBS_X86_64", inventory)
         self.assertIn("known substrate stub is absent from recursive closure", helper)
+        self.assertIn("substrate stub is not in the expected closure set", helper)
+        self.assertIn("inventory_stub_set", helper)
+        self.assertIn("'arch=s'", helper)
         build_full = BUILD_FULL.read_text()
         self.assertIn("restaging $framework loud-abort stub", build_full)
         self.assertIn("staged\\tdarwin/System/Library/Frameworks/%s.framework/%s", build_full)
+        text = BUILD.read_text()
+        self.assertIn('--arch "$ARCH"', text)
+        onboarding = (ROOT / "full/swiftui/build_focus_onboarding_guest.sh").read_text()
+        self.assertIn('--arch "$ARCH"', onboarding)
 
     def test_nested_guest_root_has_canonical_labels_and_tamper_teeth(self) -> None:
         with tempfile.TemporaryDirectory(prefix="nested-guest-root-closure.") as temporary:
@@ -496,6 +505,8 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
                 str(package),
                 "--guest-root",
                 str(guest_root),
+                "--arch",
+                "arm64",
             ]
             accepted = subprocess.run(
                 command, check=True, capture_output=True, text=True
@@ -542,6 +553,156 @@ for dependency in dependencies.get(Path(sys.argv[-1]).name, []):
             )
             self.assertNotEqual(missing.returncode, 0)
             self.assertIn("cannot resolve LC_LOAD_DYLIB", missing.stderr)
+
+    def test_closure_substrate_stubs_fail_closed_per_arch(self) -> None:
+        foundation_label = (
+            "guest-root/darwin/System/Library/Frameworks/"
+            "Foundation.framework/Foundation"
+        )
+        core_label = (
+            "guest-root/darwin/System/Library/Frameworks/"
+            "CoreFoundation.framework/CoreFoundation"
+        )
+        self.assertEqual(
+            inventories.stubs("widget", "substrate", "arm64"),
+            (foundation_label, core_label),
+        )
+        self.assertEqual(
+            inventories.stubs("onboarding", "substrate", "arm64"),
+            inventories.stubs("widget", "substrate", "arm64"),
+        )
+        self.assertEqual(inventories.stubs("widget", "substrate", "x86_64"), ())
+        self.assertEqual(
+            inventories.stubs("onboarding", "substrate", "x86_64"), ()
+        )
+        self.assertEqual(
+            inventories.stubs("widget", "universe", "x86_64"),
+            inventories.CLOSURE_STUB_UNIVERSE,
+        )
+
+        def run_closure(arch: str, *, load_stubs: bool, pass_arch: bool = True):
+            temporary = tempfile.TemporaryDirectory(prefix="stub-inventory-closure.")
+            root = Path(temporary.name)
+            package = root / "package"
+            guest_root = package / "guest-root"
+            executable = package / "probe/CoreGuestPackageProbe"
+            runtime = guest_root / "darwin/usr/lib/swift/libRuntime.dylib"
+            foundation = (
+                guest_root
+                / "darwin/System/Library/Frameworks/Foundation.framework/Foundation"
+            )
+            core_foundation = (
+                guest_root
+                / "darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+            )
+            loader = guest_root / "machorun"
+            root_manifest = guest_root / ".manifest"
+            for fixture in (
+                executable,
+                runtime,
+                foundation,
+                core_foundation,
+                loader,
+                root_manifest,
+            ):
+                fixture.parent.mkdir(parents=True, exist_ok=True)
+                fixture.write_text(f"{fixture.name}\n", encoding="utf-8")
+            runtime_deps = [
+                "/System/Library/Frameworks/Foundation.framework/Foundation",
+                "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+            ] if load_stubs else []
+            fake_otool = root / "fake-otool"
+            fake_otool.write_text(
+                """#!/usr/bin/env python3
+from pathlib import Path
+import sys
+deps = {
+    "CoreGuestPackageProbe": ["/usr/lib/swift/libRuntime.dylib"],
+    "libRuntime.dylib": %r,
+}
+for dependency in deps.get(Path(sys.argv[-1]).name, []):
+    print("Load command 0")
+    print("      cmd LC_LOAD_DYLIB")
+    print(f"     name {dependency} (offset 24)")
+"""
+                % (runtime_deps,),
+                encoding="utf-8",
+            )
+            fake_otool.chmod(0o755)
+            command = [
+                "perl",
+                str(ATTEST),
+                "closure",
+                "--otool",
+                str(fake_otool),
+                "--executable",
+                str(executable),
+                "--package",
+                str(package),
+                "--guest-root",
+                str(guest_root),
+            ]
+            if pass_arch:
+                command.extend(["--arch", arch])
+            result = subprocess.run(command, check=False, capture_output=True, text=True)
+            return result, temporary
+
+        missing_arch, missing_arch_tmp = run_closure(
+            "arm64", load_stubs=True, pass_arch=False
+        )
+        try:
+            self.assertNotEqual(missing_arch.returncode, 0)
+            self.assertIn("closure requires", missing_arch.stderr)
+            self.assertIn("--arch", missing_arch.stderr)
+        finally:
+            missing_arch_tmp.cleanup()
+
+        arm_ok, arm_ok_tmp = run_closure("arm64", load_stubs=True)
+        try:
+            self.assertEqual(arm_ok.returncode, 0, arm_ok.stderr)
+            self.assertIn(foundation_label, arm_ok.stdout)
+            self.assertIn(core_label, arm_ok.stdout)
+        finally:
+            arm_ok_tmp.cleanup()
+
+        arm_missing, arm_missing_tmp = run_closure("arm64", load_stubs=False)
+        try:
+            self.assertNotEqual(arm_missing.returncode, 0)
+            self.assertIn(
+                "known substrate stub is absent from recursive closure",
+                arm_missing.stderr,
+            )
+            self.assertIn(foundation_label, arm_missing.stderr)
+            self.assertIn("arch\tarm64", arm_missing.stderr)
+            self.assertIn(f"expected\t{foundation_label}", arm_missing.stderr)
+            self.assertIn(f"expected\t{core_label}", arm_missing.stderr)
+            self.assertIn("file\texecutable/CoreGuestPackageProbe", arm_missing.stderr)
+            self.assertNotIn("expected\t(none)", arm_missing.stderr)
+        finally:
+            arm_missing_tmp.cleanup()
+
+        x86_ok, x86_ok_tmp = run_closure("x86_64", load_stubs=False)
+        try:
+            self.assertEqual(x86_ok.returncode, 0, x86_ok.stderr)
+            self.assertIn("file\tguest-root/darwin/usr/lib/swift/libRuntime.dylib\t", x86_ok.stdout)
+            self.assertNotIn("Foundation.framework/Foundation", x86_ok.stdout)
+            self.assertNotIn("CoreFoundation.framework/CoreFoundation", x86_ok.stdout)
+        finally:
+            x86_ok_tmp.cleanup()
+
+        x86_extra, x86_extra_tmp = run_closure("x86_64", load_stubs=True)
+        try:
+            self.assertNotEqual(x86_extra.returncode, 0)
+            self.assertIn(
+                "substrate stub is not in the expected closure set",
+                x86_extra.stderr,
+            )
+            self.assertIn(foundation_label, x86_extra.stderr)
+            self.assertIn("arch\tx86_64", x86_extra.stderr)
+            self.assertIn("expected\t(none)", x86_extra.stderr)
+            self.assertIn("file\t" + foundation_label, x86_extra.stderr)
+        finally:
+            x86_extra_tmp.cleanup()
 
     def test_provider_gate_is_universal_and_rejects_reverse_ownership(self) -> None:
         helper = ATTEST.read_text()
@@ -749,6 +910,14 @@ _ARM64_PACKAGE_SHA256 = {
     "directories": "6f919ab8362dc40f9cea64edd9b93a1e59aee0be48fdb2622c956392b02406be",
     "fe_module_files": "f3bdd5f1c2f371c76a19a96bab86c624318d21b8e85d253c805cbe033d9f50cb",
 }
+_ARM64_STUB_SHA256 = {
+    "substrate": "8b1b341eec181d0d668c72b19ee70516026c5794af691adb0939b158fe173360",
+    "universe": "8b1b341eec181d0d668c72b19ee70516026c5794af691adb0939b158fe173360",
+}
+_X86_STUB_SHA256 = {
+    "substrate": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "universe": "8b1b341eec181d0d668c72b19ee70516026c5794af691adb0939b158fe173360",
+}
 
 
 class FocusWidgetGuestInventoryTests(unittest.TestCase):
@@ -765,6 +934,8 @@ class FocusWidgetGuestInventoryTests(unittest.TestCase):
         self.assertIn("guest_gate_inventory widget inputs", widget)
         self.assertIn("guest_gate_inventory widget package", widget)
         self.assertIn("guest_gate_inventory onboarding inputs", onboarding)
+        self.assertIn('--arch "$ARCH"', widget)
+        self.assertIn('--arch "$ARCH"', onboarding)
         self.assertNotIn("libswift_errno.dylib", widget)
         self.assertNotIn("/usr/lib/swift/libswift_DarwinFoundation1.dylib", widget)
         self.assertIn("MH_MAGIC_64[[:space:]]+${OTOOL_CPU}", widget)
@@ -974,6 +1145,95 @@ class FocusWidgetGuestInventoryTests(unittest.TestCase):
         self.assertIn("@rpath/libFoundationEssentials.dylib", swiftui_arm)
         swiftui_inputs = inventories.inputs("widget", "swiftui", "arm64")
         self.assertIn("{PACKAGE}/libFoundationEssentials.dylib", swiftui_inputs)
+
+    def test_substrate_stub_inventory_is_arch_conditional(self) -> None:
+        self.assertEqual(
+            tuple(sorted(_ARM64_STUB_SHA256)),
+            inventories.check_names("widget", "stubs"),
+        )
+        self.assertEqual(
+            inventories.check_names("onboarding", "stubs"),
+            inventories.check_names("widget", "stubs"),
+        )
+        for name, digest in _ARM64_STUB_SHA256.items():
+            items = inventories.stubs("widget", name, "arm64")
+            self.assertEqual(inventories.inventory_sha256(items), digest, name)
+            self.assertEqual(
+                inventories.stubs("onboarding", name, "arm64"), items, name
+            )
+        self.assertEqual(
+            inventories.stubs("widget", "substrate", "arm64"),
+            inventories.CLOSURE_STUB_UNIVERSE,
+        )
+        self.assertEqual(
+            inventories.stubs("widget", "substrate", "x86_64"), ()
+        )
+        for name, digest in _X86_STUB_SHA256.items():
+            items = inventories.stubs("widget", name, "x86_64")
+            self.assertEqual(inventories.inventory_sha256(items), digest, name)
+            self.assertEqual(
+                inventories.stubs("onboarding", name, "x86_64"), items, name
+            )
+        arm_cli = subprocess.check_output(
+            [
+                "python3",
+                str(INVENTORIES_PY),
+                "--arch",
+                "arm64",
+                "--gate",
+                "widget",
+                "--kind",
+                "stubs",
+                "--name",
+                "substrate",
+            ],
+            text=True,
+        )
+        x86_cli = subprocess.check_output(
+            [
+                "python3",
+                str(INVENTORIES_PY),
+                "--arch",
+                "x86_64",
+                "--gate",
+                "widget",
+                "--kind",
+                "stubs",
+                "--name",
+                "substrate",
+            ],
+            text=True,
+        )
+        self.assertIn("Foundation.framework/Foundation\n", arm_cli)
+        self.assertIn("CoreFoundation.framework/CoreFoundation\n", arm_cli)
+        self.assertEqual(x86_cli, "")
+        with self.assertRaises(KeyError):
+            inventories.stubs("widget", "missing", "arm64")
+        script = r"""
+set -euo pipefail
+W=%s
+. "$W/full/scripts/guest_arch.inc"
+. "$W/full/swiftui/guest_gate_inventories.inc"
+ARCH=arm64
+guest_gate_inventory widget stubs substrate
+printf '==SPLIT==\n'
+ARCH=x86_64
+guest_gate_inventory widget stubs substrate
+printf '==ONBOARDING==\n'
+guest_gate_inventory onboarding stubs substrate
+""" % ROOT
+        result = subprocess.run(
+            ["bash", "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        arm, rest = result.stdout.split("==SPLIT==\n", 1)
+        x86, onboarding_x86 = rest.split("==ONBOARDING==\n", 1)
+        self.assertIn("Foundation.framework/Foundation", arm)
+        self.assertIn("CoreFoundation.framework/CoreFoundation", arm)
+        self.assertEqual(x86, "")
+        self.assertEqual(onboarding_x86, "")
 
     def test_cli_emits_printf_compatible_lists(self) -> None:
         arm = subprocess.check_output(

--- a/scripts/x86/test_phase2.sh
+++ b/scripts/x86/test_phase2.sh
@@ -416,6 +416,31 @@ openuikit_x86=$(python3 "$INVENTORIES" --arch x86_64 --gate widget --kind loads 
     && ! printf '%s\n' "$openuikit_x86" | grep -q 'DarwinFoundation1' \
     && ok "x86 OpenUIKit loads drop errno without DarwinFoundation1" \
     || die_test "x86 OpenUIKit loads drifted: $(echo "$openuikit_x86" | tr '\n' '|')"
+arm_stubs=$(python3 "$INVENTORIES" --arch arm64 --gate widget --kind stubs --name substrate)
+x86_stubs=$(python3 "$INVENTORIES" --arch x86_64 --gate widget --kind stubs --name substrate)
+onboarding_x86_stubs=$(python3 "$INVENTORIES" --arch x86_64 --gate onboarding --kind stubs --name substrate)
+printf '%s\n' "$arm_stubs" | grep -qx 'guest-root/darwin/System/Library/Frameworks/Foundation.framework/Foundation' \
+    && printf '%s\n' "$arm_stubs" | grep -qx 'guest-root/darwin/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation' \
+    && [ -z "$x86_stubs" ] && [ -z "$onboarding_x86_stubs" ] \
+    && ok "x86 closure stubs are empty; arm64 still requires Foundation+CoreFoundation" \
+    || die_test "closure stub inventory drifted arm=$(printf '%s' "$arm_stubs" | tr '\n' '|') x86=$(printf '%s' "$x86_stubs" | tr '\n' '|')"
+expect_grep 'closure requires --otool, --executable, --package, --guest-root, and --arch' \
+    "$ROOT/full/swiftui/focus_widget_guest_attest.pl" \
+    "widget/onboarding closure attest requires --arch"
+command -v llvm-objdump-18 >/dev/null \
+    || die_test "llvm-objdump-18 missing; cannot measure committed x86 overlays"
+overlay_foundation_hits=0
+for overlay in "$ROOT"/swiftcore-macho/artifacts/swift-macosx/x86_64/*.dylib; do
+    [ -f "$overlay" ] || die_test "committed x86 overlay missing: $overlay"
+    if llvm-objdump-18 --macho --private-headers "$overlay" \
+        | grep -qE '(^|[[:space:]])name .*(/| )(Core)?Foundation\.framework'; then
+        overlay_foundation_hits=$((overlay_foundation_hits + 1))
+        echo "FOUNDATION_LC $(basename "$overlay")" >&2
+    fi
+done
+[ "$overlay_foundation_hits" -eq 0 ] \
+    && ok "committed x86 overlays declare no Foundation/CoreFoundation" \
+    || die_test "committed x86 overlays naming Foundation.framework: $overlay_foundation_hits"
 expect_grep 'libswiftCore.tbd' "$ROOT/full/swiftui/focus_widget_guest_attest.pl" \
     "widget attest requires named libswiftCore.tbd"
 expect_grep '[-]lswiftCore' "$ROOT/foundation-macho/scripts/link_ud_guest.sh" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The x86_64 Focus widget gate now reaches `focus_widget_guest_attest.pl closure` and stops there. The attest walks the guest's recursive dylib closure and required the loud-abort Foundation / CoreFoundation placeholders to appear in it. On arm64 they do, because Apple's iOS-simulator overlays declare those frameworks in `LC_LOAD_DYLIB`. On x86_64 the twelve overlays are cross-built from source (swiftcore-macho ninja + in-tree shells) and, like Apple's macOS overlays, do not load Foundation at all — so the placeholder is legitimately absent.

Operator log on i-0a2e25f3895c819b3 (`scripts/ops/run_box.sh x86 cycle`, main 7cec78d2):

```
focus_widget_guest_attest: known substrate stub is absent from recursive closure: guest-root/darwin/System/Library/Frameworks/Foundation.framework/Foundation
build_focus_widget_guest.sh exit 255
```

This is the same declared-dependency-vs-used-dependency split PR #54/#59 already applied to `LC_LOAD_DYLIB` inventories.

## Measurement

**Arm64 (repo census, not this VM).** `foundation-macho/docs/cf-census/fe-overlay-wall-2026-08-28.txt` and `foundation-macho/src/placeholder/FoundationPlaceholder.c`: four iOS-simulator overlays declare **both** `Foundation.framework/Foundation` and `CoreFoundation.framework/CoreFoundation` in `LC_LOAD_DYLIB` and bind **0 of 2,858** overlay symbols through either:

- `libswift_Builtin_float`
- `libswift_RegexParser`
- `libswiftSynchronization`
- `libswift_StringProcessing`

Operator re-measure on the arm64 box:

```bash
llvm-otool-18 -L scratch/mrroot_full/darwin/usr/lib/swift/*.dylib
```

**x86_64 (this change, committed artifacts).** `llvm-objdump-18 --macho --private-headers` on all 13 dylibs under `swiftcore-macho/artifacts/swift-macosx/x86_64/*.dylib`: **none** name `Foundation.framework` or `CoreFoundation.framework`. Loads are libSystem / libobjc / libc++ / libswiftCore and sibling overlays only. The same four images that declare Foundation on arm64:

| overlay | x86_64 LC_LOAD_DYLIB (frameworks) |
|---|---|
| `libswift_Builtin_float` | none (Core, libSystem, libobjc, libc++) |
| `libswift_RegexParser` | none (Core, libSystem, libobjc, libc++) |
| `libswiftSynchronization` | Darwin + Core / libSystem / libobjc / libc++ |
| `libswift_StringProcessing` | RegexParser + Core / libSystem / libobjc / libc++ |

Apple's macOS overlays also skip Foundation; the x86_64 cross-build matches that, not the iOS-simulator layout.

## Rule

`guest_gate_inventories.py` kind `stubs`:

- `substrate` arm64 → both placeholders (sha256 `8b1b341eec181d0d668c72b19ee70516026c5794af691adb0939b158fe173360`)
- `substrate` x86_64 → empty (sha256 `e3b0c442…` / empty string)
- `universe` → both labels on every arch (the fail-closed extra-image set)

`focus_widget_guest_attest.pl closure` now requires `--arch`. It fails closed if an expected stub is missing **or** a universe stub the inventory does not list appears in the walk. Failure dumps `arch`, `expected` (or `expected (none)`), then every `file` in the closure. Widget, onboarding, and package-guest closure calls all pass `--arch "$ARCH"`. `guest_gate_inventories.inc` is unchanged: it already proxies `--kind` to Python.

## Tests

- `python3 full/swiftui/test_focus_widget_guest.py` — 38 OK (per-arch stub hashes, bash helper empty x86 emit, missing `--arch`, arm64 missing stubs, x86 unexpected stubs, x86 pass without Foundation in the walk)
- `python3 full/swiftui/test_focus_onboarding_guest.py` — 23 OK
- `python3 scripts/env/test_contract.py` — 10 OK, `focus_widget_attestation_pins 25/25 agree (23 literal, 2 via guest_gate_inventories arm64)`
- `bash scripts/x86/test_phase2.sh` — new teeth PASS (empty x86 substrate / arm64 both; attest requires `--arch`; committed x86 overlays declare no Foundation). Remaining FAILs are pre-existing env gaps (libobjc.tbd / mrroot / sysroot).

## Operator

On i-0a2e25f3895c819b3:

```bash
scripts/ops/run_box.sh x86 cycle
```

Expect **rung b** to get past the closure attestation to the machorun run of the widget and its first pixel comparison on x86_64.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06dde341-4c60-4f03-bcf6-e5f01dadedc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06dde341-4c60-4f03-bcf6-e5f01dadedc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

