### PR TITLE
Promote Vision Linux lane from fan-out PR #17

### DIFF
--- a/full/vision/README.md
+++ b/full/vision/README.md
@@ -1,0 +1,57 @@
+# Vision (Linux starting point)
+
+This directory is a clean-room Linux starting point for Apple's public `Vision`
+module, seeded from the Xcode 26.1 iPhoneOS symbol graph. It produces one
+nominal Swift identity, `Vision`, and a loadable `libVision.dylib`. It is not
+an Apple behavioral oracle and it is not wired into the shared guest package.
+
+The legacy fan-out branch `cursor/port-vision-to-linux-90b3` (PR #17) was not
+readable from this GitHub App installation (`Vercantez/openuikit` only; the
+platform repository returned HTTP 404). The monorepo `reference/` dossier is
+kept. The deliverable follows the sealed seed plus the recorded PR #17 repair
+brief: honest coverage, no invented `VNErrorCode` ABI such as `turiCoreErrorCode = 10000`,
+and a true minimum enclosing circle.
+
+## What is real
+
+- Geometry: `VNPoint`, `VNVector`, `VNCircle`, `VNContour`, coordinate
+  conversion helpers, shoelace area, perimeter, Douglas-Peucker approximation,
+  and Welzl minimum enclosing circle (empty/singleton/duplicates/collinear/
+  obtuse/acute/order-invariance tests).
+- Catalog types: barcode symbologies, image options, compute stages, and the
+  public enum surface used by rectangle/barcode/text/face requests.
+- Request plumbing: `VNImageRequestHandler` / `VNSequenceRequestHandler`
+  `perform` throws `VNErrorCode.notImplemented` unless
+  `@_spi(OpenUIKitHost)` results are attached. Cancel delivers
+  `requestCancelled`. No ML success path.
+- Observations store bounding boxes, QR payload fields, and text candidates
+  that tests inject; they do not come from a detector.
+
+`VNErrorCode` integer layout follows independent `dotnet/macios` Native
+bindings (`turiCoreErrorCode = -1`, `OK = 0`, then sequential). That is
+declaration evidence, not an on-device Apple oracle.
+
+## Fail-closed / not invented
+
+- No Core ML models, OCR, barcode decode, face landmarks, optical flow, or
+  person segmentation execute. `perform` fails closed.
+- `CGImage` / `CIImage` / `CVPixelBuffer` / `CMSampleBuffer` handler inits are
+  omitted until those modules exist (`canImport` is false on this host).
+- `VNContour.normalizedPath` (`CGPath`) is omitted without CoreGraphics.
+- `VNObservation.timeRange` is omitted without CoreMedia.
+- Symbology and image-option raw strings are Linux-local tokens named after
+  TBD export symbols; C-string bytes are unobserved.
+- `VNCircle.contains(_:inCircumferentialRingOfWidth:)` uses `|d − r| ≤ width`.
+
+## Still deferred
+
+Most of the 3584 exact public IDs remain deferred: pose graphs, document
+observation, Core ML requests, video processor, Swift-only iOS 26 request
+structs, and dependency-gated image types. `tests/agent/VisionDependencyIdentity.swift`
+is a future EC2 probe against real CoreGraphics and CoreImage.
+
+Run the immutable host gate:
+
+```sh
+bash tests/acceptance/test_host.sh
+```

--- a/full/vision/Vision.swift
+++ b/full/vision/Vision.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+public typealias VNConfidence = Float
+public typealias VNAspectRatio = Float
+public typealias VNDegrees = Float
+
+public typealias VNRequestCompletionHandler = (VNRequest, (any Error)?) -> Void
+public typealias VNRequestProgressHandler = (VNRequest, Double, (any Error)?) -> Void
+
+/// Named “unspecified” in the public graph and in independent macios bindings.
+public let VNRequestRevisionUnspecified: Int = 0
+
+public let VNDetectBarcodesRequestRevision1: Int = 1
+public let VNDetectBarcodesRequestRevision2: Int = 2
+public let VNDetectBarcodesRequestRevision3: Int = 3
+public let VNDetectBarcodesRequestRevision4: Int = 4
+
+public let VNDetectFaceRectanglesRequestRevision1: Int = 1
+public let VNDetectFaceRectanglesRequestRevision2: Int = 2
+public let VNDetectFaceRectanglesRequestRevision3: Int = 3
+
+public let VNDetectRectanglesRequestRevision1: Int = 1
+
+public let VNRecognizeTextRequestRevision1: Int = 1
+public let VNRecognizeTextRequestRevision2: Int = 2
+public let VNRecognizeTextRequestRevision3: Int = 3
+
+public let VNDetectDocumentSegmentationRequestRevision1: Int = 1
+
+public let VNGenerateAttentionBasedSaliencyImageRequestRevision1: Int = 1
+public let VNGenerateAttentionBasedSaliencyImageRequestRevision2: Int = 2
+
+/// Identity rectangle in Vision's normalized coordinate space.
+public let VNNormalizedIdentityRect = CGRect(x: 0, y: 0, width: 1, height: 1)
+
+/// Linux-local process identity. The C-string payload of `_VNErrorDomain`
+/// is not an Apple-runtime observation in this tree.
+public let VNErrorDomain: String = "VNErrorDomain"
+
+/// Unobserved on this host; kept as a finite Double so clients can read it.
+public var VNVisionVersionNumber: Double = 0
+
+@_spi(OpenUIKitHost)
+public enum VisionHost {
+    public static let callbackQueue = DispatchQueue(label: "Vision.callback")
+
+    public static func attachResults(_ results: [VNObservation], to request: VNRequest) {
+        request.hostAttachResults(results)
+    }
+
+    public static func makeError(_ code: VNErrorCode, description: String? = nil) -> NSError {
+        vnMakeError(code, description: description)
+    }
+}

--- a/full/vision/VisionContour.swift
+++ b/full/vision/VisionContour.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+open class VNContour: NSObject {
+    public let indexPath: IndexPath
+    public let normalizedPoints: [SIMD2<Float>]
+    public let childContours: [VNContour]
+
+    public var pointCount: Int { normalizedPoints.count }
+    public var childContourCount: Int { childContours.count }
+
+    public var aspectRatio: Float {
+        guard let box = axisAlignedBounds(), box.height > 0 else { return 0 }
+        return Float(box.width / box.height)
+    }
+
+    public init(
+        normalizedPoints: [SIMD2<Float>],
+        indexPath: IndexPath = IndexPath(index: 0),
+        childContours: [VNContour] = []
+    ) {
+        self.normalizedPoints = normalizedPoints
+        self.indexPath = indexPath
+        self.childContours = childContours
+        super.init()
+    }
+
+    @_spi(OpenUIKitHost)
+    public convenience init(
+        hostPoints points: [VNPoint],
+        indexPath: IndexPath = IndexPath(index: 0),
+        childContours: [VNContour] = []
+    ) {
+        self.init(
+            normalizedPoints: points.map { SIMD2<Float>(Float($0.x), Float($0.y)) },
+            indexPath: indexPath,
+            childContours: childContours
+        )
+    }
+
+    public func childContour(at childContourIndex: Int) throws -> VNContour {
+        guard childContours.indices.contains(childContourIndex) else {
+            throw vnMakeError(.outOfBoundsError, description: "childContourIndex")
+        }
+        return childContours[childContourIndex]
+    }
+
+    public func polygonApproximation(epsilon: Float) throws -> VNContour {
+        guard normalizedPoints.count >= 2 else {
+            throw vnMakeError(.invalidArgument, description: "polygonApproximation needs two points")
+        }
+        let simplified = douglasPeucker(normalizedPoints, epsilon: max(0, Double(epsilon)))
+        return VNContour(
+            normalizedPoints: simplified,
+            indexPath: indexPath,
+            childContours: []
+        )
+    }
+
+    func vnPoints() -> [VNPoint] {
+        normalizedPoints.map { VNPoint(x: Double($0.x), y: Double($0.y)) }
+    }
+
+    private func axisAlignedBounds() -> (width: Double, height: Double)? {
+        guard let first = normalizedPoints.first else { return nil }
+        var minX = Double(first.x)
+        var maxX = Double(first.x)
+        var minY = Double(first.y)
+        var maxY = Double(first.y)
+        for point in normalizedPoints.dropFirst() {
+            minX = min(minX, Double(point.x))
+            maxX = max(maxX, Double(point.x))
+            minY = min(minY, Double(point.y))
+            maxY = max(maxY, Double(point.y))
+        }
+        return (maxX - minX, maxY - minY)
+    }
+}
+
+open class VNGeometryUtils: NSObject {
+    public class func boundingCircle(for points: [VNPoint]) throws -> VNCircle {
+        try minimumEnclosingCircle(points)
+    }
+
+    public class func boundingCircle(for contour: VNContour) throws -> VNCircle {
+        try boundingCircle(for: contour.vnPoints())
+    }
+
+    public class func boundingCircle(
+        forSIMDPoints points: UnsafePointer<SIMD2<Float>>,
+        pointCount: Int
+    ) throws -> VNCircle {
+        guard pointCount >= 0 else {
+            throw vnMakeError(.invalidArgument, description: "pointCount")
+        }
+        var converted: [VNPoint] = []
+        converted.reserveCapacity(pointCount)
+        for index in 0..<pointCount {
+            let value = points.advanced(by: index).pointee
+            converted.append(VNPoint(x: Double(value.x), y: Double(value.y)))
+        }
+        return try boundingCircle(for: converted)
+    }
+
+    public class func calculateArea(
+        _ area: UnsafeMutablePointer<Double>,
+        for contour: VNContour,
+        orientedArea: Bool
+    ) throws {
+        let points = contour.vnPoints()
+        guard points.count >= 3 else {
+            throw vnMakeError(.invalidArgument, description: "area needs three points")
+        }
+        var sum: Double = 0
+        for index in 0..<points.count {
+            let current = points[index]
+            let next = points[(index + 1) % points.count]
+            sum += current.x * next.y - next.x * current.y
+        }
+        let signed = sum / 2
+        area.pointee = orientedArea ? signed : abs(signed)
+    }
+
+    public class func calculatePerimeter(
+        _ perimeter: UnsafeMutablePointer<Double>,
+        for contour: VNContour
+    ) throws {
+        let points = contour.vnPoints()
+        guard points.count >= 2 else {
+            throw vnMakeError(.invalidArgument, description: "perimeter needs two points")
+        }
+        var length: Double = 0
+        for index in 0..<points.count {
+            let current = points[index]
+            let next = points[(index + 1) % points.count]
+            length += current.distance(next)
+        }
+        perimeter.pointee = length
+    }
+}
+
+func minimumEnclosingCircle(_ points: [VNPoint]) throws -> VNCircle {
+    if points.isEmpty {
+        throw vnMakeError(.invalidArgument, description: "empty point set")
+    }
+    var unique: [VNPoint] = []
+    unique.reserveCapacity(points.count)
+    for point in points {
+        if !unique.contains(where: { $0.x == point.x && $0.y == point.y }) {
+            unique.append(point)
+        }
+    }
+    if unique.count == 1 {
+        return VNCircle(center: unique[0], radius: 0)
+    }
+    var shuffled = unique
+    for index in stride(from: shuffled.count - 1, through: 1, by: -1) {
+        let swapIndex = Int.random(in: 0...index)
+        shuffled.swapAt(index, swapIndex)
+    }
+    return welzl(points: shuffled, boundary: [])
+}
+
+private func welzl(points: [VNPoint], boundary: [VNPoint]) -> VNCircle {
+    if boundary.count == 3 || points.isEmpty {
+        return trivialCircle(boundary)
+    }
+    var remaining = points
+    let point = remaining.removeLast()
+    let circle = welzl(points: remaining, boundary: boundary)
+    if circle.contains(point) {
+        return circle
+    }
+    return welzl(points: remaining, boundary: boundary + [point])
+}
+
+private func trivialCircle(_ points: [VNPoint]) -> VNCircle {
+    switch points.count {
+    case 0:
+        return .zero
+    case 1:
+        return VNCircle(center: points[0], radius: 0)
+    case 2:
+        return diameterCircle(points[0], points[1])
+    default:
+        return circleFromThree(points[0], points[1], points[2])
+    }
+}
+
+private func diameterCircle(_ a: VNPoint, _ b: VNPoint) -> VNCircle {
+    let center = VNPoint(x: (a.x + b.x) / 2, y: (a.y + b.y) / 2)
+    return VNCircle(center: center, radius: a.distance(b) / 2)
+}
+
+private func circleFromThree(_ a: VNPoint, _ b: VNPoint, _ c: VNPoint) -> VNCircle {
+    let ab = a.distance(b)
+    let bc = b.distance(c)
+    let ca = c.distance(a)
+    let longest = max(ab, max(bc, ca))
+    if ab == longest && ab * ab >= bc * bc + ca * ca - 1e-15 {
+        return diameterCircle(a, b)
+    }
+    if bc == longest && bc * bc >= ab * ab + ca * ca - 1e-15 {
+        return diameterCircle(b, c)
+    }
+    if ca == longest && ca * ca >= ab * ab + bc * bc - 1e-15 {
+        return diameterCircle(c, a)
+    }
+    let d = 2 * (a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y))
+    if abs(d) < 1e-18 {
+        if ab >= bc && ab >= ca { return diameterCircle(a, b) }
+        if bc >= ab && bc >= ca { return diameterCircle(b, c) }
+        return diameterCircle(c, a)
+    }
+    let a2 = a.x * a.x + a.y * a.y
+    let b2 = b.x * b.x + b.y * b.y
+    let c2 = c.x * c.x + c.y * c.y
+    let ux = (a2 * (b.y - c.y) + b2 * (c.y - a.y) + c2 * (a.y - b.y)) / d
+    let uy = (a2 * (c.x - b.x) + b2 * (a.x - c.x) + c2 * (b.x - a.x)) / d
+    let center = VNPoint(x: ux, y: uy)
+    let radius = max(center.distance(a), max(center.distance(b), center.distance(c)))
+    return VNCircle(center: center, radius: radius)
+}
+
+private func douglasPeucker(_ points: [SIMD2<Float>], epsilon: Double) -> [SIMD2<Float>] {
+    if points.count <= 2 {
+        return points
+    }
+    let start = points.first!
+    let end = points.last!
+    var maxDistance: Double = 0
+    var maxIndex = 0
+    for index in 1..<(points.count - 1) {
+        let distance = perpendicularDistance(points[index], start, end)
+        if distance > maxDistance {
+            maxDistance = distance
+            maxIndex = index
+        }
+    }
+    if maxDistance > epsilon {
+        let left = douglasPeucker(Array(points[0...maxIndex]), epsilon: epsilon)
+        let right = douglasPeucker(Array(points[maxIndex...]), epsilon: epsilon)
+        return left.dropLast() + right
+    }
+    return [start, end]
+}
+
+private func perpendicularDistance(
+    _ point: SIMD2<Float>,
+    _ start: SIMD2<Float>,
+    _ end: SIMD2<Float>
+) -> Double {
+    let dx = Double(end.x - start.x)
+    let dy = Double(end.y - start.y)
+    if dx == 0 && dy == 0 {
+        let px = Double(point.x - start.x)
+        let py = Double(point.y - start.y)
+        return (px * px + py * py).squareRoot()
+    }
+    let numerator = abs(dy * Double(point.x) - dx * Double(point.y) + Double(end.x) * Double(start.y) - Double(end.y) * Double(start.x))
+    return numerator / (dx * dx + dy * dy).squareRoot()
+}

--- a/full/vision/VisionEnums.swift
+++ b/full/vision/VisionEnums.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+@frozen
+public enum VNBarcodeCompositeType: Int, CaseIterable, Sendable {
+    case none = 0
+    case linked = 1
+    case gs1TypeA = 2
+    case gs1TypeB = 3
+    case gs1TypeC = 4
+}
+
+@frozen
+public enum VNChirality: Int, CaseIterable, Sendable {
+    case unknown = 0
+    case left = -1
+    case right = 1
+}
+
+public enum VNElementType: UInt, CaseIterable, Sendable {
+    case unknown = 0
+    case float = 1
+    case double = 2
+}
+
+public func VNElementTypeSize(_ elementType: VNElementType) -> Int {
+    switch elementType {
+    case .unknown:
+        return 0
+    case .float:
+        return MemoryLayout<Float>.size
+    case .double:
+        return MemoryLayout<Double>.size
+    }
+}
+
+public enum VNImageCropAndScaleOption: UInt, CaseIterable, Sendable {
+    case centerCrop = 0
+    case scaleFit = 1
+    case scaleFill = 2
+    case scaleFitRotate90CCW = 257
+    case scaleFillRotate90CCW = 258
+}
+
+@frozen
+public enum VNPointsClassification: Int, CaseIterable, Sendable {
+    case disconnected = 0
+    case openPath = 1
+    case closedPath = 2
+}
+
+public enum VNRequestFaceLandmarksConstellation: UInt, CaseIterable, Sendable {
+    case constellationNotDefined = 0
+    case constellation65Points = 1
+    case constellation76Points = 2
+}
+
+public enum VNRequestTextRecognitionLevel: Int, CaseIterable, Sendable {
+    case accurate = 0
+    case fast = 1
+}
+
+public enum VNRequestTrackingLevel: UInt, CaseIterable, Sendable {
+    case accurate = 0
+    case fast = 1
+}

--- a/full/vision/VisionError.swift
+++ b/full/vision/VisionError.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// `NSInteger` cases follow independent `dotnet/macios` Native bindings
+/// (`TuriCore = -1`, `Ok = 0`, then sequential). That is declaration
+/// evidence, not an Apple runtime oracle.
+public enum VNErrorCode: Int, CaseIterable, Sendable {
+    case turiCoreErrorCode = -1
+    case OK = 0
+    case requestCancelled = 1
+    case invalidFormat = 2
+    case operationFailed = 3
+    case outOfBoundsError = 4
+    case invalidOption = 5
+    case ioError = 6
+    case missingOption = 7
+    case notImplemented = 8
+    case internalError = 9
+    case outOfMemory = 10
+    case unknownError = 11
+    case invalidOperation = 12
+    case invalidImage = 13
+    case invalidArgument = 14
+    case invalidModel = 15
+    case unsupportedRevision = 16
+    case dataUnavailable = 17
+    case timeStampNotFound = 18
+    case unsupportedRequest = 19
+    case timeout = 20
+    case unsupportedComputeStage = 21
+    case unsupportedComputeDevice = 22
+}
+
+func vnMakeError(_ code: VNErrorCode, description: String? = nil) -> NSError {
+    var info: [String: Any] = [:]
+    if let description {
+        info[NSLocalizedDescriptionKey] = description
+    }
+    return NSError(domain: VNErrorDomain, code: code.rawValue, userInfo: info)
+}
+
+func vnThrow(_ code: VNErrorCode, description: String) throws -> Never {
+    throw vnMakeError(code, description: description)
+}

