### PR TITLE
Focus onboarding/package guest builders: assert the arch-suffixed output path

### DIFF
--- a/full/swiftui/build_focus_onboarding_guest.sh
+++ b/full/swiftui/build_focus_onboarding_guest.sh
@@ -169,7 +169,7 @@ validate_bundle() {
     [ "$actual_digest" = "$digest" ] || die "$label tree drifted: $actual_digest"
 }
 
-[ "$OUT" = "$W/build/focus-onboarding-guest" ] \
+[ "$OUT" = "$W/build/focus-onboarding-guest${FULL_OUT_SUFFIX}" ] \
     || die "derived output path invariant changed"
 assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
 assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun

--- a/full/swiftui/build_focus_package_guest.sh
+++ b/full/swiftui/build_focus_package_guest.sh
@@ -116,7 +116,7 @@ check_source_manifest() {
         || die "$label source manifest drifted: $actual"
 }
 
-[ "$OUT" = "$W/build/focus-package-guest" ] \
+[ "$OUT" = "$W/build/focus-package-guest${FULL_OUT_SUFFIX}" ] \
     || die "derived output path invariant changed"
 assert_vendor_tree "$W" uikit "$UIKIT" "$EXPECTED_UIKIT_TREE" OpenUIKit
 assert_vendor_tree "$W" machorun "$MACHORUN" "$EXPECTED_INREPO_MACHORUN_TREE" machorun


### PR DESCRIPTION
x86_64 onboarding half of rung b (box run b0o8klq2x at 14603746) died on `derived output path invariant changed`: OUT is derived with FULL_OUT_SUFFIX but the guard asserted the suffix-less path. Same latent guard in build_focus_package_guest.sh. Assert the derived expression. arm64 unchanged (empty suffix). full/ only, no pins. test_contract.py green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188aCUiPNF2xwAWXcozrKDS