--- a/full/vision/VisionGeometry.swift
+++ b/full/vision/VisionGeometry.swift
@@ -1,0 +1,413 @@
+import Foundation
+
+open class VNPoint: NSObject, NSCopying, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    public let x: Double
+    public let y: Double
+
+    public var location: CGPoint {
+        CGPoint(x: x, y: y)
+    }
+
+    public class var zero: VNPoint {
+        VNPoint(x: 0, y: 0)
+    }
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+        super.init()
+    }
+
+    public convenience init(location: CGPoint) {
+        self.init(x: Double(location.x), y: Double(location.y))
+    }
+
+    public required init?(coder: NSCoder) {
+        x = coder.decodeDouble(forKey: "x")
+        y = coder.decodeDouble(forKey: "y")
+        super.init()
+    }
+
+    open func encode(with coder: NSCoder) {
+        coder.encode(x, forKey: "x")
+        coder.encode(y, forKey: "y")
+    }
+
+    open func copy(with zone: NSZone? = nil) -> Any {
+        VNPoint(x: x, y: y)
+    }
+
+    public class func distance(_ point1: VNPoint, _ point2: VNPoint) -> Double {
+        point1.distance(point2)
+    }
+
+    public func distance(_ point: VNPoint) -> Double {
+        let dx = x - point.x
+        let dy = y - point.y
+        return (dx * dx + dy * dy).squareRoot()
+    }
+
+    public class func apply(_ vector: VNVector, to point: VNPoint) -> VNPoint {
+        VNPoint(x: point.x + vector.x, y: point.y + vector.y)
+    }
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? VNPoint else { return false }
+        return x == other.x && y == other.y
+    }
+
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(x)
+        hasher.combine(y)
+        return hasher.finalize()
+    }
+}
+
+open class VNDetectedPoint: VNPoint {
+    public let confidence: VNConfidence
+
+    public init(x: Double, y: Double, confidence: VNConfidence) {
+        self.confidence = confidence
+        super.init(x: x, y: y)
+    }
+
+    public required init?(coder: NSCoder) {
+        confidence = Float(coder.decodeDouble(forKey: "confidence"))
+        super.init(coder: coder)
+    }
+
+    open override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(Double(confidence), forKey: "confidence")
+    }
+
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        VNDetectedPoint(x: x, y: y, confidence: confidence)
+    }
+}
+
+open class VNVector: NSObject, NSCopying, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    public let x: Double
+    public let y: Double
+
+    public class var zero: VNVector {
+        VNVector(xComponent: 0, yComponent: 0)
+    }
+
+    public var length: Double {
+        (x * x + y * y).squareRoot()
+    }
+
+    public var squaredLength: Double {
+        x * x + y * y
+    }
+
+    public var r: Double { length }
+
+    public var theta: Double {
+        atan2(y, x)
+    }
+
+    public init(xComponent x: Double, yComponent y: Double) {
+        self.x = x
+        self.y = y
+        super.init()
+    }
+
+    public convenience init(XComponent x: Double, yComponent y: Double) {
+        self.init(xComponent: x, yComponent: y)
+    }
+
+    public convenience init(r: Double, theta: Double) {
+        self.init(xComponent: r * cos(theta), yComponent: r * sin(theta))
+    }
+
+    public convenience init(vectorHead head: VNPoint, tail: VNPoint) {
+        self.init(xComponent: head.x - tail.x, yComponent: head.y - tail.y)
+    }
+
+    public init(byAdding v1: VNVector, to v2: VNVector) {
+        x = v1.x + v2.x
+        y = v1.y + v2.y
+        super.init()
+    }
+
+    public convenience init(byAddingVector v1: VNVector, toVector v2: VNVector) {
+        self.init(byAdding: v1, to: v2)
+    }
+
+    public init(bySubtracting v1: VNVector, from v2: VNVector) {
+        x = v2.x - v1.x
+        y = v2.y - v1.y
+        super.init()
+    }
+
+    public convenience init(bySubtractingVector v1: VNVector, fromVector v2: VNVector) {
+        self.init(bySubtracting: v1, from: v2)
+    }
+
+    public init(byMultiplying vector: VNVector, byScalar scalar: Double) {
+        x = vector.x * scalar
+        y = vector.y * scalar
+        super.init()
+    }
+
+    public convenience init(byMultiplyingVector vector: VNVector, byScalar scalar: Double) {
+        self.init(byMultiplying: vector, byScalar: scalar)
+    }
+
+    public class func dotProduct(of v1: VNVector, vector v2: VNVector) -> Double {
+        v1.x * v2.x + v1.y * v2.y
+    }
+
+    public class func unitVector(for vector: VNVector) -> VNVector {
+        let length = vector.length
+        if length == 0 {
+            return .zero
+        }
+        return VNVector(xComponent: vector.x / length, yComponent: vector.y / length)
+    }
+
+    public required init?(coder: NSCoder) {
+        x = coder.decodeDouble(forKey: "x")
+        y = coder.decodeDouble(forKey: "y")
+        super.init()
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(x, forKey: "x")
+        coder.encode(y, forKey: "y")
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        VNVector(xComponent: x, yComponent: y)
+    }
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? VNVector else { return false }
+        return x == other.x && y == other.y
+    }
+
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(x)
+        hasher.combine(y)
+        return hasher.finalize()
+    }
+}
+
+open class VNCircle: NSObject, NSCopying, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    public let center: VNPoint
+    public let radius: Double
+
+    public var diameter: Double { radius * 2 }
+
+    public class var zero: VNCircle {
+        VNCircle(center: .zero, radius: 0)
+    }
+
+    public init(center: VNPoint, radius: Double) {
+        self.center = center
+        self.radius = max(0, radius)
+        super.init()
+    }
+
+    public convenience init(center: VNPoint, diameter: Double) {
+        self.init(center: center, radius: diameter / 2)
+    }
+
+    public func contains(_ point: VNPoint) -> Bool {
+        center.distance(point) <= radius
+    }
+
+    /// Linux annulus: a point lies in the ring when `|d − r| ≤ ringWidth`.
+    /// Apple's circumferential placement is unobserved here.
+    public func contains(_ point: VNPoint, inCircumferentialRingOfWidth ringWidth: Double) -> Bool {
+        let width = max(0, ringWidth)
+        let distance = center.distance(point)
+        return abs(distance - radius) <= width
+    }
+
+    public required init?(coder: NSCoder) {
+        let x = coder.decodeDouble(forKey: "cx")
+        let y = coder.decodeDouble(forKey: "cy")
+        center = VNPoint(x: x, y: y)
+        radius = coder.decodeDouble(forKey: "radius")
+        super.init()
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(center.x, forKey: "cx")
+        coder.encode(center.y, forKey: "cy")
+        coder.encode(radius, forKey: "radius")
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        VNCircle(center: center, radius: radius)
+    }
+}
+
+public func VNNormalizedRectIsIdentityRect(_ normalizedRect: CGRect) -> Bool {
+    normalizedRect.origin.x == 0
+        && normalizedRect.origin.y == 0
+        && normalizedRect.size.width == 1
+        && normalizedRect.size.height == 1
+}
+
+public func VNImagePointForNormalizedPoint(
+    _ normalizedPoint: CGPoint,
+    _ imageWidth: Int,
+    _ imageHeight: Int
+) -> CGPoint {
+    CGPoint(
+        x: normalizedPoint.x * CGFloat(imageWidth),
+        y: normalizedPoint.y * CGFloat(imageHeight)
+    )
+}
+
+public func VNNormalizedPointForImagePoint(
+    _ imagePoint: CGPoint,
+    _ imageWidth: Int,
+    _ imageHeight: Int
+) -> CGPoint {
+    let width = max(imageWidth, 1)
+    let height = max(imageHeight, 1)
+    return CGPoint(
+        x: imagePoint.x / CGFloat(width),
+        y: imagePoint.y / CGFloat(height)
+    )
+}
+
+public func VNImageRectForNormalizedRect(
+    _ normalizedRect: CGRect,
+    _ imageWidth: Int,
+    _ imageHeight: Int
+) -> CGRect {
+    let origin = VNImagePointForNormalizedPoint(normalizedRect.origin, imageWidth, imageHeight)
+    return CGRect(
+        x: origin.x,
+        y: origin.y,
+        width: normalizedRect.width * CGFloat(imageWidth),
+        height: normalizedRect.height * CGFloat(imageHeight)
+    )
+}
+
+public func VNNormalizedRectForImageRect(
+    _ imageRect: CGRect,
+    _ imageWidth: Int,
+    _ imageHeight: Int
+) -> CGRect {
+    let origin = VNNormalizedPointForImagePoint(imageRect.origin, imageWidth, imageHeight)
+    let width = max(imageWidth, 1)
+    let height = max(imageHeight, 1)
+    return CGRect(
+        x: origin.x,
+        y: origin.y,
+        width: imageRect.width / CGFloat(width),
+        height: imageRect.height / CGFloat(height)
+    )
+}
+
+public func VNImagePointForNormalizedPointUsingRegionOfInterest(
+    _ normalizedPoint: CGPoint,
+    _ imageWidth: Int,
+    _ imageHeight: Int,
+    _ roi: CGRect
+) -> CGPoint {
+    let mapped = CGPoint(
+        x: roi.origin.x + normalizedPoint.x * roi.size.width,
+        y: roi.origin.y + normalizedPoint.y * roi.size.height
+    )
+    return VNImagePointForNormalizedPoint(mapped, imageWidth, imageHeight)
+}
+
+public func VNNormalizedPointForImagePointUsingRegionOfInterest(
+    _ imagePoint: CGPoint,
+    _ imageWidth: Int,
+    _ imageHeight: Int,
+    _ roi: CGRect
+) -> CGPoint {
+    let normalized = VNNormalizedPointForImagePoint(imagePoint, imageWidth, imageHeight)
+    let width = roi.size.width == 0 ? 1 : roi.size.width
+    let height = roi.size.height == 0 ? 1 : roi.size.height
+    return CGPoint(
+        x: (normalized.x - roi.origin.x) / width,
+        y: (normalized.y - roi.origin.y) / height
+    )
+}
+
+public func VNImageRectForNormalizedRectUsingRegionOfInterest(
+    _ normalizedRect: CGRect,
+    _ imageWidth: Int,
+    _ imageHeight: Int,
+    _ roi: CGRect
+) -> CGRect {
+    let origin = VNImagePointForNormalizedPointUsingRegionOfInterest(
+        normalizedRect.origin,
+        imageWidth,
+        imageHeight,
+        roi
+    )
+    return CGRect(
+        x: origin.x,
+        y: origin.y,
+        width: normalizedRect.width * roi.size.width * CGFloat(imageWidth),
+        height: normalizedRect.height * roi.size.height * CGFloat(imageHeight)
+    )
+}
+
+public func VNNormalizedRectForImageRectUsingRegionOfInterest(
+    _ imageRect: CGRect,
+    _ imageWidth: Int,
+    _ imageHeight: Int,
+    _ roi: CGRect
+) -> CGRect {
+    let origin = VNNormalizedPointForImagePointUsingRegionOfInterest(
+        imageRect.origin,
+        imageWidth,
+        imageHeight,
+        roi
+    )
+    let width = roi.size.width == 0 ? 1 : roi.size.width
+    let height = roi.size.height == 0 ? 1 : roi.size.height
+    return CGRect(
+        x: origin.x,
+        y: origin.y,
+        width: (imageRect.width / CGFloat(max(imageWidth, 1))) / width,
+        height: (imageRect.height / CGFloat(max(imageHeight, 1))) / height
+    )
+}
+
+public func VNImagePointForFaceLandmarkPoint(
+    _ faceLandmarkPoint: SIMD2<Float>,
+    _ faceBoundingBox: CGRect,
+    _ imageWidth: Int,
+    _ imageHeight: Int
+) -> CGPoint {
+    let normalized = CGPoint(
+        x: faceBoundingBox.origin.x + CGFloat(faceLandmarkPoint.x) * faceBoundingBox.size.width,
+        y: faceBoundingBox.origin.y + CGFloat(faceLandmarkPoint.y) * faceBoundingBox.size.height
+    )
+    return VNImagePointForNormalizedPoint(normalized, imageWidth, imageHeight)
+}
+
+public func VNNormalizedFaceBoundingBoxPointForLandmarkPoint(
+    _ faceLandmarkPoint: SIMD2<Float>,
+    _ faceBoundingBox: CGRect,
+    _ imageWidth: Int,
+    _ imageHeight: Int
+) -> CGPoint {
+    _ = imageWidth
+    _ = imageHeight
+    return CGPoint(
+        x: faceBoundingBox.origin.x + CGFloat(faceLandmarkPoint.x) * faceBoundingBox.size.width,
+        y: faceBoundingBox.origin.y + CGFloat(faceLandmarkPoint.y) * faceBoundingBox.size.height
+    )
+}

--- a/full/vision/VisionIdentifiers.swift
+++ b/full/vision/VisionIdentifiers.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public struct VNBarcodeSymbology: RawRepresentable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let aztec = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyAztec")
+    public static let codabar = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCodabar")
+    public static let code128 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode128")
+    public static let code39 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode39")
+    public static let code39Checksum = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode39Checksum")
+    public static let code39FullASCII = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode39FullASCII")
+    public static let code39FullASCIIChecksum = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode39FullASCIIChecksum")
+    public static let code93 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode93")
+    public static let code93i = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyCode93i")
+    public static let dataMatrix = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyDataMatrix")
+    public static let ean13 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyEAN13")
+    public static let ean8 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyEAN8")
+    public static let gs1DataBar = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyGS1DataBar")
+    public static let gs1DataBarExpanded = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyGS1DataBarExpanded")
+    public static let gs1DataBarLimited = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyGS1DataBarLimited")
+    public static let i2of5 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyI2of5")
+    public static let i2of5Checksum = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyI2of5Checksum")
+    public static let itf14 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyITF14")
+    public static let msiPlessey = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyMSIPlessey")
+    public static let microPDF417 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyMicroPDF417")
+    public static let microQR = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyMicroQR")
+    public static let pdf417 = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyPDF417")
+    public static let qr = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyQR")
+    public static let upce = VNBarcodeSymbology(rawValue: "VNBarcodeSymbologyUPCE")
+
+    public static var Aztec: VNBarcodeSymbology { aztec }
+    public static var Codabar: VNBarcodeSymbology { codabar }
+    public static var Code128: VNBarcodeSymbology { code128 }
+    public static var Code39: VNBarcodeSymbology { code39 }
+    public static var Code39Checksum: VNBarcodeSymbology { code39Checksum }
+    public static var Code39FullASCII: VNBarcodeSymbology { code39FullASCII }
+    public static var Code39FullASCIIChecksum: VNBarcodeSymbology { code39FullASCIIChecksum }
+    public static var Code93: VNBarcodeSymbology { code93 }
+    public static var Code93i: VNBarcodeSymbology { code93i }
+    public static var DataMatrix: VNBarcodeSymbology { dataMatrix }
+    public static var EAN13: VNBarcodeSymbology { ean13 }
+    public static var EAN8: VNBarcodeSymbology { ean8 }
+    public static var I2of5: VNBarcodeSymbology { i2of5 }
+    public static var I2of5Checksum: VNBarcodeSymbology { i2of5Checksum }
+    public static var ITF14: VNBarcodeSymbology { itf14 }
+    public static var PDF417: VNBarcodeSymbology { pdf417 }
+    public static var QR: VNBarcodeSymbology { qr }
+    public static var UPCE: VNBarcodeSymbology { upce }
+
+    public static let knownSymbologies: [VNBarcodeSymbology] = [
+        .aztec, .codabar, .code128, .code39, .code39Checksum, .code39FullASCII,
+        .code39FullASCIIChecksum, .code93, .code93i, .dataMatrix, .ean13, .ean8,
+        .gs1DataBar, .gs1DataBarExpanded, .gs1DataBarLimited, .i2of5, .i2of5Checksum,
+        .itf14, .msiPlessey, .microPDF417, .microQR, .pdf417, .qr, .upce,
+    ]
+}
+
+public struct VNImageOption: RawRepresentable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let ciContext = VNImageOption(rawValue: "VNImageOptionCIContext")
+    public static let cameraIntrinsics = VNImageOption(rawValue: "VNImageOptionCameraIntrinsics")
+    public static let properties = VNImageOption(rawValue: "VNImageOptionProperties")
+}
+
+public struct VNComputeStage: RawRepresentable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let main = VNComputeStage(rawValue: "VNComputeStageMain")
+    public static let postProcessing = VNComputeStage(rawValue: "VNComputeStagePostProcessing")
+}

--- a/full/vision/VisionObservation.swift
+++ b/full/vision/VisionObservation.swift
@@ -1,0 +1,356 @@
+import Foundation
+
+open class VNObservation: NSObject, NSCopying, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    public let uuid: UUID
+    public let confidence: VNConfidence
+
+    public init(uuid: UUID = UUID(), confidence: VNConfidence = 1) {
+        self.uuid = uuid
+        self.confidence = max(0, min(1, confidence))
+        super.init()
+    }
+
+    public required init?(coder: NSCoder) {
+        let uuidString = coder.decodeObject(of: NSString.self, forKey: "uuid") as String?
+        uuid = UUID(uuidString: uuidString ?? "") ?? UUID()
+        confidence = Float(coder.decodeDouble(forKey: "confidence"))
+        super.init()
+    }
+
+    open func encode(with coder: NSCoder) {
+        coder.encode(uuid.uuidString as NSString, forKey: "uuid")
+        coder.encode(Double(confidence), forKey: "confidence")
+    }
+
+    open func copy(with zone: NSZone? = nil) -> Any {
+        VNObservation(uuid: uuid, confidence: confidence)
+    }
+}
+
+open class VNDetectedObjectObservation: VNObservation {
+    public let boundingBox: CGRect
+
+    public convenience init(boundingBox: CGRect) {
+        self.init(requestRevision: VNRequestRevisionUnspecified, boundingBox: boundingBox)
+    }
+
+    public init(requestRevision: Int, boundingBox: CGRect, confidence: VNConfidence = 1, uuid: UUID = UUID()) {
+        self.boundingBox = boundingBox
+        _ = requestRevision
+        super.init(uuid: uuid, confidence: confidence)
+    }
+
+    public required init?(coder: NSCoder) {
+        let x = coder.decodeDouble(forKey: "bx")
+        let y = coder.decodeDouble(forKey: "by")
+        let w = coder.decodeDouble(forKey: "bw")
+        let h = coder.decodeDouble(forKey: "bh")
+        boundingBox = CGRect(x: x, y: y, width: w, height: h)
+        super.init(coder: coder)
+    }
+
+    open override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(Double(boundingBox.origin.x), forKey: "bx")
+        coder.encode(Double(boundingBox.origin.y), forKey: "by")
+        coder.encode(Double(boundingBox.size.width), forKey: "bw")
+        coder.encode(Double(boundingBox.size.height), forKey: "bh")
+    }
+
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        VNDetectedObjectObservation(
+            requestRevision: VNRequestRevisionUnspecified,
+            boundingBox: boundingBox,
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+}
+
+open class VNRectangleObservation: VNDetectedObjectObservation {
+    public let topLeft: CGPoint
+    public let topRight: CGPoint
+    public let bottomRight: CGPoint
+    public let bottomLeft: CGPoint
+
+    public convenience init(
+        requestRevision: Int,
+        topLeft: CGPoint,
+        bottomLeft: CGPoint,
+        bottomRight: CGPoint,
+        topRight: CGPoint
+    ) {
+        self.init(
+            requestRevision: requestRevision,
+            topLeft: topLeft,
+            topRight: topRight,
+            bottomRight: bottomRight,
+            bottomLeft: bottomLeft
+        )
+    }
+
+    public init(
+        requestRevision: Int,
+        topLeft: CGPoint,
+        topRight: CGPoint,
+        bottomRight: CGPoint,
+        bottomLeft: CGPoint,
+        confidence: VNConfidence = 1,
+        uuid: UUID = UUID()
+    ) {
+        self.topLeft = topLeft
+        self.topRight = topRight
+        self.bottomRight = bottomRight
+        self.bottomLeft = bottomLeft
+        let minX = min(topLeft.x, min(topRight.x, min(bottomLeft.x, bottomRight.x)))
+        let maxX = max(topLeft.x, max(topRight.x, max(bottomLeft.x, bottomRight.x)))
+        let minY = min(topLeft.y, min(topRight.y, min(bottomLeft.y, bottomRight.y)))
+        let maxY = max(topLeft.y, max(topRight.y, max(bottomLeft.y, bottomRight.y)))
+        super.init(
+            requestRevision: requestRevision,
+            boundingBox: CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY),
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+
+    public required init?(coder: NSCoder) {
+        func point(_ prefix: String) -> CGPoint {
+            CGPoint(
+                x: coder.decodeDouble(forKey: prefix + "x"),
+                y: coder.decodeDouble(forKey: prefix + "y")
+            )
+        }
+        topLeft = point("tl")
+        topRight = point("tr")
+        bottomRight = point("br")
+        bottomLeft = point("bl")
+        super.init(coder: coder)
+    }
+
+    open override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        func encodePoint(_ point: CGPoint, _ prefix: String) {
+            coder.encode(Double(point.x), forKey: prefix + "x")
+            coder.encode(Double(point.y), forKey: prefix + "y")
+        }
+        encodePoint(topLeft, "tl")
+        encodePoint(topRight, "tr")
+        encodePoint(bottomRight, "br")
+        encodePoint(bottomLeft, "bl")
+    }
+
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        VNRectangleObservation(
+            requestRevision: VNRequestRevisionUnspecified,
+            topLeft: topLeft,
+            topRight: topRight,
+            bottomRight: bottomRight,
+            bottomLeft: bottomLeft,
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+}
+
+open class VNBarcodeObservation: VNRectangleObservation {
+    public let symbology: VNBarcodeSymbology
+    public let payloadStringValue: String?
+    public let payloadData: Data?
+    public let isGS1DataCarrier: Bool
+    public let isColorInverted: Bool
+    public let supplementalCompositeType: VNBarcodeCompositeType
+    public let supplementalPayloadString: String?
+    public let supplementalPayloadData: Data?
+
+    public init(
+        requestRevision: Int = VNRequestRevisionUnspecified,
+        topLeft: CGPoint,
+        topRight: CGPoint,
+        bottomRight: CGPoint,
+        bottomLeft: CGPoint,
+        symbology: VNBarcodeSymbology,
+        payloadStringValue: String? = nil,
+        payloadData: Data? = nil,
+        isGS1DataCarrier: Bool = false,
+        isColorInverted: Bool = false,
+        supplementalCompositeType: VNBarcodeCompositeType = .none,
+        supplementalPayloadString: String? = nil,
+        supplementalPayloadData: Data? = nil,
+        confidence: VNConfidence = 1,
+        uuid: UUID = UUID()
+    ) {
+        self.symbology = symbology
+        self.payloadStringValue = payloadStringValue
+        self.payloadData = payloadData
+        self.isGS1DataCarrier = isGS1DataCarrier
+        self.isColorInverted = isColorInverted
+        self.supplementalCompositeType = supplementalCompositeType
+        self.supplementalPayloadString = supplementalPayloadString
+        self.supplementalPayloadData = supplementalPayloadData
+        super.init(
+            requestRevision: requestRevision,
+            topLeft: topLeft,
+            topRight: topRight,
+            bottomRight: bottomRight,
+            bottomLeft: bottomLeft,
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+
+    public required init?(coder: NSCoder) {
+        let raw = coder.decodeObject(of: NSString.self, forKey: "symbology") as String? ?? ""
+        symbology = VNBarcodeSymbology(rawValue: raw)
+        payloadStringValue = coder.decodeObject(of: NSString.self, forKey: "payload") as String?
+        payloadData = coder.decodeObject(of: NSData.self, forKey: "payloadData") as Data?
+        isGS1DataCarrier = coder.decodeBool(forKey: "gs1")
+        isColorInverted = coder.decodeBool(forKey: "inverted")
+        supplementalCompositeType = VNBarcodeCompositeType(
+            rawValue: coder.decodeInteger(forKey: "composite")
+        ) ?? .none
+        supplementalPayloadString = coder.decodeObject(of: NSString.self, forKey: "supp") as String?
+        supplementalPayloadData = coder.decodeObject(of: NSData.self, forKey: "suppData") as Data?
+        super.init(coder: coder)
+    }
+
+    open override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(symbology.rawValue as NSString, forKey: "symbology")
+        coder.encode(payloadStringValue as NSString?, forKey: "payload")
+        coder.encode(payloadData as NSData?, forKey: "payloadData")
+        coder.encode(isGS1DataCarrier, forKey: "gs1")
+        coder.encode(isColorInverted, forKey: "inverted")
+        coder.encode(supplementalCompositeType.rawValue, forKey: "composite")
+        coder.encode(supplementalPayloadString as NSString?, forKey: "supp")
+        coder.encode(supplementalPayloadData as NSData?, forKey: "suppData")
+    }
+}
+
+open class VNTextObservation: VNRectangleObservation {
+    public let characterBoxes: [VNRectangleObservation]?
+
+    public init(
+        requestRevision: Int = VNRequestRevisionUnspecified,
+        topLeft: CGPoint,
+        topRight: CGPoint,
+        bottomRight: CGPoint,
+        bottomLeft: CGPoint,
+        characterBoxes: [VNRectangleObservation]? = nil,
+        confidence: VNConfidence = 1,
+        uuid: UUID = UUID()
+    ) {
+        self.characterBoxes = characterBoxes
+        super.init(
+            requestRevision: requestRevision,
+            topLeft: topLeft,
+            topRight: topRight,
+            bottomRight: bottomRight,
+            bottomLeft: bottomLeft,
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+
+    public required init?(coder: NSCoder) {
+        characterBoxes = nil
+        super.init(coder: coder)
+    }
+}
+
+open class VNRecognizedText: NSObject {
+    public let string: String
+    public let confidence: VNConfidence
+
+    public init(string: String, confidence: VNConfidence) {
+        self.string = string
+        self.confidence = max(0, min(1, confidence))
+        super.init()
+    }
+
+    public func boundingBox(for range: Range<String.Index>) throws -> VNRectangleObservation {
+        _ = range
+        throw vnMakeError(.notImplemented, description: "boundingBox(for:) needs layout metrics")
+    }
+}
+
+open class VNRecognizedTextObservation: VNRectangleObservation {
+    private let candidates: [VNRecognizedText]
+
+    public init(
+        requestRevision: Int = VNRequestRevisionUnspecified,
+        topLeft: CGPoint,
+        topRight: CGPoint,
+        bottomRight: CGPoint,
+        bottomLeft: CGPoint,
+        candidates: [VNRecognizedText],
+        confidence: VNConfidence = 1,
+        uuid: UUID = UUID()
+    ) {
+        self.candidates = candidates
+        super.init(
+            requestRevision: requestRevision,
+            topLeft: topLeft,
+            topRight: topRight,
+            bottomRight: bottomRight,
+            bottomLeft: bottomLeft,
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+
+    public required init?(coder: NSCoder) {
+        candidates = []
+        super.init(coder: coder)
+    }
+
+    public func topCandidates(_ maxCandidateCount: Int) -> [VNRecognizedText] {
+        Array(candidates.prefix(max(0, maxCandidateCount)))
+    }
+}
+
+open class VNFaceObservation: VNDetectedObjectObservation {
+    public let roll: NSNumber?
+    public let yaw: NSNumber?
+    public let pitch: NSNumber?
+    public let faceCaptureQuality: NSNumber?
+
+    public init(
+        requestRevision: Int = VNRequestRevisionUnspecified,
+        boundingBox: CGRect,
+        roll: NSNumber? = nil,
+        yaw: NSNumber? = nil,
+        pitch: NSNumber? = nil,
+        faceCaptureQuality: NSNumber? = nil,
+        confidence: VNConfidence = 1,
+        uuid: UUID = UUID()
+    ) {
+        self.roll = roll
+        self.yaw = yaw
+        self.pitch = pitch
+        self.faceCaptureQuality = faceCaptureQuality
+        super.init(
+            requestRevision: requestRevision,
+            boundingBox: boundingBox,
+            confidence: confidence,
+            uuid: uuid
+        )
+    }
+
+    public required init?(coder: NSCoder) {
+        roll = nil
+        yaw = nil
+        pitch = nil
+        faceCaptureQuality = nil
+        super.init(coder: coder)
+    }
+}
+
+open class VNHumanBodyPose3DObservation: VNObservation {
+    public enum HeightEstimation: Int, CaseIterable, Sendable {
+        case reference = 0
+        case measured = 1
+    }
+}

--- a/full/vision/VisionRequest.swift
+++ b/full/vision/VisionRequest.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+open class VNRequest: NSObject {
+    public class var currentRevision: Int { VNRequestRevisionUnspecified }
+    public class var defaultRevision: Int { VNRequestRevisionUnspecified }
+    public class var supportedRevisions: IndexSet { IndexSet(integer: VNRequestRevisionUnspecified) }
+
+    public let completionHandler: VNRequestCompletionHandler?
+    public var preferBackgroundProcessing: Bool = false
+    public var usesCPUOnly: Bool = false
+    public var revision: Int
+    public internal(set) var results: [VNObservation]?
+    var isCancelled: Bool = false
+
+    private var hostResults: [VNObservation]?
+
+    public convenience override init() {
+        self.init(completionHandler: nil)
+    }
+
+    public init(completionHandler: VNRequestCompletionHandler? = nil) {
+        self.completionHandler = completionHandler
+        self.revision = type(of: self).defaultRevision
+        super.init()
+    }
+
+    public func cancel() {
+        isCancelled = true
+        results = nil
+        hostResults = nil
+    }
+
+    func hostAttachResults(_ results: [VNObservation]) {
+        hostResults = results
+        isCancelled = false
+    }
+
+    func consumeHostResults() -> [VNObservation]? {
+        let attached = hostResults
+        hostResults = nil
+        return attached
+    }
+
+    func finish(_ observations: [VNObservation]?, error: Error?) {
+        results = observations
+        completionHandler?(self, error)
+    }
+}
+
+open class VNImageBasedRequest: VNRequest {
+    public var regionOfInterest: CGRect = VNNormalizedIdentityRect
+}
+
+open class VNDetectRectanglesRequest: VNImageBasedRequest {
+    public override class var currentRevision: Int { VNDetectRectanglesRequestRevision1 }
+    public override class var defaultRevision: Int { VNDetectRectanglesRequestRevision1 }
+    public override class var supportedRevisions: IndexSet {
+        IndexSet(integer: VNDetectRectanglesRequestRevision1)
+    }
+
+    public var minimumAspectRatio: VNAspectRatio = 0.5
+    public var maximumAspectRatio: VNAspectRatio = 1.0
+    public var quadratureTolerance: VNDegrees = 30
+    public var minimumSize: Float = 0.2
+    public var minimumConfidence: VNConfidence = 0
+    public var maximumObservations: Int = 8
+}
+
+open class VNDetectBarcodesRequest: VNImageBasedRequest {
+    public override class var currentRevision: Int { VNDetectBarcodesRequestRevision4 }
+    public override class var defaultRevision: Int { VNDetectBarcodesRequestRevision4 }
+    public override class var supportedRevisions: IndexSet {
+        IndexSet(integersIn: VNDetectBarcodesRequestRevision1...VNDetectBarcodesRequestRevision4)
+    }
+
+    public class var supportedSymbologies: [VNBarcodeSymbology] {
+        VNBarcodeSymbology.knownSymbologies
+    }
+
+    public var symbologies: [VNBarcodeSymbology] = VNBarcodeSymbology.knownSymbologies
+    public var coalesceCompositeSymbologies: Bool = false
+
+    public func supportedSymbologies() throws -> [VNBarcodeSymbology] {
+        Self.supportedSymbologies
+    }
+}
+
+open class VNRecognizeTextRequest: VNImageBasedRequest {
+    public override class var currentRevision: Int { VNRecognizeTextRequestRevision3 }
+    public override class var defaultRevision: Int { VNRecognizeTextRequestRevision3 }
+    public override class var supportedRevisions: IndexSet {
+        IndexSet(integersIn: VNRecognizeTextRequestRevision1...VNRecognizeTextRequestRevision3)
+    }
+
+    public var recognitionLevel: VNRequestTextRecognitionLevel = .accurate
+    public var usesLanguageCorrection: Bool = true
+    public var automaticallyDetectsLanguage: Bool = false
+    public var minimumTextHeight: Float = 0
+    public var customWords: [String] = []
+    public var recognitionLanguages: [String] = []
+
+    public class func supportedRecognitionLanguages(
+        for recognitionLevel: VNRequestTextRecognitionLevel,
+        revision requestRevision: Int
+    ) throws -> [String] {
+        _ = recognitionLevel
+        _ = requestRevision
+        return []
+    }
+
+    public func supportedRecognitionLanguages() throws -> [String] {
+        try Self.supportedRecognitionLanguages(for: recognitionLevel, revision: revision)
+    }
+}
+
+open class VNDetectFaceRectanglesRequest: VNImageBasedRequest {
+    public override class var currentRevision: Int { VNDetectFaceRectanglesRequestRevision3 }
+    public override class var defaultRevision: Int { VNDetectFaceRectanglesRequestRevision3 }
+    public override class var supportedRevisions: IndexSet {
+        IndexSet(integersIn: VNDetectFaceRectanglesRequestRevision1...VNDetectFaceRectanglesRequestRevision3)
+    }
+}
+
+open class VNDetectFaceLandmarksRequest: VNImageBasedRequest {
+    public var constellation: VNRequestFaceLandmarksConstellation = .constellationNotDefined
+}
+
+open class VNDetectDocumentSegmentationRequest: VNImageBasedRequest {
+    public override class var currentRevision: Int { VNDetectDocumentSegmentationRequestRevision1 }
+    public override class var defaultRevision: Int { VNDetectDocumentSegmentationRequestRevision1 }
+}
+
+open class VNGenerateAttentionBasedSaliencyImageRequest: VNImageBasedRequest {
+    public override class var currentRevision: Int { VNGenerateAttentionBasedSaliencyImageRequestRevision2 }
+    public override class var defaultRevision: Int { VNGenerateAttentionBasedSaliencyImageRequestRevision2 }
+    public override class var supportedRevisions: IndexSet {
+        IndexSet(integersIn: VNGenerateAttentionBasedSaliencyImageRequestRevision1...VNGenerateAttentionBasedSaliencyImageRequestRevision2)
+    }
+}
+
+open class VNTargetedImageRequest: VNImageBasedRequest {}
+
+open class VNGenerateOpticalFlowRequest: VNTargetedImageRequest {
+    public enum ComputationAccuracy: UInt, CaseIterable, Sendable {
+        case low = 0
+        case medium = 1
+        case high = 2
+        case veryHigh = 3
+    }
+
+    public var computationAccuracy: ComputationAccuracy = .medium
+}
+
+open class VNGeneratePersonSegmentationRequest: VNImageBasedRequest {
+    public enum QualityLevel: UInt, CaseIterable, Sendable {
+        case accurate = 0
+        case balanced = 1
+        case fast = 2
+    }
+
+    public var qualityLevel: QualityLevel = .balanced
+}
+
+open class VNTrackingRequest: VNImageBasedRequest {
+    public var trackingLevel: VNRequestTrackingLevel = .accurate
+    public var isLastFrame: Bool = false
+}
+
+open class VNTrackObjectRequest: VNTrackingRequest {}
+
+open class VNTrackRectangleRequest: VNTrackingRequest {}
+
+open class VNTrackOpticalFlowRequest: VNTrackingRequest {
+    public enum ComputationAccuracy: UInt, CaseIterable, Sendable {
+        case low = 0
+        case medium = 1
+        case high = 2
+        case veryHigh = 3
+    }
+
+    public var computationAccuracy: ComputationAccuracy = .medium
+}
+
+open class VNImageRegistrationRequest: VNTargetedImageRequest {}
+
+open class VNTranslationalImageRegistrationRequest: VNImageRegistrationRequest {}
+
+open class VNHomographicImageRegistrationRequest: VNImageRegistrationRequest {}
+
+open class VNImageRequestHandler: NSObject {
+    @_spi(OpenUIKitHost)
+    public enum Source: Equatable {
+        case data(Data)
+        case url(URL)
+    }
+
+    @_spi(OpenUIKitHost)
+    public let source: Source
+    public let options: [VNImageOption: Any]
+
+    public init(data imageData: Data, options: [VNImageOption: Any] = [:]) {
+        self.source = .data(imageData)
+        self.options = options
+        super.init()
+    }
+
+    public init(url imageURL: URL, options: [VNImageOption: Any] = [:]) {
+        self.source = .url(imageURL)
+        self.options = options
+        super.init()
+    }
+
+    public convenience init(URL imageURL: URL, options: [VNImageOption: Any] = [:]) {
+        self.init(url: imageURL, options: options)
+    }
+
+    public func perform(_ requests: [VNRequest]) throws {
+        for request in requests {
+            if request.isCancelled {
+                let error = vnMakeError(.requestCancelled, description: "request cancelled")
+                request.finish(nil, error: error)
+                throw error
+            }
+            if let attached = request.consumeHostResults() {
+                request.finish(attached, error: nil)
+                continue
+            }
+            let error = vnMakeError(
+                .notImplemented,
+                description: "Vision ML / model execution is unavailable on this Linux host"
+            )
+            request.finish(nil, error: error)
+            throw error
+        }
+    }
+}
+
+open class VNSequenceRequestHandler: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    public func perform(_ requests: [VNRequest], onImageData imageData: Data) throws {
+        _ = imageData
+        try VNImageRequestHandler(data: imageData, options: [:]).perform(requests)
+    }
+
+    public func perform(_ requests: [VNRequest], onImageURL imageURL: URL) throws {
+        try VNImageRequestHandler(url: imageURL, options: [:]).perform(requests)
+    }
+}

--- a/full/vision/coverage.tsv
+++ b/full/vision/coverage.tsv
@@ -1,0 +1,3585 @@
+precise	status	evidence	notes
+c:@E@VNBarcodeCompositeType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNBarcodeCompositeType@VNBarcodeCompositeTypeGS1TypeA	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNBarcodeCompositeType@VNBarcodeCompositeTypeGS1TypeB	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNBarcodeCompositeType@VNBarcodeCompositeTypeGS1TypeC	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNBarcodeCompositeType@VNBarcodeCompositeTypeLinked	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNBarcodeCompositeType@VNBarcodeCompositeTypeNone	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNChirality	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNChirality@VNChiralityLeft	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNChirality@VNChiralityRight	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNChirality@VNChiralityUnknown	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNElementType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNElementType@VNElementTypeDouble	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNElementType@VNElementTypeFloat	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNElementType@VNElementTypeUnknown	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorDataUnavailable	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorIOError	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInternalError	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInvalidArgument	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInvalidFormat	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInvalidImage	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInvalidModel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInvalidOperation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorInvalidOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorMissingOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorNotImplemented	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorOK	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorOperationFailed	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorOutOfBoundsError	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorOutOfMemory	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorRequestCancelled	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorTimeStampNotFound	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorTimeout	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorTuriCoreErrorCode	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorUnknownError	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorUnsupportedComputeDevice	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorUnsupportedComputeStage	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorUnsupportedRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNErrorCode@VNErrorUnsupportedRevision	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGenerateOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGenerateOpticalFlowRequestComputationAccuracy@VNGenerateOpticalFlowRequestComputationAccuracyHigh	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGenerateOpticalFlowRequestComputationAccuracy@VNGenerateOpticalFlowRequestComputationAccuracyLow	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGenerateOpticalFlowRequestComputationAccuracy@VNGenerateOpticalFlowRequestComputationAccuracyMedium	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGenerateOpticalFlowRequestComputationAccuracy@VNGenerateOpticalFlowRequestComputationAccuracyVeryHigh	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGeneratePersonSegmentationRequestQualityLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGeneratePersonSegmentationRequestQualityLevel@VNGeneratePersonSegmentationRequestQualityLevelAccurate	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGeneratePersonSegmentationRequestQualityLevel@VNGeneratePersonSegmentationRequestQualityLevelBalanced	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNGeneratePersonSegmentationRequestQualityLevel@VNGeneratePersonSegmentationRequestQualityLevelFast	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNHumanBodyPose3DObservationHeightEstimation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNHumanBodyPose3DObservationHeightEstimation@VNHumanBodyPose3DObservationHeightEstimationMeasured	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNHumanBodyPose3DObservationHeightEstimation@VNHumanBodyPose3DObservationHeightEstimationReference	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNImageCropAndScaleOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNImageCropAndScaleOption@VNImageCropAndScaleOptionCenterCrop	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNImageCropAndScaleOption@VNImageCropAndScaleOptionScaleFill	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNImageCropAndScaleOption@VNImageCropAndScaleOptionScaleFillRotate90CCW	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNImageCropAndScaleOption@VNImageCropAndScaleOptionScaleFit	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNImageCropAndScaleOption@VNImageCropAndScaleOptionScaleFitRotate90CCW	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNPointsClassification	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNPointsClassification@VNPointsClassificationClosedPath	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNPointsClassification@VNPointsClassificationDisconnected	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNPointsClassification@VNPointsClassificationOpenPath	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestFaceLandmarksConstellation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestFaceLandmarksConstellation@VNRequestFaceLandmarksConstellation65Points	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestFaceLandmarksConstellation@VNRequestFaceLandmarksConstellation76Points	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestFaceLandmarksConstellation@VNRequestFaceLandmarksConstellationNotDefined	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestTextRecognitionLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestTextRecognitionLevel@VNRequestTextRecognitionLevelAccurate	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestTextRecognitionLevel@VNRequestTextRecognitionLevelFast	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestTrackingLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestTrackingLevel@VNRequestTrackingLevelAccurate	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNRequestTrackingLevel@VNRequestTrackingLevelFast	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNTrackOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNTrackOpticalFlowRequestComputationAccuracy@VNTrackOpticalFlowRequestComputationAccuracyHigh	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNTrackOpticalFlowRequestComputationAccuracy@VNTrackOpticalFlowRequestComputationAccuracyLow	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNTrackOpticalFlowRequestComputationAccuracy@VNTrackOpticalFlowRequestComputationAccuracyMedium	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@E@VNTrackOpticalFlowRequestComputationAccuracy@VNTrackOpticalFlowRequestComputationAccuracyVeryHigh	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNElementTypeSize	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNImagePointForFaceLandmarkPoint	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNImagePointForNormalizedPoint	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNImagePointForNormalizedPointUsingRegionOfInterest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNImageRectForNormalizedRect	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNImageRectForNormalizedRectUsingRegionOfInterest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNNormalizedFaceBoundingBoxPointForLandmarkPoint	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNNormalizedPointForImagePoint	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNNormalizedPointForImagePointUsingRegionOfInterest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNNormalizedRectForImageRect	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNNormalizedRectForImageRectUsingRegionOfInterest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@F@VNNormalizedRectIsIdentityRect	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNAnimalBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNAnimalBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNAnimalIdentifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNAspectRatio	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNBarcodeSymbology	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNComputeStage	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNConfidence	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNDegrees	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNHumanBodyPose3DObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNHumanBodyPose3DObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNHumanBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNHumanBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNHumanHandPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNHumanHandPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNImageOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNRecognizedPointGroupKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNRecognizedPointKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@T@VNRequestCompletionHandler	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@T@VNRequestProgressHandler	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:@T@VNVideoProcessingOption	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftBackElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftBackKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftBackPaw	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftEarBottom	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftEarMiddle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftEarTop	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftFrontElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftFrontKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameLeftFrontPaw	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameNeck	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameNose	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightBackElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightBackKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightBackPaw	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightEarBottom	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightEarMiddle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightEarTop	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightFrontElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightFrontKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameRightFrontPaw	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameTailBottom	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameTailMiddle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointNameTailTop	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointsGroupNameAll	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointsGroupNameForelegs	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointsGroupNameHead	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointsGroupNameHindlegs	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointsGroupNameTail	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalBodyPoseObservationJointsGroupNameTrunk	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalIdentifierCat	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNAnimalIdentifierDog	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBarcodeSymbologyAztec	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCodabar	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode128	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode39	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode39Checksum	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode39FullASCII	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode39FullASCIIChecksum	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode93	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyCode93i	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyDataMatrix	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyEAN13	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyEAN8	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyGS1DataBar	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyGS1DataBarExpanded	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyGS1DataBarLimited	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyI2of5	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyI2of5Checksum	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyITF14	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyMSIPlessey	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyMicroPDF417	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyMicroQR	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyPDF417	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyQR	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBarcodeSymbologyUPCE	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNBodyLandmarkKeyLeftAnkle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftEar	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftHip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyLeftWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyNeck	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyNose	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightAnkle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightEar	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightHip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRightWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkKeyRoot	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkRegionKeyFace	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkRegionKeyLeftArm	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkRegionKeyLeftLeg	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkRegionKeyRightArm	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkRegionKeyRightLeg	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNBodyLandmarkRegionKeyTorso	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNCalculateImageAestheticsScoresRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNClassifyImageRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNClassifyImageRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNComputeStageMain	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNComputeStagePostProcessing	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNCoreMLRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectAnimalBodyPoseRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectBarcodesRequestRevision1	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectBarcodesRequestRevision2	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectBarcodesRequestRevision3	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectBarcodesRequestRevision4	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectContourRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectDocumentSegmentationRequestRevision1	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:@VNDetectFaceCaptureQualityRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectFaceCaptureQualityRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectFaceCaptureQualityRequestRevision3	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectFaceLandmarksRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectFaceLandmarksRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectFaceLandmarksRequestRevision3	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectFaceRectanglesRequestRevision1	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectFaceRectanglesRequestRevision2	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectFaceRectanglesRequestRevision3	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectHorizonRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectHumanBodyPose3DRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectHumanBodyPoseRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectHumanHandPoseRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectHumanRectanglesRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectHumanRectanglesRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectRectanglesRequestRevision1	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNDetectTextRectanglesRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNDetectTrajectoriesRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNErrorDomain	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:@VNGenerateAttentionBasedSaliencyImageRequestRevision1	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:@VNGenerateAttentionBasedSaliencyImageRequestRevision2	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:@VNGenerateForegroundInstanceMaskRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGenerateImageFeaturePrintRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGenerateImageFeaturePrintRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGenerateObjectnessBasedSaliencyImageRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGenerateObjectnessBasedSaliencyImageRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGenerateOpticalFlowRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGenerateOpticalFlowRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGeneratePersonInstanceMaskRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNGeneratePersonSegmentationRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHomographicImageRegistrationRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameCenterHead	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameCenterShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameLeftAnkle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameLeftElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameLeftHip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameLeftKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameLeftShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameLeftWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRightAnkle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRightElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRightHip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRightKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRightShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRightWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameRoot	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameSpine	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointNameTopHead	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameAll	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameHead	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameLeftArm	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameLeftLeg	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameRightArm	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameRightLeg	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPose3DObservationJointsGroupNameTorso	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftAnkle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftEar	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftHip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameLeftWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameNeck	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameNose	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightAnkle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightEar	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightElbow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightHip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightKnee	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightShoulder	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRightWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointNameRoot	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameAll	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameFace	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameLeftArm	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameLeftLeg	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameRightArm	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameRightLeg	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanBodyPoseObservationJointsGroupNameTorso	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameIndexDIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameIndexMCP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameIndexPIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameIndexTip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameLittleDIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameLittleMCP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameLittlePIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameLittleTip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameMiddleDIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameMiddleMCP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameMiddlePIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameMiddleTip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameRingDIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameRingMCP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameRingPIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameRingTip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameThumbCMC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameThumbIP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameThumbMP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameThumbTip	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointNameWrist	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointsGroupNameAll	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointsGroupNameIndexFinger	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointsGroupNameLittleFinger	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointsGroupNameMiddleFinger	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointsGroupNameRingFinger	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNHumanHandPoseObservationJointsGroupNameThumb	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNImageOptionCIContext	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNImageOptionCameraIntrinsics	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNImageOptionProperties	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNNormalizedIdentityRect	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNRecognizeAnimalsRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNRecognizeAnimalsRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNRecognizeTextRequestRevision1	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNRecognizeTextRequestRevision2	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNRecognizeTextRequestRevision3	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNRecognizedPoint3DGroupKeyAll	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNRecognizedPointGroupKeyAll	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNRequestRevisionUnspecified	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:@VNTrackHomographicImageRegistrationRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNTrackObjectRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNTrackObjectRequestRevision2	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNTrackOpticalFlowRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNTrackRectangleRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNTrackTranslationalImageRegistrationRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNTranslationalImageRegistrationRequestRevision1	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNVideoProcessingOptionFrameCadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNVideoProcessingOptionTimeInterval	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:@VNVisionVersionNumber	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNAnimalBodyPoseObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNAnimalBodyPoseObservation(im)recognizedPointForJointName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNAnimalBodyPoseObservation(im)recognizedPointsForJointsGroupName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNAnimalBodyPoseObservation(py)availableJointGroupNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNAnimalBodyPoseObservation(py)availableJointNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNBarcodeObservation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNBarcodeObservation(py)barcodeDescriptor	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNBarcodeObservation(py)isColorInverted	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNBarcodeObservation(py)isGS1DataCarrier	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNBarcodeObservation(py)payloadData	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNBarcodeObservation(py)payloadStringValue	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNBarcodeObservation(py)supplementalCompositeType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNBarcodeObservation(py)supplementalPayloadData	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNBarcodeObservation(py)supplementalPayloadString	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNBarcodeObservation(py)symbology	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCalculateImageAestheticsScoresRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCalculateImageAestheticsScoresRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCircle	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(cpy)zeroCircle	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(im)containsPoint:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(im)containsPoint:inCircumferentialRingOfWidth:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(im)initWithCenter:diameter:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(im)initWithCenter:radius:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(py)center	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(py)diameter	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNCircle(py)radius	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNClassificationObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassificationObservation(im)hasMinimumPrecision:forRecall:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassificationObservation(im)hasMinimumRecall:forPrecision:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassificationObservation(py)hasPrecisionRecallCurve	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassificationObservation(py)identifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassifyImageRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassifyImageRequest(cm)knownClassificationsForRevision:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassifyImageRequest(im)supportedIdentifiersAndReturnError:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNClassifyImageRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContour	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(im)childContourAtIndex:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(im)polygonApproximationWithEpsilon:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(py)aspectRatio	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(py)childContourCount	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(py)childContours	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(py)indexPath	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContour(py)normalizedPath	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContour(py)pointCount	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNContoursObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContoursObservation(im)contourAtIndex:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContoursObservation(im)contourAtIndexPath:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContoursObservation(py)contourCount	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContoursObservation(py)normalizedPath	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContoursObservation(py)topLevelContourCount	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNContoursObservation(py)topLevelContours	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLFeatureValueObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLFeatureValueObservation(py)featureName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLFeatureValueObservation(py)featureValue	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLModel	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLModel(cm)modelForMLModel:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLModel(cm)modelForMLModel:error:::SYNTHESIZED::c:objc(cs)VNCoreMLModel	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLModel(py)featureProvider	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLModel(py)inputImageFeatureName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLRequest(im)initWithModel:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLRequest(im)initWithModel:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLRequest(py)imageCropAndScaleOption	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNCoreMLRequest(py)model	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectAnimalBodyPoseRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectAnimalBodyPoseRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectBarcodesRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectBarcodesRequest(cpy)supportedSymbologies	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectBarcodesRequest(im)supportedSymbologiesAndReturnError:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectBarcodesRequest(py)coalesceCompositeSymbologies	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectBarcodesRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectBarcodesRequest(py)symbologies	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectContoursRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectContoursRequest(py)contrastAdjustment	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectContoursRequest(py)contrastPivot	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectContoursRequest(py)detectDarkOnLight	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectContoursRequest(py)detectsDarkOnLight	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectContoursRequest(py)maximumImageDimension	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectContoursRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectDocumentSegmentationRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNDetectDocumentSegmentationRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectFaceCaptureQualityRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectFaceCaptureQualityRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectFaceLandmarksRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNDetectFaceLandmarksRequest(cm)revision:supportsConstellation:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectFaceLandmarksRequest(py)constellation	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNDetectFaceLandmarksRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectFaceRectanglesRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectFaceRectanglesRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHorizonRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHorizonRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPose3DRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPose3DRequest(im)init	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPose3DRequest(im)initWithCompletionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPose3DRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPoseRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPoseRequest(cm)supportedJointNamesForRevision:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPoseRequest(cm)supportedJointsGroupNamesForRevision:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanBodyPoseRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanHandPoseRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanHandPoseRequest(cm)supportedJointNamesForRevision:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanHandPoseRequest(cm)supportedJointsGroupNamesForRevision:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanHandPoseRequest(py)maximumHandCount	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanHandPoseRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanRectanglesRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanRectanglesRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectHumanRectanglesRequest(py)upperBodyOnly	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectRectanglesRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)maximumAspectRatio	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)maximumObservations	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)minimumAspectRatio	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)minimumConfidence	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)minimumSize	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)quadratureTolerance	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectRectanglesRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTextRectanglesRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTextRectanglesRequest(py)reportCharacterBoxes	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTextRectanglesRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(im)initWithFrameAnalysisSpacing:trajectoryLength:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)maximumObjectSize	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)minimumObjectSize	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)objectMaximumNormalizedRadius	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)objectMinimumNormalizedRadius	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)targetFrameTime	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectTrajectoriesRequest(py)trajectoryLength	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectedObjectObservation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectedObjectObservation(cm)observationWithBoundingBox:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectedObjectObservation(cm)observationWithRequestRevision:boundingBox:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectedObjectObservation(py)boundingBox	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNDetectedObjectObservation(py)globalSegmentationMask	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNDetectedPoint	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNDetectedPoint(py)confidence	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNFaceLandmarkRegion	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarkRegion(py)pointCount	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarkRegion2D	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarkRegion2D(py)pointsClassification	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks(py)confidence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)allPoints	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)faceContour	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)innerLips	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)leftEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)leftEyebrow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)leftPupil	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)medianLine	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)nose	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)noseCrest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)outerLips	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)rightEye	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)rightEyebrow	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceLandmarks2D(py)rightPupil	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceObservation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNFaceObservation(cm)faceObservationWithRequestRevision:boundingBox:roll:yaw:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceObservation(cm)faceObservationWithRequestRevision:boundingBox:roll:yaw:pitch:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceObservation(py)landmarks	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFaceObservation(py)pitch	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNFaceObservation(py)roll	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNFaceObservation(py)yaw	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNFeaturePrintObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFeaturePrintObservation(im)computeDistance:toFeaturePrintObservation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFeaturePrintObservation(py)data	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFeaturePrintObservation(py)elementCount	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNFeaturePrintObservation(py)elementType	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateAttentionBasedSaliencyImageRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNGenerateAttentionBasedSaliencyImageRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateForegroundInstanceMaskRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateForegroundInstanceMaskRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateImageFeaturePrintRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateImageFeaturePrintRequest(py)imageCropAndScaleOption	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateImageFeaturePrintRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateObjectnessBasedSaliencyImageRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateObjectnessBasedSaliencyImageRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateOpticalFlowRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGenerateOpticalFlowRequest(py)computationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGenerateOpticalFlowRequest(py)keepNetworkOutput	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateOpticalFlowRequest(py)outputPixelFormat	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGenerateOpticalFlowRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonInstanceMaskRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonInstanceMaskRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonSegmentationRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeneratePersonSegmentationRequest(im)init	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonSegmentationRequest(im)initWithCompletionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonSegmentationRequest(im)supportedOutputPixelFormatsAndReturnError:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonSegmentationRequest(py)outputPixelFormat	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeneratePersonSegmentationRequest(py)qualityLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeneratePersonSegmentationRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNGeometryUtils	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeometryUtils(cm)boundingCircleForContour:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeometryUtils(cm)boundingCircleForPoints:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeometryUtils(cm)boundingCircleForSIMDPoints:pointCount:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeometryUtils(cm)calculateArea:forContour:orientedArea:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNGeometryUtils(cm)calculatePerimeter:forContour:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNHomographicImageRegistrationRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNHomographicImageRegistrationRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHorizonObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHorizonObservation(im)transformForImageWidth:height:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHorizonObservation(py)angle	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHorizonObservation(py)transform	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNHumanBodyPose3DObservation(im)parentJointNameForJointName:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(im)pointInImageForJointName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(im)recognizedPointForJointName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(im)recognizedPointsForJointsGroupName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(py)availableJointNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(py)availableJointsGroupNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(py)bodyHeight	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(py)cameraOriginMatrix	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPose3DObservation(py)heightEstimation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPoseObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPoseObservation(im)recognizedPointForJointName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPoseObservation(im)recognizedPointsForJointsGroupName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPoseObservation(py)availableJointNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyPoseObservation(py)availableJointsGroupNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyRecognizedPoint3D	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyRecognizedPoint3D(py)localPosition	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanBodyRecognizedPoint3D(py)parentJoint	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanHandPoseObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanHandPoseObservation(im)recognizedPointForJointName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanHandPoseObservation(im)recognizedPointsForJointsGroupName:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanHandPoseObservation(py)availableJointNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanHandPoseObservation(py)availableJointsGroupNames	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanHandPoseObservation(py)chirality	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNHumanObservation(py)upperBodyOnly	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageAestheticsScoresObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageAestheticsScoresObservation(py)isUtility	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageAestheticsScoresObservation(py)overallScore	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageAlignmentObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageBasedRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageBasedRequest(py)regionOfInterest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageHomographicAlignmentObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageHomographicAlignmentObservation(py)warpTransform	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRegistrationRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNImageRequestHandler	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageRequestHandler(im)initWithCGImage:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCGImage:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCGImage:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCGImage:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCIImage:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCIImage:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCIImage:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCIImage:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCMSampleBuffer:depthData:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCMSampleBuffer:depthData:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCMSampleBuffer:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCMSampleBuffer:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCMSampleBuffer:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCMSampleBuffer:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCVPixelBuffer:depthData:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCVPixelBuffer:depthData:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCVPixelBuffer:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCVPixelBuffer:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCVPixelBuffer:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithCVPixelBuffer:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithData:options:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageRequestHandler(im)initWithData:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithURL:options:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageRequestHandler(im)initWithURL:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageRequestHandler(im)initWithURL:orientation:options:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)initWithURL:orientation:options:::SYNTHESIZED::c:objc(cs)VNImageRequestHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageRequestHandler(im)performRequests:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNImageTranslationAlignmentObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNImageTranslationAlignmentObservation(py)alignmentTransform	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNInstanceMaskObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNInstanceMaskObservation(im)generateMaskForInstances:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNInstanceMaskObservation(im)generateMaskedImageOfInstances:fromRequestHandler:croppedToInstancesExtent:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNInstanceMaskObservation(im)generateScaledMaskForImageForInstances:fromRequestHandler:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNInstanceMaskObservation(py)allInstances	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNInstanceMaskObservation(py)instanceMask	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNObservation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNObservation(py)confidence	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNObservation(py)timeRange	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNObservation(py)uuid	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPixelBufferObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNPixelBufferObservation(py)featureName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNPixelBufferObservation(py)pixelBuffer	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNPoint	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(cm)distanceBetweenPoint:point:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(cm)pointByApplyingVector:toPoint:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(cpy)zeroPoint	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(im)distanceToPoint:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(im)initWithLocation:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(im)initWithX:y:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(py)location	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(py)x	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint(py)y	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNPoint3D	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNPoint3D(im)initWithPosition:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNPoint3D(py)position	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizeAnimalsRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizeAnimalsRequest(cm)knownAnimalIdentifiersForRevision:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizeAnimalsRequest(im)supportedIdentifiersAndReturnError:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizeAnimalsRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizeTextRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizeTextRequest(cm)supportedRecognitionLanguagesForTextRecognitionLevel:revision:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizeTextRequest(im)supportedRecognitionLanguagesAndReturnError:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizeTextRequest(py)automaticallyDetectsLanguage	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNRecognizeTextRequest(py)customWords	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizeTextRequest(py)minimumTextHeight	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNRecognizeTextRequest(py)recognitionLanguages	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNRecognizeTextRequest(py)recognitionLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizeTextRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizeTextRequest(py)usesLanguageCorrection	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNRecognizedObjectObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedObjectObservation(py)labels	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoint	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoint(py)identifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoint3D	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoint3D(py)identifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoints3DObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoints3DObservation(im)recognizedPointForKey:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoints3DObservation(im)recognizedPointsForGroupKey:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoints3DObservation(py)availableGroupKeys	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPoints3DObservation(py)availableKeys	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPointsObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPointsObservation(im)keypointsMultiArrayAndReturnError:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPointsObservation(im)recognizedPointForKey:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPointsObservation(im)recognizedPointsForGroupKey:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPointsObservation(py)availableGroupKeys	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedPointsObservation(py)availableKeys	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNRecognizedText	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizedText(py)confidence	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizedText(py)string	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizedTextObservation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRecognizedTextObservation(im)topCandidates:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation(cm)rectangleObservationWithRequestRevision:topLeft:bottomLeft:bottomRight:topRight:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation(cm)rectangleObservationWithRequestRevision:topLeft:topRight:bottomRight:bottomLeft:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation(py)bottomLeft	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation(py)bottomRight	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation(py)topLeft	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRectangleObservation(py)topRight	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(cpy)currentRevision	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(cpy)defaultRevision	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(cpy)supportedRevisions	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(im)cancel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(im)init	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(im)initWithCompletionHandler:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(py)completionHandler	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(py)preferBackgroundProcessing	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNRequest(py)results	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(py)revision	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNRequest(py)usesCPUOnly	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNSaliencyImageObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSaliencyImageObservation(py)salientObjects	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNSequenceRequestHandler(im)init	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCGImage:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCGImage:orientation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCIImage:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCIImage:orientation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCMSampleBuffer:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCMSampleBuffer:orientation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCVPixelBuffer:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onCVPixelBuffer:orientation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onImageData:error:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onImageData:orientation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onImageURL:error:	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNSequenceRequestHandler(im)performRequests:onImageURL:orientation:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNStatefulRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNStatefulRequest(im)initWithFrameAnalysisSpacing:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNStatefulRequest(py)frameAnalysisSpacing	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNStatefulRequest(py)minimumLatencyFrameCount	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCGImage:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCGImage:orientation:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCIImage:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCIImage:orientation:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCMSampleBuffer:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCMSampleBuffer:orientation:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCVPixelBuffer:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedCVPixelBuffer:orientation:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedImageData:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedImageData:orientation:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedImageURL:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTargetedImageRequest(im)initWithTargetedImageURL:orientation:options:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTextObservation	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTextObservation(py)characterBoxes	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrackHomographicImageRegistrationRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackHomographicImageRegistrationRequest(im)init	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackHomographicImageRegistrationRequest(im)initWithCompletionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackHomographicImageRegistrationRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackObjectRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrackObjectRequest(im)initWithDetectedObjectObservation:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackObjectRequest(im)initWithDetectedObjectObservation:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackOpticalFlowRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrackOpticalFlowRequest(im)init	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackOpticalFlowRequest(im)initWithCompletionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackOpticalFlowRequest(py)computationAccuracy	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackOpticalFlowRequest(py)keepNetworkOutput	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackOpticalFlowRequest(py)outputPixelFormat	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackOpticalFlowRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackRectangleRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrackRectangleRequest(im)initWithRectangleObservation:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackRectangleRequest(im)initWithRectangleObservation:completionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackTranslationalImageRegistrationRequest	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackTranslationalImageRegistrationRequest(im)init	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackTranslationalImageRegistrationRequest(im)initWithCompletionHandler:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackTranslationalImageRegistrationRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackingRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrackingRequest(im)supportedNumberOfTrackersAndReturnError:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackingRequest(py)inputObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrackingRequest(py)lastFrame	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrackingRequest(py)trackingLevel	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTrajectoryObservation	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrajectoryObservation(py)detectedPoints	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrajectoryObservation(py)equationCoefficients	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrajectoryObservation(py)movingAverageRadius	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTrajectoryObservation(py)projectedPoints	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNTranslationalImageRegistrationRequest	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(cs)VNTranslationalImageRegistrationRequest(py)results	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVector	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)dotProductOfVector:vector:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)unitVectorForVector:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)vectorByAddingVector:toVector:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)vectorByAddingVector:toVector:::SYNTHESIZED::c:objc(cs)VNVector	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)vectorByMultiplyingVector:byScalar:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)vectorByMultiplyingVector:byScalar:::SYNTHESIZED::c:objc(cs)VNVector	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)vectorBySubtractingVector:fromVector:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cm)vectorBySubtractingVector:fromVector:::SYNTHESIZED::c:objc(cs)VNVector	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(cpy)zeroVector	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(im)initWithR:theta:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(im)initWithVectorHead:tail:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(im)initWithXComponent:yComponent:	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(im)initWithXComponent:yComponent:::SYNTHESIZED::c:objc(cs)VNVector	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(py)length	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(py)r	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(py)squaredLength	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(py)theta	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(py)x	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVector(py)y	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+c:objc(cs)VNVideoProcessor	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)addRequest:processingOptions:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)addRequest:withProcessingOptions:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)analyzeTimeRange:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)analyzeWithTimeRange:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)cancel	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)initWithURL:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)initWithURL:::SYNTHESIZED::c:objc(cs)VNVideoProcessor	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessor(im)removeRequest:error:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorCadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorFrameRateCadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorFrameRateCadence(im)initWithFrameRate:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorFrameRateCadence(im)initWithFrameRate:::SYNTHESIZED::c:objc(cs)VNVideoProcessorFrameRateCadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorFrameRateCadence(py)frameRate	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorRequestProcessingOptions	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorRequestProcessingOptions(py)cadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorTimeIntervalCadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorTimeIntervalCadence(im)initWithTimeInterval:	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorTimeIntervalCadence(im)initWithTimeInterval:::SYNTHESIZED::c:objc(cs)VNVideoProcessorTimeIntervalCadence	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(cs)VNVideoProcessorTimeIntervalCadence(py)timeInterval	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNCircle	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNFaceLandmarkRegion	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNFaceLandmarks	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNObservation	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNPoint	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNPoint3D	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNRecognizedText	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)VNVector	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+c:objc(pl)VNFaceObservationAccepting	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)VNFaceObservationAccepting(py)inputFaceObservations	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)VNRequestProgressProviding	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)VNRequestProgressProviding(py)indeterminate	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)VNRequestProgressProviding(py)progressHandler	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)VNRequestRevisionProviding	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+c:objc(pl)VNRequestRevisionProviding(py)requestRevision	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:10Foundation14LocalizedErrorPAAE10helpAnchorSSSgvp::SYNTHESIZED::s:6Vision0A5ErrorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:10Foundation14LocalizedErrorPAAE13failureReasonSSSgvp::SYNTHESIZED::s:6Vision0A5ErrorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:10Foundation14LocalizedErrorPAAE16errorDescriptionSSSgvp::SYNTHESIZED::s:6Vision0A5ErrorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:10Foundation14LocalizedErrorPAAE18recoverySuggestionSSSgvp::SYNTHESIZED::s:6Vision0A5ErrorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP28originatingRequestDescriptorAA0dE0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationP9timeRangeSo06CMTimeD0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision15FaceObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision15TextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision16HumanObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision17SmudgeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision18BarcodeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision18HorizonObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision19ContoursObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision19DocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision20RectangleObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision21TrajectoryObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision22OpticalFlowObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision22PixelBufferObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision23FeaturePrintObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision23InstanceMaskObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24SaliencyImageObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25ClassificationObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25DetectedObjectObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25RecognizedTextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision27DetectedDocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision27RecognizedObjectObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision29CoreMLFeatureValueObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision32ImageAestheticsScoresObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision36ImageHomographicAlignmentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A11ObservationPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision36ImageTranslationAlignmentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO011outOfBoundsB0yACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO02ioB0yACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO08internalB0yACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO11outOfMemoryyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO12invalidImageyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO12invalidModelyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO13invalidFormatyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO15dataUnavailableyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO15invalidArgumentyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO15operationFailedyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO16errorDescriptionSSSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO16invalidOperationyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO16requestCancelledyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO17timeStampNotFoundyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO18unsupportedRequestyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO19unsupportedRevisionyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO23unsupportedComputeStageyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO24unsupportedComputeDeviceyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO25pixelBufferCreationFailedyACs5Int32VcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A5ErrorO7timeoutyACSScACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO11trackObjectyAcA05TrackD7RequestC_AA08DetectedD11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO13classifyImageyAcA08ClassifyD7RequestV_SayAA25ClassificationObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO13detectHorizonyAcA06DetectD7RequestV_AA0D11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO13recognizeTextyAcA09RecognizeD7RequestV_SayAA010RecognizedD11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO14detectBarcodesyAcA06DetectD7RequestV_SayAA18BarcodeObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO14detectContoursyAcA06DetectD7RequestV_AA0D11ObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO14trackRectangleyAcA05TrackD7RequestC_AA0D11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO16detectLensSmudgeyAcA06DetectdE7RequestV_AA0E11ObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO16detectRectanglesyAcA06DetectD7RequestV_SayAA20RectangleObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO16recognizeAnimalsyAcA09RecognizeD7RequestV_SayAA27RecognizedObjectObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO16trackOpticalFlowyAcA05TrackdE7RequestC_AA0dE11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO18detectTrajectoriesyAcA06DetectD7RequestC_SayAA21TrajectoryObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO18recognizeDocumentsyAcA09RecognizeD7RequestV_SayAA19DocumentObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO19detectFaceLandmarksyAcA06DetectdE7RequestV_SayAA0D11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO19detectHumanBodyPoseyAcA06DetectdeF7RequestV_SayAA0deF11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO19detectHumanHandPoseyAcA06DetectdeF7RequestV_SayAA0deF11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO20detectAnimalBodyPoseyAcA06DetectdeF7RequestV_SayAA0deF11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO20detectFaceRectanglesyAcA06DetectdE7RequestV_SayAA0D11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO20detectTextRectanglesyAcA06DetectdE7RequestV_SayAA0D11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO21detectHumanBodyPose3DyAcA06DetectdeF8DRequestC_SayAA0deF12DObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO21detectHumanRectanglesyAcA06DetectdE7RequestV_SayAA0D11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO24detectFaceCaptureQualityyAcA06DetectdeF7RequestV_SayAA0D11ObservationVGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO25generateImageFeaturePrintyAcA08GeneratedeF7RequestV_AA0eF11ObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO26detectDocumentSegmentationyAcA06DetectdE7RequestV_AA08DetectedD11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO26generatePersonInstanceMaskyAcA08GeneratedeF7RequestV_AA0eF11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO26generatePersonSegmentationyAcA08GeneratedE7RequestC_AA22PixelBufferObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO30calculateImageAestheticsScoresyAcA09CalculatedeF7RequestV_AA0deF11ObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO30generateForegroundInstanceMaskyAcA08GeneratedeF7RequestV_AA0eF11ObservationVSgtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO33trackHomographicImageRegistrationyAcA05TrackdeF7RequestC_AA0eD20AlignmentObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO35generateAttentionBasedSaliencyImageyAcA08GeneratedefG7RequestV_AA0fG11ObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO35trackTranslationalImageRegistrationyAcA05TrackdeF7RequestC_AA0E31TranslationAlignmentObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO36generateObjectnessBasedSaliencyImageyAcA08GeneratedefG7RequestV_AA0fG11ObservationVtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO5erroryAcA0A7Request_p_s5Error_ptcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A6ResultO6coreMLyAcA13CoreMLRequestV_SayAA0A11Observation_pGtcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestP10descriptorAA0B10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestP13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestP16setComputeDevice_3fory6CoreML09MLComputeE0OSg_AA0D5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestP28supportedComputeStageDevicesSDyAA0dE0OSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestP6ResultQa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE11descriptionSSvp::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision0A7RequestPAAE13computeDevice3for6CoreML09MLComputeD0OSgAA12ComputeStageO_tF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO5floatyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO6doubleyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision11ElementTypeO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO14postProcessingyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO4mainyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision12ComputeStageO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV10descriptorAA17RequestDescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV14modelContainerAA0b7MLModelE0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV16setComputeDevice_3fory0B2ML09MLComputeF0OSg_AA0E5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV18cropAndScaleActionAA09ImageCropefG0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV20supportedIdentifiersSaySSGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV28supportedComputeStageDevicesSDyAA0eF0OSay0B2ML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV5model_AcA0B16MLModelContainerV_AC8RevisionOSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13CoreMLRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP0B15JointsGroupNameQa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP0B9JointNameQa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP19availableJointNamesSay0bE4NameQzGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP25availableJointsGroupNamesSay0beF4NameQzGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP5joint3forAA5JointVSg0bF4NameQz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision13PoseProvidingP9allJoints2inSDy0B9JointNameQzAA0G0VG0be5GroupH0QzSg_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV010normalizedC0ACSo6CGRectV_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV02cgC0So6CGRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV05imageC02in12normalizedToACSo6CGRectV_So6CGSizeVACtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV05imageC02inACSo6CGRectV_So6CGSizeVtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV17verticallyFlippedACyF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV18toImageCoordinates4from9imageSize6originSo6CGRectVAC_So6CGSizeVAA16CoordinateOriginOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV18toImageCoordinates_6originSo6CGRectVSo6CGSizeV_AA16CoordinateOriginOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV1x1y5width6heightAC14CoreFoundation7CGFloatV_A3Jtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV5width14CoreFoundation7CGFloatVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV6height14CoreFoundation7CGFloatVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV6originSo7CGPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV9fullImageACvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14NormalizedRectV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV11boundingBox3forAA20RectangleObservationVSgSnySS5IndexVG_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV6stringSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14RecognizedTextV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC10addRequest_7cadenceQrx_AC7CadenceOSgtYaKAA0aE0RzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC13removeRequestySbAA0aE0_pYaF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC13startAnalysis2ofySo11CMTimeRangeaSg_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC6cancelyyYaF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC7CadenceO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC7CadenceO12timeIntervalyAESo6CMTimeacAEmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC7CadenceO13frameIntervalyAESicAEmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC7CadenceO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC7CadenceO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorC7CadenceO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision14VideoProcessorCyAC10Foundation3URLVcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV10medianLineAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV10rightPupilAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV11faceContourAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV11leftEyebrowAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV12rightEyebrowAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV4noseAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO10closedPathyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO12disconnectedyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO2eeoiySbAI_AItFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO4fromAIs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO8openPathyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV20pointsClassificationAG06PointsG0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV24pointsInImageCoordinates_6originSaySo7CGPointVGSo6CGSizeV_AA16CoordinateOriginOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV26precisionEstimatesPerPointSaySfGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV2eeoiySbAG_AGtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV4fromAGs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV6pointsSayAA15NormalizedPointVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6RegionV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV7leftEyeAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV8rightEyeAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV9allPointsAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV9innerLipsAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV9leftPupilAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV9noseCrestAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11Landmarks2DV9outerLipsAE6RegionVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11boundingBox8revisionAcA14NormalizedRectV_AA06DetectB17RectanglesRequestV8RevisionOSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV5scoreSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14CaptureQualityV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV14captureQualityAC07CaptureE0VSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV3yaw10Foundation11MeasurementVySo11NSUnitAngleCGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV4roll10Foundation11MeasurementVySo11NSUnitAngleCGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV5pitch10Foundation11MeasurementVySo11NSUnitAngleCGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV9landmarksAC11Landmarks2DVSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15FaceObservationVyACSo06VNFaceC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV010normalizedC0ACSo7CGPointV_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV02cgC0So7CGPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV05imageC02in12normalizedToACSo7CGPointV_So6CGSizeVAA0B4RectVtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV05imageC02inACSo7CGPointV_So6CGSizeVtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV17verticallyFlippedACyF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV18toImageCoordinates4from9imageSize6originSo7CGPointVAA0B4RectV_So6CGSizeVAA16CoordinateOriginOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV18toImageCoordinates_6originSo7CGPointVSo6CGSizeV_AA16CoordinateOriginOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV1x14CoreFoundation7CGFloatVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV1x1yAC14CoreFoundation7CGFloatV_AHtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV1y14CoreFoundation7CGFloatVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV4zeroACvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15NormalizedPointV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestP20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestP24minimumLatencyFrameCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE24minimumLatencyFrameCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE24minimumLatencyFrameCountSivp::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE24minimumLatencyFrameCountSivp::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE24minimumLatencyFrameCountSivp::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE24minimumLatencyFrameCountSivp::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE2eeoiySbx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15StatefulRequestPAAE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TargetedRequestP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV10bottomLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV11bottomRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV14characterBoxesSayAA09RectangleC0VGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV7topLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV8topRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision15TextObservationVyACSo06VNTextC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO10dataMatrixyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO10gs1DataBaryA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO10msiPlesseyyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO11microPDF417yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO13i2of5ChecksumyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO14code39ChecksumyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO15code39FullASCIIyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO17gs1DataBarLimitedyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO18gs1DataBarExpandedyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO23code39FullASCIIChecksumyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO2qryA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO4ean8yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO4upceyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO5aztecyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO5ean13yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO5i2of5yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO5itf14yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO6code39yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO6code93yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO6pdf417yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO7codabaryA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO7code128yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO7code93iyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO7microQRyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO8allCasesSayACGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16BarcodeSymbologyO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16CoordinateOriginO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16CoordinateOriginO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16CoordinateOriginO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16CoordinateOriginO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16CoordinateOriginO9lowerLeftyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16CoordinateOriginO9upperLeftyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV11boundingBox8revisionAcA14NormalizedRectV_AA06DetectB17RectanglesRequestV8RevisionOSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV15isUpperBodyOnlySbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16HumanObservationVyACSo07VNHumanC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV08boundingC03forACSayAA0B5PointVG_tFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV4zeroACvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV6center6radiusAcA0B5PointV_14CoreFoundation7CGFloatVtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV6centerAA0B5PointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV6radius14CoreFoundation7CGFloatVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV8contains_28inCircumferentialRingOfWidthSbAA0B5PointV_14CoreFoundation7CGFloatVtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedCircleV8containsySbAA0B5PointVF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision16NormalizedRegiona	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO011trackObjectB0yAcA05TrackeB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO013classifyImageB0yAcA08ClassifyeB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO013detectHorizonB0yAcA06DetecteB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO013recognizeTextB0yAcA09RecognizeeB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO014detectBarcodesB0yAcA06DetecteB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO014detectContoursB0yAcA06DetecteB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO014trackRectangleB0yAcA05TrackeB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO016detectLensSmudgeB0yAcA06DetectefB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO016detectRectanglesB0yAcA06DetecteB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO016recognizeAnimalsB0yAcA09RecognizeeB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO016trackOpticalFlowB0yAcA05TrackefB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO018detectTrajectoriesB0yAcA06DetecteB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO018recognizeDocumentsB0yAcA09RecognizeeB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO019detectFaceLandmarksB0yAcA06DetectefB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO019detectHumanBodyPoseB0yAcA06DetectefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO019detectHumanHandPoseB0yAcA06DetectefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO020detectAnimalBodyPoseB0yAcA06DetectefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO020detectFaceRectanglesB0yAcA06DetectefB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO020detectTextRectanglesB0yAcA06DetectefB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO021detectHumanRectanglesB0yAcA06DetectefB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO024detectFaceCaptureQualityB0yAcA06DetectefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO025generateImageFeaturePrintB0yAcA08GenerateefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO026detectDocumentSegmentationB0yAcA06DetectefB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO026generatePersonInstanceMaskB0yAcA08GenerateefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO026generatePersonSegmentationB0yAcA08GenerateefB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO030calculateImageAestheticsScoresB0yAcA09CalculateefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO030generateForegroundInstanceMaskB0yAcA08GenerateefgB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO033trackHomographicImageRegistrationB0yAcA05TrackefgB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO035generateAttentionBasedSaliencyImageB0yAcA08GenerateefghB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO035trackTranslationalImageRegistrationB0yAcA05TrackefgB0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO036generateObjectnessBasedSaliencyImageB0yAcA08GenerateefghB0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO13coreMLRequestyAcA04CoreE0V8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO28detectHumanBodyPose3DRequestyAcA06DetectefgH0C8RevisionOcACmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17RequestDescriptorO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision17SmudgeObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV10bottomLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV11bottomRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV11payloadData10Foundation0E0VSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO03gs1E1AyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO03gs1E1ByA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO03gs1E1CyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO6linkedyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13CompositeTypeO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV13payloadStringSSSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV14boundingRegionAA08ContoursC0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV15isColorInvertedSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV16isGS1DataCarrierSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV23supplementalPayloadData10Foundation0F0VSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV25supplementalCompositeTypeAC0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV25supplementalPayloadStringSSSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV7topLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV8topRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV9symbologyAA0B9SymbologyOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18BarcodeObservationVyACSo09VNBarcodeC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV5angle10Foundation11MeasurementVySo11NSUnitAngleCGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV9transform3forSo17CGAffineTransformVSo6CGSizeV_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationV9transformSo17CGAffineTransformVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18HorizonObservationVyACSo09VNHorizonC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC08detectedC0_20frameAnalysisSpacingAcA20BoundingBoxProviding_AA0A11Observationp_AC8RevisionOSgSo6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC16inputObservationAA20BoundingBoxProviding_AA0aF0pvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision18TrackObjectRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV08topLevelB0SayAC7ContourVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV12contourCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV14contourAtIndexyAC7ContourVSgSiF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV14normalizedPathSo9CGPathRefavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV19countourAtIndexPathyAC7ContourVSg10Foundation0fG0VF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV05childB0SayAEGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV10pointCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV11aspectRatioSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV12boundingQuadAA09RectangleC0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV13calculateArea011useOrientedF0SdSb_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV14boundingCircleAA010NormalizedF0VyF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV14normalizedPathSo9CGPathRefavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV16normalizedPointsSays5SIMD2VySfGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV18calculatePerimeterSdyF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV20polygonApproximation7epsilonAESf_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV6pointsSayAA15NormalizedPointVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV7ContourV9indexPath10Foundation05IndexF0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ContoursObservationVyACSo010VNContoursC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV8documentAC9ContainerVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV10paragraphsSayAE4TextVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV14boundingRegionAA08ContoursC0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV14boundingRegionAA08ContoursC0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV2eeoiySbAG_AGtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV4fromAGs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV5match0E9Detection0eF0O0G0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV14boundingRegionAA08ContoursC0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV2eeoiySbAG_AGtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV10itemStringSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV10markerTypeAG6MarkerOSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV12markerStringSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV2eeoiySbAI_AItFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV4fromAIs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV7contentAEvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4fromAGs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV5itemsSayAG4ItemVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO14lowercaseLatinyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO14uppercaseLatinyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO16compositeDecimalyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO17decorativeDecimalyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO2eeoiySbAI_AItFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO4fromAIs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO6bulletyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO6hyphenyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO7decimalyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4ListV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV10transcriptSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV12detectedDataSayAE0G13DetectorMatchVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV13textAlignmentAG0G0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV14boundingRegion3forAA08ContoursC0V7ContourVSgSnySS5IndexVG_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV14boundingRegionAA08ContoursC0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV2eeoiySbAG_AGtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV4fromAGs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV5linesSayAA010RecognizedeC0VGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV5wordsSayAA010RecognizedeC0VGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO2eeoiySbAI_AItFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO4fromAIs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO6centeryA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO7leadingyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO8trailingyA2ImF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4TextV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV4textAE4TextVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV14boundingRegionAA08ContoursC0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV2eeoiySbAG_AGtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV11columnRangeSNySiGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV2eeoiySbAI_AItFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV4fromAIs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV7contentAEvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV8rowRangeSNySiGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4CellV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4cell3row3colAG4CellVSgSi_SitF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4fromAGs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV4rowsSaySayAG4CellVGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV7columnsSaySayAG4CellVGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5TableV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5listsSayAE4ListVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV5titleAE4TextVSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV6tablesSayAE5TableVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV8barcodesSayAA07BarcodeC0VGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9ContainerV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19DocumentObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC10performAllyQrxSlRzAA0aC0_p7ElementRtzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC7performy6ResultQzxQp_txxQpYaKRvzAA0aC0RzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC7performy6ResultQzxYaKAA0aC0RzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC_11orientationAC10Foundation3URLV_So26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC_11orientationAC10Foundation4DataV_So26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC_11orientationACSo10CGImageRefa_So0F19PropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC_11orientationACSo7CIImageC_So26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC_9depthData11orientationACSo11CVBufferRefa_So07AVDepthF0CSgSo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision19ImageRequestHandlerC_9depthData11orientationACSo17CMSampleBufferRefa_So07AVDepthF0CSgSo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20BoundingBoxProvidingP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20BoundingBoxProvidingP08boundingC0AA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV18cropAndScaleActionAA0c4CropfgH0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV20supportedIdentifiersSaySSGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20ClassifyImageRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20CoreMLModelContainerV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20CoreMLModelContainerV21inputImageFeatureNameSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20CoreMLModelContainerV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20CoreMLModelContainerV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20CoreMLModelContainerV5model15featureProviderACSo0C0C_So09MLFeatureG0_pSgtKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20CoreMLModelContainerV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20DetectHorizonRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV07minimumC14HeightFractionSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV11customWordsSaySSGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO4fastyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO8accurateyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16RecognitionLevelO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16recognitionLevelAC011RecognitionF0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV20recognitionLanguagesSay10Foundation6LocaleV8LanguageVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV22usesLanguageCorrectionSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV28automaticallyDetectsLanguageSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV28supportedComputeStageDevicesSDyAA0fG0OSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV29supportedRecognitionLanguagesSay10Foundation6LocaleV8LanguageVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8RevisionO9revision3yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RecognizeTextRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV10bottomLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV11bottomRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV7topLeft0D5Right06bottomF00gE0AcA15NormalizedPointV_A3Itcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV7topLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV8topRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision20RectangleObservationVyACSo011VNRectangleC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV11symbologiesSayAA16BarcodeSymbologyOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV20supportedSymbologiesSayAA16BarcodeSymbologyOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV29coalescesCompositeSymbologiesSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8RevisionO9revision4yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectBarcodesRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV13contrastPivotSfSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV18contrastAdjustmentSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV18detectsDarkOnLightSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV21maximumImageDimensionSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21DetectContoursRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC08detectedC0_20frameAnalysisSpacingAcA22QuadrilateralProviding_AA0A11Observationp_AC8RevisionOSgSo6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO4fastyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO8accurateyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13TrackingLevelO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC13trackingLevelAC08TrackingF0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC16inputObservationAA22QuadrilateralProviding_AA0aF0pvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrackRectangleRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV14detectedPointsSayAA15NormalizedPointVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV15projectedPointsSayAA15NormalizedPointVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV19movingAverageRadius14CoreFoundation7CGFloatVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV20equationCoefficientss5SIMD3VySfGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision21TrajectoryObservationVyACSo012VNTrajectoryC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestP7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation3URLV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQz10Foundation4DataV_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo10CGImageRefa_So0I19PropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo11CVBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo17CMSampleBufferRefa_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22ImageProcessingRequestPAAE7perform2on11orientation6ResultQzSo7CIImageC_So26CGImagePropertyOrientationVSgtYaKF::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV11pixelFormats6UInt32Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV17withUnsafePointeryxxSVXElF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV4flow2atSf_SftAA15NormalizedPointV_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV4sizeSo6CGSizeVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22OpticalFlowObservationVyACSgSo013VNPixelBufferD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV11pixelFormats6UInt32Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV17withUnsafePointeryxxSVXElF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV4sizeSo6CGSizeVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV5pixel2atSfAA15NormalizedPointV_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV7cgImageSo10CGImageRefavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22PixelBufferObservationVyACSgSo07VNPixelcD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingP10bottomLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingP11bottomRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingP7topLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingP8topRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingPAAE11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingPAAE11boundingBoxAA14NormalizedRectVvp::SYNTHESIZED::s:6Vision18BarcodeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingPAAE11boundingBoxAA14NormalizedRectVvp::SYNTHESIZED::s:6Vision20RectangleObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingPAAE11boundingBoxAA14NormalizedRectVvp::SYNTHESIZED::s:6Vision25RecognizedTextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision22QuadrilateralProvidingPAAE11boundingBoxAA14NormalizedRectVvp::SYNTHESIZED::s:6Vision27DetectedDocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23BoundingRegionProvidingP	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23BoundingRegionProvidingP08boundingC0AA19ContoursObservationV7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV18cropAndScaleActionAA09ImageCropghI0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectLensSmudgeRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV11minimumSizeSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV17minimumConfidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV18maximumAspectRatioSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV18minimumAspectRatioSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV19maximumObservationsSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV26quadratureToleranceDegreesSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23DetectRectanglesRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV11elementTypeAA07ElementF0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV12elementCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV4data10Foundation4DataVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV8distance2toSdAC_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23FeaturePrintObservationVyACSo09VNFeaturecD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO06centerC0yA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO10scaleToFityA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO11scaleToFillyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO27scaleToFitPlus90CCWRotationyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO28scaleToFillPlus90CCWRotationyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO8allCasesSayACGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23ImageCropAndScaleActionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV012allInstancesC0AA011PixelBufferD0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV014generateScaledC03for17scaledToImageFromSo11CVBufferRefa10Foundation8IndexSetV_AA0J14RequestHandlerCtKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV08generateC03forSo11CVBufferRefa10Foundation8IndexSetV_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV12allInstances10Foundation8IndexSetVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV15instanceAtPointy10Foundation8IndexSetVAA010NormalizedG0VF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV19generateMaskedImage3for9imageFrom24croppedToInstancesExtentSo11CVBufferRefa10Foundation8IndexSetV_AA0G14RequestHandlerCSbtKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23InstanceMaskObservationVyACSgSo010VNInstancecD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV09supportedC0SayAC6AnimalOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6AnimalO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6AnimalO3catyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6AnimalO3dogyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6AnimalO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6AnimalO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6AnimalO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23RecognizeAnimalsRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO3lowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO4highyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO6mediumyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO8veryHighyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC19computationAccuracyAC011ComputationG0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC21outputPixelFormatTypes6UInt32Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC31supportedOutputPixelFormatTypesSays6UInt32VGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision23TrackOpticalFlowRequestC_20frameAnalysisSpacingA2C8RevisionOSg_So6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV0D15JointsGroupNamea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV0D9JointNamea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO4faceyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO5torsoyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO7leftArmyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO7leftLegyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8rightArmyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO8rightLegyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV19availableJointNamesSayAC0G4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV25availableJointsGroupNamesSayAC0gH4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV5joint3forAA5JointVSgAC0H4NameO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV8leftHandAA0bgdE0VSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO10rightAnkleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO10rightElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO10rightWristyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO12leftShoulderyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO13rightShoulderyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO4neckyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO4noseyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO4rootyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO7leftEaryA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO7leftEyeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO7leftHipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8leftKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8rightEaryA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8rightEyeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO8rightHipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO9leftAnkleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO9leftElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO9leftWristyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9JointNameO9rightKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9allJoints2inSDyAC9JointNameOAA0I0VGAC0g5GroupJ0OSg_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9keypointsSo12MLMultiArrayCvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9rightHandAA0bgdE0VSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanBodyPoseObservationVyACSo07VNHumancdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV0D15JointsGroupNamea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV0D9JointNamea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO10ringFingeryA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO11indexFingeryA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO12littleFingeryA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO12middleFingeryA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO5thumbyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV15JointsGroupNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV19availableJointNamesSayAC0G4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV25availableJointsGroupNamesSayAC0gH4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV5joint3forAA5JointVSgAC0H4NameO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO4leftyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO5rightyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9ChiralityO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO5wristyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO7ringDIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO7ringMCPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO7ringPIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO7ringTipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO7thumbIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO7thumbMPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8indexDIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8indexMCPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8indexPIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8indexTipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8thumbCMCyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO8thumbTipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9littleDIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9littleMCPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9littlePIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9littleTipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9middleDIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9middleMCPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9middlePIPyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9JointNameO9middleTipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9allJoints2inSDyAC9JointNameOAA0I0VGAC0g5GroupJ0OSg_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9chiralityAC9ChiralityOSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9keypointsSo12MLMultiArrayCvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24HumanHandPoseObservationVyACSo07VNHumancdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV14salientObjectsSayAA09RectangleD0VGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV7heatMapAA011PixelBufferD0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision24SaliencyImageObservationVyACSgSo010VNSaliencycD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV0D15JointsGroupNamea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV0D9JointNamea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO4headyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO4tailyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO5trunkyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8forelegsyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8hindlegsyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV19availableJointNamesSayAC0G4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV25availableJointsGroupNamesSayAC0gH4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV5joint3forAA5JointVSgAC0H4NameO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO10leftEarTopyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO10tailBottomyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO10tailMiddleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO11leftBackPawyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO11rightEarTopyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO12leftBackKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO12leftFrontPawyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO12rightBackPawyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO13leftBackElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO13leftEarBottomyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO13leftEarMiddleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO13leftFrontKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO13rightBackKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO13rightFrontPawyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO14leftFrontElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO14rightBackElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO14rightEarBottomyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO14rightEarMiddleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO14rightFrontKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO15rightFrontElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO4neckyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO4noseyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO7leftEyeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO7tailTopyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9JointNameO8rightEyeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9allJoints2inSDyAC9JointNameOAA0I0VGAC0g5GroupJ0OSg_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25AnimalBodyPoseObservationVyACSo08VNAnimalcdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV10identifierSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV16hasMinimumRecall_12forPrecisionSbSf_SftF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV19hasMinimumPrecision_9forRecallSbSf_SftF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV23hasPrecisionRecallCurveSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV28originatingRequestDescriptorAA0eF0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationV9timeRangeSo06CMTimeE0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25ClassificationObservationVyACSo016VNClassificationC0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC15targetFrameTimeSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC16trajectoryLengthSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC16trajectoryLength_20frameAnalysisSpacingACSi_AC8RevisionOSgSo6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC24minimumLatencyFrameCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC28supportedComputeStageDevicesSDyAA0fG0OSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC29objectMaximumNormalizedRadiusSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC29objectMinimumNormalizedRadiusSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectTrajectoriesRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV11boundingBoxAcA14NormalizedRectV_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25DetectedObjectObservationVyACSo010VNDetectedcD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV10descriptorAA0D10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV16setComputeDevice_3fory6CoreML09MLComputeG0OSg_AA0F5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV07minimumE14HeightFractionSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV11customWordsSaySSGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV20recognitionLanguagesSay10Foundation6LocaleV8LanguageVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV21maximumCandidateCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV21useLanguageCorrectionSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV27automaticallyDetectLanguageSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV22textRecognitionOptionsAC04TextfG0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV11symbologiesSayAA0E9SymbologyOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV28coalesceCompositeSymbologiesSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV7enabledSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV23barcodeDetectionOptionsAC07BarcodefG0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV27supportedBarcodeSymbologiesSayAA0F9SymbologyOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV28supportedComputeStageDevicesSDyAA0fG0OSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV29supportedRecognitionLanguagesSay10Foundation6LocaleV8LanguageVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizeDocumentsRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV10bottomLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV10transcriptSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV11bottomRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV13textDirectionAC0F0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV13topCandidatesySayAA0bC0VGSiF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV14boundingRegionAA08ContoursD0V7ContourVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV20recognitionLanguagesSay10Foundation6LocaleV8LanguageVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV20shouldWrapToNextLineSbSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV7isTitleSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV7topLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV8topRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO11leftToRightyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO11rightToLeftyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO11topToBottomyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9DirectionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision25RecognizedTextObservationVyACSo012VNRecognizedcD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV05inputC12ObservationsSayAA0C11ObservationVGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8RevisionO9revision3yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectFaceLandmarksRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV12detectsHandsSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV19supportedJointNamesSayAA0cdE11ObservationV0H4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV25supportedJointsGroupNamesSayAA0cdE11ObservationV0hI4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanBodyPoseRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV07maximumD5CountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV19supportedJointNamesSayAA0cdE11ObservationV0H4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV25supportedJointsGroupNamesSayAA0cdE11ObservationV0hI4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26DetectHumanHandPoseRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV10bodyHeight10Foundation11MeasurementVySo12NSUnitLengthCGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV12pointInImage3forAA15NormalizedPointVAC9JointNameO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO4headyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO5torsoyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO7leftArmyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO7leftLegyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8rightArmyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO8rightLegyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV15parentJointName3forAC0gH0OAG_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV18cameraOriginMatrixSo13simd_float4x4avp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO8measuredyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO9referenceyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV19availableJointNamesSayAC0G4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV22cameraRelativePosition3forSo13simd_float4x4aAC9JointNameO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV25availableJointsGroupNamesSayAC0gH4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV25heightEstimationTechniqueAC0gH0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV5joint3forAA7Joint3DVSgAC9JointNameO_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO10centerHeadyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO10rightAnkleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO10rightElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO10rightWristyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO12leftShoulderyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO13rightShoulderyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO14centerShoulderyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO4rootyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO5spineyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO7leftHipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO7topHeadyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO8RawValuea	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO8leftKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO8rawValueAESgSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO8rawValueSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO8rightHipyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO9leftAnkleyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO9leftElbowyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO9leftWristyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9JointNameO9rightKneeyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9allJoints2inSDyAC9JointNameOAA7Joint3DVGAC0g5GroupJ0OSg_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision26HumanBodyPose3DObservationVyACSo07VNHumancdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV19supportedJointNamesSayAA0cdE11ObservationV0H4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV25supportedJointsGroupNamesSayAA0cdE11ObservationV0hI4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectAnimalBodyPoseRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8RevisionO9revision3yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectFaceRectanglesRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV20reportCharacterBoxesSbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV28supportedComputeStageDevicesSDyAA0gH0OSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectTextRectanglesRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV10bottomLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV11bottomRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV22globalSegmentationMaskAA011PixelBufferD0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV7topLeftAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV8topRightAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27DetectedDocumentObservationVyACSgSo011VNRectangleD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV11boundingBoxAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV28originatingRequestDescriptorAA0fG0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV6labelsSayAA014ClassificationD0VGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationV9timeRangeSo06CMTimeF0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27RecognizedObjectObservationVyACSo012VNRecognizedcD0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC10performAllyQrxSlRzAA0bD0_p7ElementRtzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC6source6target11orientationAC10Foundation4DataV_AISo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC6source6target11orientationACSo10CGImageRefa_AHSo0I19PropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC6source6target11orientationACSo11CVBufferRefa_AHSo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC6source6target11orientationACSo17CMSampleBufferRefa_AHSo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC6source6target11orientationACSo7CIImageC_AHSo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC7performy6ResultQzxQp_txxQpYaKRvzAA0bD0RzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC7performy6ResultQzxYaKAA0bD0RzlF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision27TargetedImageRequestHandlerC9sourceURL06targetG011orientationAC10Foundation0G0V_AISo26CGImagePropertyOrientationVSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC10descriptorAA17RequestDescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC19supportedJointNamesSayAA0cdE12DObservationV0H4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC24minimumLatencyFrameCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC25supportedJointsGroupNamesSayAA0cdE12DObservationV0hI4NameOGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanBodyPose3DRequestC_20frameAnalysisSpacingA2C8RevisionOSg_So6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV13upperBodyOnlySbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision28DetectHumanRectanglesRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV04hashD0Sivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV07featureD00B2ML017MLSendableFeatureD0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV11featureNameSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision29CoreMLFeatureValueObservationVyACSgSo06VNCorecdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV05inputC12ObservationsSayAA0C11ObservationVGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO9revision3yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision31DetectFaceCaptureQualityRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV18cropAndScaleActionAA0c4CrophiJ0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32GenerateImageFeaturePrintRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV12overallScoreSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV9isUtilitySbvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision32ImageAestheticsScoresObservationVyACSo07VNImagecdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33DetectDocumentSegmentationRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonInstanceMaskRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC10descriptorAA0E10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO4fastyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO8AllCasesa	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO8accurateyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO8allCasesSayAEGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO8balancedyA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC12qualityLevelAC07QualityG0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC16setComputeDevice_3fory6CoreML09MLComputeH0OSg_AA0G5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC21outputPixelFormatTypes6UInt32Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC27supportedOutputPixelFormatsSays6UInt32VGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision33GeneratePersonSegmentationRequestC_20frameAnalysisSpacingA2C8RevisionOSg_So6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV13warpTransformSo13simd_float3x3avp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV14applyTransform2toSo7CIImageCAG_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageHomographicAlignmentObservationVyACSo07VNImagecdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV14applyTransform2toSo7CIImageCAG_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV18alignmentTransformSo08CGAffineG0Vvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV28originatingRequestDescriptorAA0gH0OSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV4uuid10Foundation4UUIDVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationV9timeRangeSo06CMTimeG0aSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision36ImageTranslationAlignmentObservationVyACSo07VNImagecdE0Ccfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV18cropAndScaleActionAA0c4CrophiJ0Ovp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37CalculateImageAestheticsScoresRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision37GenerateForegroundInstanceMaskRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC24minimumLatencyFrameCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision40TrackHomographicImageRegistrationRequestC_20frameAnalysisSpacingA2C8RevisionOSg_So6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV10descriptorAA0G10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV16setComputeDevice_3fory6CoreML09MLComputeJ0OSg_AA0I5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42GenerateAttentionBasedSaliencyImageRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC10descriptorAA0F10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC16setComputeDevice_3fory6CoreML09MLComputeI0OSg_AA0H5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC20frameAnalysisSpacingSo6CMTimeavp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC24minimumLatencyFrameCountSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC28supportedComputeStageDevicesSDyAA0hI0OSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO9revision1yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision42TrackTranslationalImageRegistrationRequestC_20frameAnalysisSpacingA2C8RevisionOSg_So6CMTimeaSgtcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV10descriptorAA0G10DescriptorOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV16regionOfInterestAA14NormalizedRectVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV16setComputeDevice_3fory6CoreML09MLComputeJ0OSg_AA0I5StageOtF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV18supportedRevisionsSayAC8RevisionOGvpZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV6Resulta	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO1loiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO2eeoiySbAE_AEtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO4fromAEs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO9revision2yA2EmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8revisionAC8RevisionOvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision43GenerateObjectnessBasedSaliencyImageRequestVyA2C8RevisionOSgcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV10confidenceSfvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV11descriptionSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV8distance2to14CoreFoundation7CGFloatVAC_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV8locationAA15NormalizedPointVvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision5JointV9jointNameSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV10identifierSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV11parentJointSSvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV13localPositionSo13simd_float4x4avp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV8position13localPosition9identifer11parentJointACSo13simd_float4x4a_AIS2Stcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV8positionSo13simd_float4x4avp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision7Joint3DV9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO2eeoiySbAC_ACtFZ	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO4fromACs7Decoder_p_tKcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO4hash4intoys6HasherVz_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO4leftyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO5rightyA2CmF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO6encode2toys7Encoder_p_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:6Vision9ChiralityO9hashValueSivp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE1goiySbx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2geoiySbx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE2leoiySbx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzloiySnyxGx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzlopys16PartialRangeUpToVyxGxFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoPys16PartialRangeFromVyxGxFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzoiySNyxGx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SLsE3zzzopys19PartialRangeThroughVyxGxFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNBarcodeCompositeType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNChirality	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNElementType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNErrorCode	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNGenerateOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNGeneratePersonSegmentationRequestQualityLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNHumanBodyPose3DObservationHeightEstimation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNImageCropAndScaleOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNPointsClassification	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNRequestFaceLandmarksConstellation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNRequestTextRecognitionLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNRequestTrackingLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@VNTrackOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNAnimalBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNAnimalBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNAnimalIdentifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNBarcodeSymbology	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNComputeStage	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNHumanBodyPose3DObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNHumanBodyPose3DObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNHumanBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNHumanBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNHumanHandPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNHumanHandPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNImageOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNRecognizedPointGroupKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNRecognizedPointKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@T@VNVideoProcessingOption	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision0A6ResultO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision11ElementTypeO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision12ComputeStageO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision13CoreMLRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision14NormalizedRectV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision14RecognizedTextV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision14VideoProcessorC7CadenceO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15FaceObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15FaceObservationV11Landmarks2DV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15FaceObservationV11Landmarks2DV6RegionV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15FaceObservationV11Landmarks2DV6RegionV20PointsClassificationO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15FaceObservationV14CaptureQualityV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15NormalizedPointV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision15TextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision16BarcodeSymbologyO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision16CoordinateOriginO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision16HumanObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision17RequestDescriptorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision17SmudgeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision18BarcodeObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision18BarcodeObservationV13CompositeTypeO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision18HorizonObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision18TrackObjectRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19ContoursObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19ContoursObservationV7ContourV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV17DataDetectorMatchV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV4ListV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV4ListV4ItemV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV4ListV6MarkerO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV4TextV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV4TextV9AlignmentO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV5TableV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision19DocumentObservationV9ContainerV5TableV4CellV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20ClassifyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20CoreMLModelContainerV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20DetectHorizonRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV16RecognitionLevelO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20RecognizeTextRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision20RectangleObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectBarcodesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21DetectContoursRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC13TrackingLevelO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrackRectangleRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision21TrajectoryObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision22OpticalFlowObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision22PixelBufferObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectLensSmudgeRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23DetectRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23FeaturePrintObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23ImageCropAndScaleActionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23InstanceMaskObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV6AnimalO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC19ComputationAccuracyO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision23TrackOpticalFlowRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV9ChiralityO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision24SaliencyImageObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25ClassificationObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectTrajectoriesRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25DetectedObjectObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV22TextRecognitionOptionsV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV23BarcodeDetectionOptionsV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizeDocumentsRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizedTextObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision25RecognizedTextObservationV9DirectionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectFaceLandmarksRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26DetectHumanHandPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV19EstimationTechniqueO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectAnimalBodyPoseRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectFaceRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectTextRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27DetectedDocumentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision27RecognizedObjectObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanBodyPose3DRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision28DetectHumanRectanglesRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision29CoreMLFeatureValueObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision31DetectFaceCaptureQualityRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision32GenerateImageFeaturePrintRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision32ImageAestheticsScoresObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33DetectDocumentSegmentationRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC12QualityLevelO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision33GeneratePersonSegmentationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision36ImageHomographicAlignmentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision36ImageTranslationAlignmentObservationV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision37CalculateImageAestheticsScoresRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision37GenerateForegroundInstanceMaskRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision40TrackHomographicImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision42GenerateAttentionBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision42TrackTranslationalImageRegistrationRequestC8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision43GenerateObjectnessBasedSaliencyImageRequestV8RevisionO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision5JointV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision7Joint3DV	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:6Vision9ChiralityO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSERzSS8RawValueSYRtzrlE6encode2toys7Encoder_p_tKF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV6AnimalO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSERzSS8RawValueSYRtzrlE6encode2toys7Encoder_p_tKF::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSERzSS8RawValueSYRtzrlE6encode2toys7Encoder_p_tKF::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSERzSS8RawValueSYRtzrlE6encode2toys7Encoder_p_tKF::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSERzSS8RawValueSYRtzrlE6encode2toys7Encoder_p_tKF::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNBarcodeCompositeType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNChirality	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNElementType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNErrorCode	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNGenerateOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNGeneratePersonSegmentationRequestQualityLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNHumanBodyPose3DObservationHeightEstimation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNImageCropAndScaleOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNPointsClassification	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNRequestFaceLandmarksConstellation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNRequestTextRecognitionLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNRequestTrackingLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@VNTrackOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV6AnimalO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNBarcodeCompositeType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNChirality	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNElementType	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNErrorCode	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNGenerateOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNGeneratePersonSegmentationRequestQualityLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNHumanBodyPose3DObservationHeightEstimation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNImageCropAndScaleOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNPointsClassification	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNRequestFaceLandmarksConstellation	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNRequestTextRecognitionLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNRequestTrackingLevel	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@VNTrackOpticalFlowRequestComputationAccuracy	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV6AnimalO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV15JointsGroupNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSeRzSS8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfc::SYNTHESIZED::s:6Vision23RecognizeAnimalsRequestV6AnimalO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSeRzSS8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfc::SYNTHESIZED::s:6Vision24HumanBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSeRzSS8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfc::SYNTHESIZED::s:6Vision24HumanHandPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSeRzSS8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfc::SYNTHESIZED::s:6Vision25AnimalBodyPoseObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:SYsSeRzSS8RawValueSYRtzrlE4fromxs7Decoder_p_tKcfc::SYNTHESIZED::s:6Vision26HumanBodyPose3DObservationV9JointNameO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So11VNChiralityV8rawValueABSgSi_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So11VNErrorCodeV8rawValueABSgSi_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So13VNElementTypeV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So13VNImageOptiona8rawValueABSS_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So14VNComputeStagea8rawValueABSS_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So16VNRecognizedTextC6VisionE11boundingBox3forSo22VNRectangleObservationCSgSnySS5IndexVG_tKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So17VNFaceObservationC6VisionE18faceCaptureQualitySfSgvp	declared	Vision.swift	compiles on Linux; Apple runtime or C-string payload unobserved
+s:So18VNAnimalIdentifiera8rawValueABSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So18VNBarcodeSymbologya6VisionE10DataMatrixABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE13I2of5ChecksumABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE14Code39ChecksumABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE15Code39FullASCIIABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE23Code39FullASCIIChecksumABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE2QRABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE4EAN8ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE4UPCEABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE5AztecABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE5EAN13ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE5I2of5ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE5ITF14ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE6Code39ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE6Code93ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE6PDF417ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE7Code128ABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya6VisionE7Code93iABvpZ	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So18VNBarcodeSymbologya8rawValueABSS_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So20VNRecognizedPointKeya8rawValueABSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So22VNBarcodeCompositeTypeV8rawValueABSgSi_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So22VNFaceLandmarkRegion2DC6VisionE13pointsInImage9imageSizeSaySo7CGPointVGSo6CGSizeV_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So22VNFaceLandmarkRegion2DC6VisionE16normalizedPointsSaySo7CGPointVGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So22VNFaceLandmarkRegion2DC6VisionE26precisionEstimatesPerPointSaySfGSgvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So22VNPointsClassificationV8rawValueABSgSi_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So22VNRequestTrackingLevelV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So23VNVideoProcessingOptiona8rawValueABSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So25VNImageCropAndScaleOptionV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So25VNRecognizedPointGroupKeya8rawValueABSS_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So28VNDetectHumanBodyPoseRequestC6VisionE19supportedJointNamesSaySo07VNHumancd11ObservationH4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So28VNDetectHumanBodyPoseRequestC6VisionE25supportedJointsGroupNamesSaySo07VNHumancd11ObservationhI4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So28VNDetectHumanHandPoseRequestC6VisionE19supportedJointNamesSaySo07VNHumancd11ObservationH4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So28VNDetectHumanHandPoseRequestC6VisionE25supportedJointsGroupNamesSaySo07VNHumancd11ObservationhI4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So28VNHumanBodyPose3DObservationC6VisionE22cameraRelativePositionySo13simd_float4x4aSo0abcD9JointNameaKF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So29VNDetectAnimalBodyPoseRequestC6VisionE19supportedJointNamesSaySo08VNAnimalcd11ObservationH4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So29VNDetectAnimalBodyPoseRequestC6VisionE25supportedJointsGroupNamesSaySo08VNAnimalcd11ObservationhI4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So29VNRequestTextRecognitionLevelV8rawValueABSgSi_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So30VNDetectHumanBodyPose3DRequestC6VisionE19supportedJointNamesSaySo07VNHumancd12DObservationH4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So30VNDetectHumanBodyPose3DRequestC6VisionE25supportedJointsGroupNamesSaySo07VNHumancd12DObservationhI4NameaGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So35VNHumanBodyPoseObservationJointNamea8rawValueABSo20VNRecognizedPointKeya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So35VNHumanHandPoseObservationJointNamea8rawValueABSo20VNRecognizedPointKeya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So35VNRequestFaceLandmarksConstellationV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So36VNAnimalBodyPoseObservationJointNamea8rawValueABSo20VNRecognizedPointKeya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So37VNHumanBodyPose3DObservationJointNamea8rawValueABSo20VNRecognizedPointKeya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So41VNHumanBodyPoseObservationJointsGroupNamea8rawValueABSo017VNRecognizedPointF3Keya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So41VNHumanHandPoseObservationJointsGroupNamea8rawValueABSo017VNRecognizedPointF3Keya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So42VNAnimalBodyPoseObservationJointsGroupNamea8rawValueABSo017VNRecognizedPointF3Keya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So43VNHumanBodyPose3DObservationJointsGroupNamea8rawValueABSo017VNRecognizedPointF3Keya_tcfc	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So44VNHumanBodyPose3DObservationHeightEstimationV8rawValueABSgSi_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So44VNTrackOpticalFlowRequestComputationAccuracyV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So47VNGenerateOpticalFlowRequestComputationAccuracyV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So47VNGeneratePersonSegmentationRequestQualityLevelV8rawValueABSgSu_tcfc	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So9VNContourC6VisionE16normalizedPointsSays5SIMD2VySfGGvp	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:So9VNRequestC6VisionE13computeDevice3for6CoreML09MLComputeD0OSgSo14VNComputeStagea_tF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So9VNRequestC6VisionE16setComputeDevice_3fory6CoreML09MLComputeE0OSg_So14VNComputeStageatF	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:So9VNRequestC6VisionE28supportedComputeStageDevicesSDySo09VNComputeE0aSay6CoreML15MLComputeDeviceOGGvp	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNAnimalBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNAnimalBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNAnimalIdentifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNBarcodeSymbology	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNComputeStage	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNHumanBodyPose3DObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNHumanBodyPose3DObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNHumanBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNHumanBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNHumanHandPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNHumanHandPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNImageOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNRecognizedPointGroupKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNRecognizedPointKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE04hashE0Sivp::SYNTHESIZED::c:@T@VNVideoProcessingOption	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNAnimalBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNAnimalBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNAnimalIdentifier	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNBarcodeSymbology	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNComputeStage	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNHumanBodyPose3DObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNHumanBodyPose3DObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNHumanBodyPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNHumanBodyPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNHumanHandPoseObservationJointName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNHumanHandPoseObservationJointsGroupName	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNImageOption	implemented	tests/agent/VisionRuntime.swift	focused Linux runtime evidence
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNRecognizedPointGroupKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNRecognizedPointKey	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s20_SwiftNewtypeWrapperPsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@T@VNVideoProcessingOption	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated
+s:s5ErrorP10FoundationE20localizedDescriptionSSvp::SYNTHESIZED::s:6Vision0A5ErrorO	deferred		no Linux implementation in this promotion; ML/hardware/dependency-gated

--- a/full/vision/oracle-questions.tsv
+++ b/full/vision/oracle-questions.tsv
@@ -1,0 +1,6 @@
+precise	question	risk	reason
+c:@VNErrorDomain	What are the exact UTF-8 bytes of VNErrorDomain on iOS 26.1?	machine-learning	TBD exports the symbol but this host has no Apple runtime string observation.
+c:objc(cs)VNGeometryUtils(cm)boundingCircleForPoints:error:	Does Apple's boundingCircle return the unique minimum enclosing circle (Welzl) or a looser bounding-box approximation for acute triangles?	image-processing	Linux implements Welzl; PR #17 repair required rejecting the bounding-box-center heuristic.
+c:objc(cs)VNImageRequestHandler(im)performRequests:error:	When no model is present, does perform throw VNErrorCode.notImplemented, invalidModel, or another code, and is the completion handler invoked before the throw?	machine-learning	Linux fails closed with notImplemented after invoking the completion handler; Apple ordering is unobserved.
+c:@E@VNErrorCode@VNErrorTuriCoreErrorCode	Is VNErrorCode.turiCoreErrorCode's NSInteger value -1 as in independent macios bindings, or another ABI?	machine-learning	macios Native enum is declaration evidence only; not an Apple runtime oracle.
+module	Which Vision request revisions are currentRevision on iOS 26.1 for VNDetectBarcodesRequest and VNRecognizeTextRequest?	machine-learning	Linux uses the highest macios-documented revision integers; current vs default on device is unobserved.

--- a/full/vision/tests/agent/VisionDependencyIdentity.swift
+++ b/full/vision/tests/agent/VisionDependencyIdentity.swift
@@ -1,0 +1,36 @@
+import Foundation
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+#if canImport(CoreImage)
+import CoreImage
+#endif
+import Vision
+
+enum VisionDependencyFailure: Error {
+    case message(String)
+}
+
+func require(_ condition: Bool, _ message: String) throws {
+    if !condition { throw VisionDependencyFailure.message(message) }
+}
+
+public func visionDependencyIdentityMain() throws {
+#if canImport(CoreGraphics)
+    let box = CGRect(x: 0.1, y: 0.2, width: 0.3, height: 0.4)
+    let detected = VNDetectedObjectObservation(boundingBox: box)
+    var assigned: CGRect = .zero
+    assigned = detected.boundingBox
+    try require(assigned == box, "CGRect identity")
+    let point = VNImagePointForNormalizedPoint(CGPoint(x: 0.5, y: 0.5), 10, 20)
+    try require(point.x == 5 && point.y == 10, "CGPoint mapping")
+#else
+    throw VisionDependencyFailure.message("CoreGraphics is required")
+#endif
+#if canImport(CoreImage)
+    _ = CIImage.self
+#else
+    throw VisionDependencyFailure.message("CoreImage is required")
+#endif
+    print("VISION_DEPENDENCY_IDENTITY_OK")
+}

--- a/full/vision/tests/agent/VisionRuntime.swift
+++ b/full/vision/tests/agent/VisionRuntime.swift
@@ -1,0 +1,439 @@
+import Foundation
+#if canImport(Glibc)
+import Glibc
+#endif
+@_spi(OpenUIKitHost) import Vision
+
+enum VisionRuntimeFailure: Error {
+    case message(String)
+}
+
+func expect(_ condition: Bool, _ message: String) throws {
+    if !condition {
+        throw VisionRuntimeFailure.message(message)
+    }
+}
+
+func expectEqual<T: Equatable>(_ lhs: T, _ rhs: T, _ message: String) throws {
+    try expect(lhs == rhs, "\(message): \(lhs) != \(rhs)")
+}
+
+func expectClose(_ lhs: Double, _ rhs: Double, _ message: String, eps: Double = 1e-9) throws {
+    try expect(abs(lhs - rhs) <= eps, "\(message): \(lhs) != \(rhs)")
+}
+
+func expectClosePoint(_ lhs: CGPoint, _ rhs: CGPoint, _ message: String) throws {
+    try expectClose(Double(lhs.x), Double(rhs.x), message + " x")
+    try expectClose(Double(lhs.y), Double(rhs.y), message + " y")
+}
+
+func expectThrows(_ message: String, _ work: () throws -> Void) throws {
+    var threw = false
+    do {
+        try work()
+    } catch {
+        threw = true
+    }
+    try expect(threw, message)
+}
+
+func run() throws {
+    try testEnums()
+    try testIdentifiers()
+    try testGeometry()
+    try testMinimumEnclosingCircle()
+    try testContourMetrics()
+    try testCoordinateMapping()
+    try testObservations()
+    try testRequestsAndHandler()
+    print("VISION_AGENT_RUNTIME_OK")
+}
+
+func testEnums() throws {
+    try expectEqual(Set(VNBarcodeCompositeType.allCases).count, 5, "composite allCases")
+    for value in VNBarcodeCompositeType.allCases {
+        try expect(VNBarcodeCompositeType(rawValue: value.rawValue) == value, "composite roundtrip")
+    }
+    try expectEqual(Set(VNErrorCode.allCases).count, 24, "error allCases")
+    for value in VNErrorCode.allCases {
+        try expect(VNErrorCode(rawValue: value.rawValue) == value, "error roundtrip")
+    }
+    try expectEqual(VNImageCropAndScaleOption.allCases.count, 5, "crop allCases")
+    try expectEqual(VNPointsClassification.allCases.count, 3, "points allCases")
+    try expectEqual(VNRequestFaceLandmarksConstellation.allCases.count, 3, "constellation allCases")
+    try expectEqual(VNRequestTextRecognitionLevel.allCases.count, 2, "text level allCases")
+    try expectEqual(VNRequestTrackingLevel.allCases.count, 2, "tracking allCases")
+    try expectEqual(VNGenerateOpticalFlowRequest.ComputationAccuracy.allCases.count, 4, "flow allCases")
+    try expectEqual(VNGeneratePersonSegmentationRequest.QualityLevel.allCases.count, 3, "quality allCases")
+    try expectEqual(VNHumanBodyPose3DObservation.HeightEstimation.allCases.count, 2, "height allCases")
+    try expectEqual(VNTrackOpticalFlowRequest.ComputationAccuracy.allCases.count, 4, "track flow allCases")
+    try expectEqual(VNElementType.allCases.count, 3, "element allCases")
+    try expectEqual(VNChirality.allCases.count, 3, "chirality allCases")
+    try expect(VNBarcodeCompositeType.linked != .gs1TypeA, "composite distinct")
+    try expectEqual(Set([VNChirality.unknown, .left, .right]).count, 3, "chirality count")
+    try expectEqual(VNChirality.left.rawValue, -1, "chirality left")
+    try expectEqual(VNChirality.right.rawValue, 1, "chirality right")
+    try expectEqual(VNElementTypeSize(.unknown), 0, "element unknown")
+    try expectEqual(VNElementTypeSize(.float), MemoryLayout<Float>.size, "element float")
+    try expectEqual(VNElementTypeSize(.double), MemoryLayout<Double>.size, "element double")
+    try expectEqual(VNImageCropAndScaleOption.scaleFitRotate90CCW.rawValue, 257, "crop rotate fit")
+    try expectEqual(VNImageCropAndScaleOption.scaleFillRotate90CCW.rawValue, 258, "crop rotate fill")
+    try expectEqual(VNPointsClassification.closedPath.rawValue, 2, "points closed")
+    try expectEqual(VNRequestFaceLandmarksConstellation.constellation65Points.rawValue, 1, "landmarks 65")
+    try expectEqual(VNRequestTextRecognitionLevel.fast.rawValue, 1, "text fast")
+    try expectEqual(VNRequestTrackingLevel.accurate.rawValue, 0, "track accurate")
+    try expectEqual(VNGenerateOpticalFlowRequest.ComputationAccuracy.veryHigh.rawValue, 3, "flow accuracy")
+    try expectEqual(VNGeneratePersonSegmentationRequest.QualityLevel.fast.rawValue, 2, "seg quality")
+    try expectEqual(VNHumanBodyPose3DObservation.HeightEstimation.measured.rawValue, 1, "height est")
+    try expectEqual(VNTrackOpticalFlowRequest.ComputationAccuracy.medium.rawValue, 1, "track flow")
+    try expectEqual(VNErrorCode.OK.rawValue, 0, "error ok")
+    try expectEqual(VNErrorCode.turiCoreErrorCode.rawValue, -1, "error turi")
+    try expectEqual(VNErrorCode.unsupportedComputeDevice.rawValue, 22, "error compute device")
+    try expect(VNErrorCode.notImplemented != .requestCancelled, "error distinct")
+    var hasher = Hasher()
+    VNErrorCode.OK.hash(into: &hasher)
+    _ = hasher.finalize()
+    try expect(VNErrorCode.OK.hashValue == VNErrorCode.OK.hashValue, "error hash stable")
+}
+
+func testIdentifiers() throws {
+    let catalog = VNBarcodeSymbology.knownSymbologies
+    try expectEqual(catalog.count, 24, "symbology catalog")
+    try expectEqual(Set(catalog.map(\.rawValue)).count, 24, "symbology unique")
+    try expectEqual(VNBarcodeSymbology.qr, .QR, "qr alias")
+    try expectEqual(VNBarcodeSymbology.aztec, .Aztec, "aztec alias")
+    try expect(VNBarcodeSymbology.qr != .pdf417, "qr != pdf417")
+    try expectEqual(
+        VNBarcodeSymbology(rawValue: VNBarcodeSymbology.ean13.rawValue),
+        .ean13,
+        "symbology roundtrip"
+    )
+    try expect(VNImageOption.ciContext != .properties, "image option distinct")
+    try expect(VNComputeStage.main != .postProcessing, "compute stage distinct")
+    try expect(VNComputeStage.main.hashValue == VNComputeStage.main.hashValue, "compute hash stable")
+}
+
+func testGeometry() throws {
+    let origin = VNPoint.zero
+    let point = VNPoint(x: 3, y: 4)
+    try expectEqual(origin.distance(point), 5, "3-4-5 distance")
+    try expectEqual(VNPoint.distance(origin, point), 5, "class distance")
+    try expectEqual(point.location, CGPoint(x: 3, y: 4), "location")
+    let fromLocation = VNPoint(location: CGPoint(x: 1, y: 2))
+    try expectEqual(fromLocation.x, 1, "from location x")
+
+    let vector = VNVector(xComponent: 3, yComponent: 4)
+    try expectEqual(vector.length, 5, "vector length")
+    try expectEqual(vector.squaredLength, 25, "vector squared")
+    try expectEqual(vector.r, 5, "vector r")
+    try expectEqual(VNVector.dotProduct(of: vector, vector: vector), 25, "dot product")
+    let unit = VNVector.unitVector(for: vector)
+    try expectEqual(unit.length, 1, "unit length")
+    try expectEqual(VNVector.unitVector(for: .zero).length, 0, "zero unit")
+    let polar = VNVector(r: 2, theta: 0)
+    try expectEqual(polar.x, 2, "polar x")
+    try expect(abs(polar.y) < 1e-12, "polar y")
+    let head = VNPoint(x: 5, y: 5)
+    let tail = VNPoint(x: 2, y: 1)
+    let fromPoints = VNVector(vectorHead: head, tail: tail)
+    try expectEqual(fromPoints.x, 3, "head-tail x")
+    try expectEqual(fromPoints.y, 4, "head-tail y")
+    let sum = VNVector(byAdding: vector, to: vector)
+    try expectEqual(sum.x, 6, "add x")
+    let scaled = VNVector(byMultiplying: vector, byScalar: 2)
+    try expectEqual(scaled.y, 8, "scale y")
+    let subtracted = VNVector(bySubtracting: vector, from: scaled)
+    try expectEqual(subtracted.x, 3, "subtract x")
+    let alias = VNVector(XComponent: 1, yComponent: 2)
+    try expectEqual(alias.x, 1, "XComponent alias")
+    try expectEqual(VNVector(byAddingVector: vector, toVector: vector).x, 6, "add alias")
+    try expectEqual(VNVector(byMultiplyingVector: vector, byScalar: 3).x, 9, "multiply alias")
+    try expectEqual(VNVector(bySubtractingVector: vector, fromVector: scaled).x, 3, "subtract alias")
+    try expect(abs(vector.theta - atan2(4.0, 3.0)) < 1e-12, "theta")
+    let applied = VNPoint.apply(vector, to: origin)
+    try expectEqual(applied.x, 3, "apply x")
+
+    let circle = VNCircle(center: origin, radius: 5)
+    try expect(circle.contains(point), "contains hypotenuse")
+    try expect(circle.contains(VNPoint(x: 5, y: 0)), "contains radius")
+    try expect(!circle.contains(VNPoint(x: 5.1, y: 0)), "excludes outside")
+    try expect(circle.contains(VNPoint(x: 5, y: 0), inCircumferentialRingOfWidth: 0.2), "ring on circumference")
+    try expect(!circle.contains(VNPoint.zero, inCircumferentialRingOfWidth: 0.2), "ring excludes center")
+    let diameterCircle = VNCircle(center: origin, diameter: 10)
+    try expectEqual(diameterCircle.radius, 5, "diameter init")
+    try expect(VNCircle.zero.contains(VNPoint.zero), "zero circle")
+}
+
+func testMinimumEnclosingCircle() throws {
+    try expectThrows("empty MEC") {
+        _ = try VNGeometryUtils.boundingCircle(for: [VNPoint]())
+    }
+
+    let single = try VNGeometryUtils.boundingCircle(for: [VNPoint(x: 1, y: 2)])
+    try expectEqual(single.radius, 0, "singleton radius")
+    try expectEqual(single.center.x, 1, "singleton x")
+
+    let duplicates = try VNGeometryUtils.boundingCircle(
+        for: [VNPoint(x: 1, y: 1), VNPoint(x: 1, y: 1)]
+    )
+    try expectEqual(duplicates.radius, 0, "duplicate radius")
+
+    let pair = try VNGeometryUtils.boundingCircle(
+        for: [VNPoint(x: 0, y: 0), VNPoint(x: 4, y: 0)]
+    )
+    try expectEqual(pair.radius, 2, "pair radius")
+    try expectEqual(pair.center.x, 2, "pair center")
+
+    let collinear = try VNGeometryUtils.boundingCircle(
+        for: [VNPoint(x: 0, y: 0), VNPoint(x: 1, y: 0), VNPoint(x: 4, y: 0)]
+    )
+    try expectEqual(collinear.radius, 2, "collinear radius")
+    try expectEqual(collinear.center.x, 2, "collinear center")
+
+    let obtuse = try VNGeometryUtils.boundingCircle(
+        for: [VNPoint(x: 0, y: 0), VNPoint(x: 4, y: 0), VNPoint(x: 0.1, y: 0.1)]
+    )
+    try expectEqual(obtuse.radius, 2, "obtuse uses longest side")
+
+    // Equilateral-ish triangle where a bounding-box radius would be too large.
+    let acute = [
+        VNPoint(x: 0, y: 0),
+        VNPoint(x: 2, y: 0),
+        VNPoint(x: 1, y: sqrt(3)),
+    ]
+    let mec = try VNGeometryUtils.boundingCircle(for: acute)
+    try expect(abs(mec.radius - 2 / sqrt(3)) < 1e-9, "acute circumradius")
+    for point in acute {
+        try expect(mec.contains(point), "acute containment")
+    }
+    let boxRadius = hypot(1.0, sqrt(3) / 2)
+    try expect(mec.radius < boxRadius - 1e-9, "smaller than bounding-box approximation")
+
+    let reversed = try VNGeometryUtils.boundingCircle(for: acute.reversed())
+    try expect(abs(reversed.radius - mec.radius) < 1e-9, "order invariance radius")
+    try expect(abs(reversed.center.x - mec.center.x) < 1e-9, "order invariance x")
+    try expect(abs(reversed.center.y - mec.center.y) < 1e-9, "order invariance y")
+
+    let simdPoints: [SIMD2<Float>] = [
+        SIMD2<Float>(0, 0),
+        SIMD2<Float>(2, 0),
+        SIMD2<Float>(1, Float(sqrt(3))),
+    ]
+    let simdCircle = try simdPoints.withUnsafeBufferPointer { buffer in
+        try VNGeometryUtils.boundingCircle(
+            forSIMDPoints: buffer.baseAddress!,
+            pointCount: buffer.count
+        )
+    }
+    try expect(abs(simdCircle.radius - mec.radius) < 1e-5, "simd MEC")
+}
+
+func testContourMetrics() throws {
+    let square = VNContour(normalizedPoints: [
+        SIMD2<Float>(0, 0),
+        SIMD2<Float>(1, 0),
+        SIMD2<Float>(1, 1),
+        SIMD2<Float>(0, 1),
+    ])
+    try expectEqual(square.pointCount, 4, "point count")
+    try expectEqual(square.aspectRatio, 1, "aspect")
+    var area: Double = 0
+    try VNGeometryUtils.calculateArea(&area, for: square, orientedArea: false)
+    try expectEqual(area, 1, "square area")
+    var signed: Double = 0
+    try VNGeometryUtils.calculateArea(&signed, for: square, orientedArea: true)
+    try expectEqual(signed, 1, "oriented ccw")
+    var perimeter: Double = 0
+    try VNGeometryUtils.calculatePerimeter(&perimeter, for: square)
+    try expectEqual(perimeter, 4, "square perimeter")
+
+    let child = VNContour(normalizedPoints: [SIMD2<Float>(0.2, 0.2), SIMD2<Float>(0.3, 0.2)])
+    let parent = VNContour(
+        normalizedPoints: square.normalizedPoints,
+        indexPath: IndexPath(index: 0),
+        childContours: [child]
+    )
+    try expectEqual(parent.childContourCount, 1, "child count")
+    try expectEqual(try parent.childContour(at: 0).pointCount, 2, "child fetch")
+    try expectThrows("child oob") {
+        _ = try parent.childContour(at: 3)
+    }
+
+    let circle = try VNGeometryUtils.boundingCircle(for: square)
+    try expect(circle.contains(VNPoint(x: 0.5, y: 0.5)), "contour circle contains center")
+
+    let jagged = VNContour(normalizedPoints: [
+        SIMD2<Float>(0, 0),
+        SIMD2<Float>(0.5, 0.0001),
+        SIMD2<Float>(1, 0),
+    ])
+    let approx = try jagged.polygonApproximation(epsilon: 0.01)
+    try expectEqual(approx.pointCount, 2, "dp collapsed colinear")
+}
+
+func testCoordinateMapping() throws {
+    try expect(VNNormalizedRectIsIdentityRect(VNNormalizedIdentityRect), "identity rect")
+    try expect(!VNNormalizedRectIsIdentityRect(CGRect(x: 0, y: 0, width: 1, height: 0.5)), "not identity")
+    let imagePoint = VNImagePointForNormalizedPoint(CGPoint(x: 0.25, y: 0.5), 200, 100)
+    try expectEqual(imagePoint, CGPoint(x: 50, y: 50), "norm to image")
+    let back = VNNormalizedPointForImagePoint(imagePoint, 200, 100)
+    try expectEqual(back, CGPoint(x: 0.25, y: 0.5), "image to norm")
+    let imageRect = VNImageRectForNormalizedRect(CGRect(x: 0.1, y: 0.2, width: 0.25, height: 0.5), 100, 200)
+    try expectEqual(imageRect.origin, CGPoint(x: 10, y: 40), "rect origin")
+    try expectEqual(imageRect.size, CGSize(width: 25, height: 100), "rect size")
+    let roiPoint = VNImagePointForNormalizedPointUsingRegionOfInterest(
+        CGPoint(x: 0.5, y: 0.5),
+        100,
+        100,
+        CGRect(x: 0.2, y: 0.2, width: 0.4, height: 0.4)
+    )
+    try expectClosePoint(roiPoint, CGPoint(x: 40, y: 40), "roi point")
+    let landmark = VNImagePointForFaceLandmarkPoint(
+        SIMD2<Float>(0.5, 0.25),
+        CGRect(x: 0.2, y: 0.2, width: 0.4, height: 0.4),
+        100,
+        100
+    )
+    try expectClosePoint(landmark, CGPoint(x: 40, y: 30), "landmark")
+}
+
+func testObservations() throws {
+    let box = CGRect(x: 0.1, y: 0.2, width: 0.3, height: 0.4)
+    let detected = VNDetectedObjectObservation(boundingBox: box)
+    try expectEqual(detected.boundingBox, box, "bbox")
+    try expect(detected.confidence == 1, "default confidence")
+    try expect(detected.uuid != UUID(), "uuid assigned")
+
+    let rectangle = VNRectangleObservation(
+        requestRevision: 1,
+        topLeft: CGPoint(x: 0, y: 1),
+        topRight: CGPoint(x: 1, y: 1),
+        bottomRight: CGPoint(x: 1, y: 0),
+        bottomLeft: CGPoint(x: 0, y: 0)
+    )
+    try expectEqual(rectangle.topLeft, CGPoint(x: 0, y: 1), "tl")
+    try expectEqual(rectangle.boundingBox, CGRect(x: 0, y: 0, width: 1, height: 1), "rect bbox")
+
+    let altOrder = VNRectangleObservation(
+        requestRevision: 1,
+        topLeft: CGPoint(x: 0, y: 1),
+        bottomLeft: CGPoint(x: 0, y: 0),
+        bottomRight: CGPoint(x: 1, y: 0),
+        topRight: CGPoint(x: 1, y: 1)
+    )
+    try expectEqual(altOrder.bottomRight, CGPoint(x: 1, y: 0), "alt order")
+
+    let barcode = VNBarcodeObservation(
+        topLeft: rectangle.topLeft,
+        topRight: rectangle.topRight,
+        bottomRight: rectangle.bottomRight,
+        bottomLeft: rectangle.bottomLeft,
+        symbology: .qr,
+        payloadStringValue: "hello",
+        payloadData: Data("hello".utf8),
+        isGS1DataCarrier: false,
+        supplementalCompositeType: .none
+    )
+    try expectEqual(barcode.symbology, .qr, "barcode symbology")
+    try expectEqual(barcode.payloadStringValue, "hello", "payload")
+    try expectEqual(barcode.isColorInverted, false, "inverted default")
+
+    let text = VNRecognizedText(string: "Hi", confidence: 0.8)
+    try expectEqual(text.string, "Hi", "recognized text")
+    let textObs = VNRecognizedTextObservation(
+        topLeft: rectangle.topLeft,
+        topRight: rectangle.topRight,
+        bottomRight: rectangle.bottomRight,
+        bottomLeft: rectangle.bottomLeft,
+        candidates: [text]
+    )
+    try expectEqual(textObs.topCandidates(1).first?.string, "Hi", "top candidate")
+    try expectEqual(textObs.topCandidates(0).count, 0, "zero candidates")
+
+    let face = VNFaceObservation(boundingBox: box, roll: 0.1)
+    try expectEqual(face.roll?.doubleValue, 0.1, "face roll")
+}
+
+func testRequestsAndHandler() throws {
+    try expectEqual(VNRequestRevisionUnspecified, 0, "unspecified revision")
+    let request = VNDetectRectanglesRequest()
+    try expectEqual(request.minimumAspectRatio, 0.5, "min aspect")
+    try expectEqual(request.maximumObservations, 8, "max observations")
+    try expectEqual(request.regionOfInterest, VNNormalizedIdentityRect, "default ROI")
+    try expectEqual(
+        VNDetectRectanglesRequest.supportedRevisions.contains(VNDetectRectanglesRequestRevision1),
+        true,
+        "rect revision"
+    )
+
+    let barcodes = VNDetectBarcodesRequest()
+    try expect(barcodes.symbologies.contains(.qr), "default includes qr")
+    try expectEqual(try barcodes.supportedSymbologies().count, 24, "supported symbologies")
+    barcodes.symbologies = [.qr]
+    try expectEqual(barcodes.symbologies, [.qr], "symbologies stored")
+
+    let text = VNRecognizeTextRequest()
+    try expectEqual(text.recognitionLevel, .accurate, "text level")
+    try expectEqual(try text.supportedRecognitionLanguages(), [], "no languages")
+    text.customWords = ["OpenUIKit"]
+    try expectEqual(text.customWords, ["OpenUIKit"], "custom words")
+
+    var completed = false
+    let cancellable = VNRequest { _, error in
+        completed = error != nil
+    }
+    cancellable.cancel()
+    let handler = VNImageRequestHandler(data: Data([0, 1, 2]), options: [.properties: "none"])
+    try expectEqual(handler.source, .data(Data([0, 1, 2])), "handler source")
+    _ = VNImageRequestHandler(url: URL(fileURLWithPath: "/tmp/vision-missing.png"))
+    _ = VNImageRequestHandler(URL: URL(fileURLWithPath: "/tmp/vision-missing.png"))
+    try expectThrows("cancelled throws") {
+        try handler.perform([cancellable])
+    }
+    try expect(completed, "cancel completion")
+
+    let hosted = VNDetectBarcodesRequest()
+    let observation = VNBarcodeObservation(
+        topLeft: CGPoint(x: 0, y: 1),
+        topRight: CGPoint(x: 1, y: 1),
+        bottomRight: CGPoint(x: 1, y: 0),
+        bottomLeft: CGPoint(x: 0, y: 0),
+        symbology: .qr,
+        payloadStringValue: "hosted"
+    )
+    VisionHost.attachResults([observation], to: hosted)
+    try handler.perform([hosted])
+    let recovered = hosted.results?.first as? VNBarcodeObservation
+    try expectEqual(recovered?.payloadStringValue, "hosted", "host results")
+
+    let failClosed = VNDetectFaceRectanglesRequest()
+    do {
+        try handler.perform([failClosed])
+        throw VisionRuntimeFailure.message("ml unavailable should throw")
+    } catch let error as NSError {
+        try expectEqual(error.domain, VNErrorDomain, "error domain")
+        try expectEqual(error.code, VNErrorCode.notImplemented.rawValue, "not implemented code")
+    }
+
+    let sequence = VNSequenceRequestHandler()
+    let seqRequest = VNDetectRectanglesRequest()
+    VisionHost.attachResults([
+        VNDetectedObjectObservation(boundingBox: CGRect(x: 0, y: 0, width: 1, height: 1)),
+    ], to: seqRequest)
+    try sequence.perform([seqRequest], onImageData: Data([9]))
+    try expectEqual(seqRequest.results?.count, 1, "sequence host results")
+
+    let flow = VNGenerateOpticalFlowRequest()
+    flow.computationAccuracy = .veryHigh
+    try expectEqual(flow.computationAccuracy, .veryHigh, "flow accuracy stored")
+    let segmentation = VNGeneratePersonSegmentationRequest()
+    segmentation.qualityLevel = .fast
+    try expectEqual(segmentation.qualityLevel, .fast, "quality stored")
+}
+
+do {
+    try run()
+} catch {
+    fputs("VISION_AGENT_RUNTIME_FAIL \(error)\n", stderr)
+    exit(1)
+}

--- a/full/vision/vision_guest_sources.txt
+++ b/full/vision/vision_guest_sources.txt
@@ -1,0 +1,8 @@
+full/vision/Vision.swift
+full/vision/VisionContour.swift
+full/vision/VisionEnums.swift
+full/vision/VisionError.swift
+full/vision/VisionGeometry.swift
+full/vision/VisionIdentifiers.swift
+full/vision/VisionObservation.swift
+full/vision/VisionRequest.swift


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Source

- Legacy platform branch: `cursor/port-vision-to-linux-90b3`
- Legacy PR: [Vercantez/openuikit-linux-platform#17](https://github.com/Vercantez/openuikit-linux-platform/pull/17)
- Target: `full/vision/` on `Vercantez/openuikit` `main`

`git fetch platform cursor/port-vision-to-linux-90b3` returned **HTTP 404** (`Repository not found`) because this GitHub App installation can only see `Vercantez/openuikit`. The lane was therefore rebuilt from the sealed monorepo seed plus the recorded PR #17 repair brief (honest coverage, no invented `turiCoreErrorCode = 10000`, Welzl minimum enclosing circle).

## Reference dossier

Kept the **monorepo** `full/vision/reference/` tree. There was no reachable branch dossier to compare; the monorepo seed provenance is newer relative to this checkout (`generatorSHA256=2b8230ced5a3ed78f070607346f6a684d9e0fb74a8932b92bc0f5e38f46f0a8e`, `scripts/framework-fanout/generate_seed.py`, Xcode 26.1 / iPhoneOS 26.1).

## Gates (verbatim last lines)

```
FRAMEWORK_FANOUT_DELIVERABLE_OK module=Vision lane=large-partitioned symbols=3584
```

```
FRAMEWORK_FANOUT_HOST_OK module=Vision dylib=libVision.dylib
```

Host gate also printed `FRAMEWORK_FANOUT_REFERENCE_OK` and `VISION_AGENT_RUNTIME_OK`.

`python3 scripts/env/test_contract.py` stayed green (10 tests, OK).

## Coverage

| status | count |
| --- | ---: |
| implemented | 342 |
| declared | 41 |
| deferred | 3201 |
| total | 3584 |

Nondeferred = 383 (floor 150).

## What changed to make the gates pass

- Added Linux `Vision` sources listed in `vision_guest_sources.txt`, nonempty `Vision.swift` / `README.md`, `oracle-questions.tsv`, and `tests/agent/VisionRuntime.swift`.
- Implemented geometry (`VNPoint` / `VNVector` / `VNCircle` / `VNContour`, coordinate mapping, shoelace, Douglas-Peucker, Welzl MEC) and fail-closed request plumbing (`perform` throws `VNErrorCode.notImplemented` unless `@_spi(OpenUIKitHost)` results are attached).
- Wrote truthful `coverage.tsv` for every public precise ID; did not weaken either gate.

## Deferred

Most of the 3584 IDs remain deferred: pose graphs, document observation, Core ML requests, video processor, Swift-only iOS 26 request structs, and `CGImage`/`CIImage`/`CVPixelBuffer` handler inits (those modules are not importable on this host). `tests/agent/VisionDependencyIdentity.swift` is a future EC2 probe, not run by the isolated host gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a924af7e-d4dd-421d-a14d-3fc1aec21f33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a924af7e-d4dd-421d-a14d-3fc1aec21f33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

