### PR TITLE
Promote CoreTelephony Linux lane from fan-out PR #7

### DIFF
--- a/full/coretelephony/CTCall.swift
+++ b/full/coretelephony/CTCall.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Deprecated call snapshot. Linux has no call stack; instances created
+/// through `NSObject` init expose empty strings and are never injected into
+/// `CTCallCenter`.
+open class CTCall: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open var callID: String { "" }
+
+    open var callState: String { "" }
+}
+
+/// Deprecated call center. `currentCalls` is `nil` and `callEventHandler` is
+/// stored but never invoked: there is no telephony service to observe.
+open class CTCallCenter: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open var currentCalls: Set<CTCall>? { nil }
+
+    open var callEventHandler: ((CTCall) -> Void)?
+}

--- a/full/coretelephony/CTCellularData.swift
+++ b/full/coretelephony/CTCellularData.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Linux has no cellular-data restriction daemon. `restrictedState` is
+/// always `.restrictedStateUnknown`. Assigning a non-nil notifier for the
+/// first time asynchronously delivers that honest state exactly once; later
+/// baseband updates are never fabricated.
+open class CTCellularData: NSObject {
+    private var notifier: CellularDataRestrictionDidUpdateNotifier?
+
+    public override init() {
+        super.init()
+    }
+
+    open var restrictedState: CTCellularDataRestrictedState {
+        .restrictedStateUnknown
+    }
+
+    open var cellularDataRestrictionDidUpdateNotifier:
+        CellularDataRestrictionDidUpdateNotifier?
+    {
+        get { notifier }
+        set {
+            let isFirstNonNilAssignment = notifier == nil && newValue != nil
+            notifier = newValue
+            if isFirstNonNilAssignment, let handler = newValue {
+                coreTelephonyHop {
+                    handler(.restrictedStateUnknown)
+                }
+            }
+        }
+    }
+}

--- a/full/coretelephony/CTCellularPlan.swift
+++ b/full/coretelephony/CTCellularPlan.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// Plan property bag. `init(coder:)` is fail-closed (`nil`): Apple archive
+/// keys are unobserved. Local mutable fields are otherwise ordinary storage.
+open class CTCellularPlanProperties: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    open var associatedIccid: String?
+    open var simCapability: CTCellularPlanCapability = .dataOnly
+    open var supportedRegionCodes: [Locale.Region] = []
+
+    public override init() {
+        super.init()
+    }
+
+    public required init?(coder: NSCoder) {
+        _ = coder
+        return nil
+    }
+
+    open func encode(with coder: NSCoder) {
+        _ = coder
+    }
+}
+
+/// eSIM add-plan request. `address` defaults to `""`. Coding is fail-closed.
+open class CTCellularPlanProvisioningRequest: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool { true }
+
+    open var address: String = ""
+    open var matchingID: String?
+    open var oid: String?
+    open var confirmationCode: String?
+    open var iccid: String?
+    open var eid: String?
+
+    public override init() {
+        super.init()
+    }
+
+    public required init?(coder: NSCoder) {
+        _ = coder
+        return nil
+    }
+
+    open func encode(with coder: NSCoder) {
+        _ = coder
+    }
+}
+
+/// Linux has no eSIM / embedded-SIM host. Support flags are `false`. Add-plan
+/// completes asynchronously with `.fail`; `update` fails closed with an
+/// `NSError`. Success is never fabricated.
+open class CTCellularPlanProvisioning: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open var supportsEmbeddedSIM: Bool { false }
+
+    open func supportsCellularPlan() -> Bool {
+        false
+    }
+
+    open func addPlan(
+        with request: CTCellularPlanProvisioningRequest,
+        completionHandler: @escaping (CTCellularPlanProvisioningAddPlanResult) -> Void
+    ) {
+        _ = request
+        coreTelephonyHop {
+            completionHandler(.fail)
+        }
+    }
+
+    open func addPlan(
+        with request: CTCellularPlanProvisioningRequest
+    ) async -> CTCellularPlanProvisioningAddPlanResult {
+        await withCheckedContinuation { continuation in
+            addPlan(with: request) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    open func addPlan(
+        request: CTCellularPlanProvisioningRequest,
+        properties: CTCellularPlanProperties?,
+        completionHandler: @escaping (CTCellularPlanProvisioningAddPlanResult) -> Void
+    ) {
+        _ = properties
+        addPlan(with: request, completionHandler: completionHandler)
+    }
+
+    open func addPlan(
+        request: CTCellularPlanProvisioningRequest,
+        properties: CTCellularPlanProperties?
+    ) async -> CTCellularPlanProvisioningAddPlanResult {
+        await withCheckedContinuation { continuation in
+            addPlan(request: request, properties: properties) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    open func update(
+        _ properties: CTCellularPlanProperties,
+        completionHandler: @escaping ((any Error)?) -> Void
+    ) {
+        _ = properties
+        coreTelephonyHop {
+            completionHandler(
+                coreTelephonyUnavailableError(
+                    "CTCellularPlanProvisioning.update is unavailable without an eSIM host"
+                )
+            )
+        }
+    }
+
+    open func update(_ properties: CTCellularPlanProperties) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            update(properties) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}
+
+/// Plan-status token APIs fail closed. Linux never invents a carrier token.
+open class CTCellularPlanStatus: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open class func getTokenWithCompletion(
+        _ completionHandler: @escaping (String?, (any Error)?) -> Void
+    ) {
+        coreTelephonyHop {
+            completionHandler(
+                nil,
+                coreTelephonyUnavailableError(
+                    "CTCellularPlanStatus.getToken is unavailable without cellular plan status"
+                )
+            )
+        }
+    }
+
+    open class func checkValidity(ofToken token: String) async throws -> Bool {
+        _ = token
+        throw coreTelephonyUnavailableError(
+            "CTCellularPlanStatus.checkValidity is unavailable without cellular plan status"
+        )
+    }
+}

--- a/full/coretelephony/CTSubscriber.swift
+++ b/full/coretelephony/CTSubscriber.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public protocol CTSubscriberDelegate: AnyObject {
+    func subscriberTokenRefreshed(_ subscriber: CTSubscriber)
+}
+
+/// Linux has no SIM / carrier-token service. `isSIMInserted` is `false`,
+/// `carrierToken` is `nil`, `refreshCarrierToken()` returns `false` and does
+/// not notify the delegate.
+open class CTSubscriber: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open var carrierToken: Data? { nil }
+
+    open var identifier: String { "" }
+
+    open var isSIMInserted: Bool { false }
+
+    public weak var delegate: (any CTSubscriberDelegate)?
+
+    open func refreshCarrierToken() -> Bool {
+        false
+    }
+}
+
+open class CTSubscriberInfo: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open class func subscribers() -> [CTSubscriber] {
+        []
+    }
+
+    /// Deprecated single-subscriber accessor. Returns an empty fail-closed
+    /// subscriber rather than inventing SIM identity.
+    open class func subscriber() -> CTSubscriber {
+        CTSubscriber()
+    }
+}

--- a/full/coretelephony/CTTelephonyNetworkInfo.swift
+++ b/full/coretelephony/CTTelephonyNetworkInfo.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Deprecated carrier snapshot. Linux has no baseband, so every identifier
+/// is `nil` and `allowsVOIP` is `false`.
+open class CTCarrier: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open var carrierName: String? { nil }
+    open var mobileCountryCode: String? { nil }
+    open var mobileNetworkCode: String? { nil }
+    open var isoCountryCode: String? { nil }
+    open var allowsVOIP: Bool { false }
+}
+
+/// Optional ObjC requirement is a real protocol member here so existential
+/// dispatch reaches conformer overrides. The default is a no-op; Linux never
+/// fabricates a data-service identifier change.
+public protocol CTTelephonyNetworkInfoDelegate: NSObjectProtocol {
+    func dataServiceIdentifierDidChange(_ identifier: String)
+}
+
+extension CTTelephonyNetworkInfoDelegate {
+    public func dataServiceIdentifierDidChange(_ identifier: String) {
+        _ = identifier
+    }
+}
+
+/// Radio / subscriber provider queries are fail-closed (`nil`). Stored
+/// notifiers and the weak delegate are never invoked with invented updates.
+open class CTTelephonyNetworkInfo: NSObject {
+    public override init() {
+        super.init()
+    }
+
+    open var dataServiceIdentifier: String? { nil }
+
+    public weak var delegate: (any CTTelephonyNetworkInfoDelegate)?
+
+    open var serviceSubscriberCellularProviders: [String: CTCarrier]? { nil }
+
+    open var subscriberCellularProvider: CTCarrier? { nil }
+
+    open var serviceSubscriberCellularProvidersDidUpdateNotifier: ((String) -> Void)?
+
+    open var subscriberCellularProviderDidUpdateNotifier: ((CTCarrier) -> Void)?
+
+    open var serviceCurrentRadioAccessTechnology: [String: String]? { nil }
+
+    open var currentRadioAccessTechnology: String? { nil }
+}

--- a/full/coretelephony/CoreTelephony.swift
+++ b/full/coretelephony/CoreTelephony.swift
@@ -1,0 +1,117 @@
+import Dispatch
+import Foundation
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+/// Linux overlay of Apple's `CTError` C structure. Domain values follow the
+/// pinned `dotnet/macios` `CTErrorDomain` explicit raw values
+/// (`NoError = 0`, `Posix = 1`, `Mach = 2`). Apple runtime ABI is otherwise
+/// unobserved in this environment.
+public struct CTError: Sendable {
+    public var domain: Int32
+    public var error: Int32
+
+    public init() {
+        self.domain = Int32(kCTErrorDomainNoError)
+        self.error = 0
+    }
+
+    public init(domain: Int32, error: Int32) {
+        self.domain = domain
+        self.error = error
+    }
+}
+
+/// Public C enum imported as `Int` getters. Values match macios
+/// `CTErrorDomain` (`NoError = 0`).
+public var kCTErrorDomainNoError: Int { 0 }
+
+/// Public C enum imported as `Int` getters. Values match macios
+/// `CTErrorDomain` (`Posix = 1`).
+public var kCTErrorDomainPOSIX: Int { 1 }
+
+/// Public C enum imported as `Int` getters. Values match macios
+/// `CTErrorDomain` (`Mach = 2`).
+public var kCTErrorDomainMach: Int { 2 }
+
+/// Sequential `NS_ENUM(NSUInteger)` matching macios `CTCellularDataRestrictedState`.
+public enum CTCellularDataRestrictedState: UInt, Sendable, Hashable {
+    case restrictedStateUnknown = 0
+    case restricted = 1
+    case notRestricted = 2
+}
+
+/// Sequential `NS_ENUM(NSInteger)` matching macios `CTCellularPlanCapability`.
+public enum CTCellularPlanCapability: Int, Sendable, Hashable {
+    case dataOnly = 0
+    case dataAndVoice = 1
+}
+
+/// Sequential `NS_ENUM(NSUInteger)` matching macios
+/// `CTCellularPlanProvisioningAddPlanResult` case order. The Swift overlay
+/// uses `UInt` (`init?(rawValue: UInt)`); macios binds the same cases as
+/// `long`.
+public enum CTCellularPlanProvisioningAddPlanResult: UInt, Sendable, Hashable {
+    case unknown = 0
+    case fail = 1
+    case success = 2
+    case cancel = 3
+}
+
+public typealias CellularDataRestrictionDidUpdateNotifier =
+    (CTCellularDataRestrictedState) -> Void
+
+// MARK: - Call / RAT / notification / token string constants
+//
+// Exact Apple string payloads are unobserved here. macios loads them with
+// `Dlfcn` / `[Field]` from the Apple dylib. These compile with provisional
+// values equal to the public symbol names and are coverage-`declared`.
+
+public let CTCallStateConnected: String = "CTCallStateConnected"
+public let CTCallStateDialing: String = "CTCallStateDialing"
+public let CTCallStateDisconnected: String = "CTCallStateDisconnected"
+public let CTCallStateIncoming: String = "CTCallStateIncoming"
+
+public let CTRadioAccessTechnologyCDMA1x: String = "CTRadioAccessTechnologyCDMA1x"
+public let CTRadioAccessTechnologyCDMAEVDORev0: String = "CTRadioAccessTechnologyCDMAEVDORev0"
+public let CTRadioAccessTechnologyCDMAEVDORevA: String = "CTRadioAccessTechnologyCDMAEVDORevA"
+public let CTRadioAccessTechnologyCDMAEVDORevB: String = "CTRadioAccessTechnologyCDMAEVDORevB"
+public let CTRadioAccessTechnologyEdge: String = "CTRadioAccessTechnologyEdge"
+public let CTRadioAccessTechnologyGPRS: String = "CTRadioAccessTechnologyGPRS"
+public let CTRadioAccessTechnologyHSDPA: String = "CTRadioAccessTechnologyHSDPA"
+public let CTRadioAccessTechnologyHSUPA: String = "CTRadioAccessTechnologyHSUPA"
+public let CTRadioAccessTechnologyLTE: String = "CTRadioAccessTechnologyLTE"
+public let CTRadioAccessTechnologyNR: String = "CTRadioAccessTechnologyNR"
+public let CTRadioAccessTechnologyNRNSA: String = "CTRadioAccessTechnologyNRNSA"
+public let CTRadioAccessTechnologyWCDMA: String = "CTRadioAccessTechnologyWCDMA"
+public let CTRadioAccessTechnologyeHRPD: String = "CTRadioAccessTechnologyeHRPD"
+
+public let CTSubscriberTokenRefreshed: String = "CTSubscriberTokenRefreshed"
+
+extension NSNotification.Name {
+    public static let CTRadioAccessTechnologyDidChange = NSNotification.Name(
+        "CTRadioAccessTechnologyDidChange"
+    )
+    public static let CTServiceRadioAccessTechnologyDidChange = NSNotification.Name(
+        "CTServiceRadioAccessTechnologyDidChange"
+    )
+}
+
+/// Fail-closed `NSError` for eSIM / plan / token APIs. This is not an Apple
+/// `NSError` domain; `kCTErrorDomain*` are C `Int` enums, not `NSError` domains.
+internal func coreTelephonyUnavailableError(_ message: String) -> NSError {
+    NSError(
+        domain: NSPOSIXErrorDomain,
+        code: Int(EPERM),
+        userInfo: [NSLocalizedDescriptionKey: message]
+    )
+}
+
+internal func coreTelephonyHop(_ body: @escaping () -> Void) {
+    DispatchQueue.global(qos: .userInitiated).async {
+        body()
+    }
+}

--- a/full/coretelephony/README.md
+++ b/full/coretelephony/README.md
@@ -1,0 +1,51 @@
+# CoreTelephony (Linux starting point)
+
+This directory is a fail-closed portable `CoreTelephony` module for the
+OpenUIKit Linux platform. It reconstructs the public Xcode 26.1 iPhoneOS Swift
+surface from the sealed symbol graph. It is not wired into the shared guest
+package; a passing isolated host gate is not integrated Linux success.
+
+The GitHub App installation for this promotion run could not fetch
+`github.com/Vercantez/openuikit-linux-platform`
+(`cursor/port-coretelephony-to-linux-7cc7`, legacy PR #7). The lane was built
+from the monorepo seed plus the in-repo PR #7 repair brief
+(`full/framework-fanout/repairs-wave1-pr4-9.json`) and pinned `dotnet/macios`
+enum raw values. The monorepo `reference/` dossier was kept (generator SHA-256
+`2b8230ced5a3ed78f070607346f6a684d9e0fb74a8932b92bc0f5e38f46f0a8e`); the
+platform branch `reference/` could not be compared (`unavailable`).
+
+## What is real
+
+- `kCTErrorDomainNoError` / `POSIX` / `Mach` are `0` / `1` / `2`, matching
+  pinned macios `CTErrorDomain`. `CTError` stores `Int32` domain and error
+  fields; `init()` is a zero error in the no-error domain.
+- Enum raw values follow sequential `NS_ENUM` / macios `[Native]` case order:
+  `CTCellularDataRestrictedState` (`UInt` 0...2), `CTCellularPlanCapability`
+  (`Int` 0...1), `CTCellularPlanProvisioningAddPlanResult` (`UInt` 0...3).
+  `hashValue`, `hash(into:)`, and `!=` are exercised for the plan enums.
+- `CTCellularData.restrictedState` is always `.restrictedStateUnknown`. The
+  first non-nil `cellularDataRestrictionDidUpdateNotifier` assignment hops
+  off the caller and delivers that state exactly once. Replacing a non-nil
+  handler does not invent later service updates; nil → non-nil fires again.
+- Delegate protocols are real requirements (the optional
+  `CTTelephonyNetworkInfoDelegate` member has a default no-op). Existential
+  dispatch reaches conformer overrides. Linux never fabricates
+  `dataServiceIdentifierDidChange` or `subscriberTokenRefreshed`.
+- Radio, carrier, SIM, call, and eSIM queries fail closed: `nil` / empty /
+  `false`. `addPlan` completes asynchronously with `.fail`; `update` and
+  plan-status token APIs fail with `NSPOSIXErrorDomain` / `EPERM`.
+- `init(coder:)` on plan types returns `nil`; Apple archive keys are
+  unobserved.
+
+## Fail-closed / not claimed
+
+- No baseband, SIM, carrier token, eSIM host, or CallKit replacement.
+- The 20 call-state, RAT, notification-name, and `CTSubscriberTokenRefreshed`
+  string payloads are provisional (symbol-name fallbacks). macios loads them
+  from the Apple dylib via `Dlfcn` / `[Field]`; exact bytes stay oracle
+  questions and coverage-`declared`.
+- `CTCallCenter.callEventHandler` is stored and never invoked.
+- No module-local CoreFoundation aliases.
+
+Did not touch `machorun/`, `uikit/`, `env/contract.json`, or
+`scripts/vendor_pins.sh`.

--- a/full/coretelephony/coretelephony_guest_sources.txt
+++ b/full/coretelephony/coretelephony_guest_sources.txt
@@ -1,0 +1,6 @@
+full/coretelephony/CTCall.swift
+full/coretelephony/CTCellularData.swift
+full/coretelephony/CTCellularPlan.swift
+full/coretelephony/CTSubscriber.swift
+full/coretelephony/CTTelephonyNetworkInfo.swift
+full/coretelephony/CoreTelephony.swift

--- a/full/coretelephony/coverage.tsv
+++ b/full/coretelephony/coverage.tsv
@@ -1,0 +1,113 @@
+precise	status	evidence	notes
+c:@CTCallStateConnected	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTCallStateDialing	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTCallStateDisconnected	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTCallStateIncoming	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyCDMA1x	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyCDMAEVDORev0	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyCDMAEVDORevA	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyCDMAEVDORevB	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyDidChangeNotification	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyEdge	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyGPRS	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyHSDPA	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyHSUPA	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyLTE	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyNR	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyNRNSA	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyWCDMA	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTRadioAccessTechnologyeHRPD	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTServiceRadioAccessTechnologyDidChangeNotification	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@CTSubscriberTokenRefreshed	declared	CoreTelephony.swift	provisional symbol-name fallback; Apple string bytes unobserved (macios Dlfcn/Field)
+c:@E@CTCellularDataRestrictedState	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularDataRestrictedState@kCTCellularDataNotRestricted	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularDataRestrictedState@kCTCellularDataRestricted	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularDataRestrictedState@kCTCellularDataRestrictedStateUnknown	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanCapability	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanCapability@CTCellularPlanCapabilityDataAndVoice	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanCapability@CTCellularPlanCapabilityDataOnly	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanProvisioningAddPlanResult	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanProvisioningAddPlanResult@CTCellularPlanProvisioningAddPlanResultCancel	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanProvisioningAddPlanResult@CTCellularPlanProvisioningAddPlanResultFail	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanProvisioningAddPlanResult@CTCellularPlanProvisioningAddPlanResultSuccess	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@E@CTCellularPlanProvisioningAddPlanResult@CTCellularPlanProvisioningAddPlanResultUnknown	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@Ea@kCTErrorDomainNoError@kCTErrorDomainMach	implemented	tests/agent/CoreTelephonyRuntime.swift	macios CTErrorDomain.Mach = 2; runtime asserts
+c:@Ea@kCTErrorDomainNoError@kCTErrorDomainNoError	implemented	tests/agent/CoreTelephonyRuntime.swift	macios CTErrorDomain.NoError = 0; runtime asserts
+c:@Ea@kCTErrorDomainNoError@kCTErrorDomainPOSIX	implemented	tests/agent/CoreTelephonyRuntime.swift	macios CTErrorDomain.Posix = 1; runtime asserts
+c:@SA@CTError	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@SA@CTError@FI@domain	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@SA@CTError@FI@error	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:@T@CellularDataRestrictionDidUpdateNotifier	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCall	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCall(py)callID	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCall(py)callState	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCallCenter	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCallCenter(py)callEventHandler	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCallCenter(py)currentCalls	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCarrier	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCarrier(py)allowsVOIP	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCarrier(py)carrierName	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCarrier(py)isoCountryCode	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCarrier(py)mobileCountryCode	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCarrier(py)mobileNetworkCode	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularData	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularData(py)cellularDataRestrictionDidUpdateNotifier	implemented	tests/agent/CoreTelephonyRuntime.swift	first nil-to-nonnil assignment hops and delivers restrictedStateUnknown exactly once
+c:objc(cs)CTCellularData(py)restrictedState	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProperties	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProperties(py)associatedIccid	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProperties(py)simCapability	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioning	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioning(im)addPlanWith:completionHandler:	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioning(im)addPlanWithRequest:properties:completionHandler:	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioning(im)supportsCellularPlan	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioning(im)updateCellularPlanProperties:completionHandler:	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioning(py)supportsEmbeddedSIM	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest(py)EID	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest(py)ICCID	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest(py)OID	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest(py)address	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest(py)confirmationCode	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanProvisioningRequest(py)matchingID	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanStatus	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanStatus(cm)checkValidityOfToken:completionHandler:	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTCellularPlanStatus(cm)getTokenWithCompletion:	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriber	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriber(im)refreshCarrierToken	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriber(py)SIMInserted	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriber(py)carrierToken	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriber(py)delegate	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriber(py)identifier	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriberInfo	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriberInfo(cm)subscriber	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTSubscriberInfo(cm)subscribers	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)currentRadioAccessTechnology	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)dataServiceIdentifier	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)delegate	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)serviceCurrentRadioAccessTechnology	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)serviceSubscriberCellularProviders	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)serviceSubscriberCellularProvidersDidUpdateNotifier	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)subscriberCellularProvider	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(cs)CTTelephonyNetworkInfo(py)subscriberCellularProviderDidUpdateNotifier	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(pl)CTSubscriberDelegate	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(pl)CTSubscriberDelegate(im)subscriberTokenRefreshed:	implemented	tests/agent/CoreTelephonyRuntime.swift	existential dispatch to test conformer; refreshCarrierToken does not fabricate
+c:objc(pl)CTTelephonyNetworkInfoDelegate	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(pl)CTTelephonyNetworkInfoDelegate(im)dataServiceIdentifierDidChange:	implemented	tests/agent/CoreTelephonyRuntime.swift	existential dispatch to test conformer override; Linux never fabricates
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)CTCellularPlanProperties	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)CTCellularPlanProvisioningRequest	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@CTCellularDataRestrictedState	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@CTCellularPlanCapability	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@CTCellularPlanProvisioningAddPlanResult	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@CTCellularDataRestrictedState	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@CTCellularPlanCapability	implemented	tests/agent/CoreTelephonyRuntime.swift	runtime hashValue inequality for dataOnly vs dataAndVoice
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@CTCellularPlanProvisioningAddPlanResult	implemented	tests/agent/CoreTelephonyRuntime.swift	runtime hashValue inequality for fail vs success
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@CTCellularDataRestrictedState	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@CTCellularPlanCapability	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@CTCellularPlanProvisioningAddPlanResult	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:So029CTCellularPlanProvisioningAddB6ResultV8rawValueABSgSu_tcfc	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:So24CTCellularPlanCapabilityV8rawValueABSgSi_tcfc	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:So24CTCellularPlanPropertiesC13CoreTelephonyE20supportedRegionCodesSay10Foundation6LocaleV0G0VGvp	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:So29CTCellularDataRestrictedStateV8rawValueABSgSu_tcfc	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:So7CTErrora6domain5errorABs5Int32V_AFtcfc	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence
+s:So7CTErroraABycfc	implemented	tests/agent/CoreTelephonyRuntime.swift	focused Linux runtime evidence

--- a/full/coretelephony/oracle-questions.tsv
+++ b/full/coretelephony/oracle-questions.tsv
@@ -1,0 +1,11 @@
+precise	question	risk	reason
+c:@CTCallStateConnected	What is the exact Darwin string payload of CTCallStateConnected?	telephony	macios loads the constant with Dlfcn from the Apple dylib; this overlay uses a symbol-name fallback only.
+c:@CTCallStateDialing	What is the exact Darwin string payload of CTCallStateDialing?	telephony	Public Field name is known; the Apple string bytes are not in the sealed seed.
+c:@CTCallStateDisconnected	What is the exact Darwin string payload of CTCallStateDisconnected?	telephony	Public Field name is known; the Apple string bytes are not in the sealed seed.
+c:@CTCallStateIncoming	What is the exact Darwin string payload of CTCallStateIncoming?	telephony	Public Field name is known; the Apple string bytes are not in the sealed seed.
+c:@CTRadioAccessTechnologyLTE	What is the exact Darwin string payload of CTRadioAccessTechnologyLTE?	telephony	macios [Field] names the symbol; payload bytes are unobserved here.
+c:@CTRadioAccessTechnologyDidChangeNotification	What is the exact NSNotification.Name rawValue for CTRadioAccessTechnologyDidChange?	telephony	Foundation overlay names the symbol; Apple notification string bytes are unobserved.
+c:@CTServiceRadioAccessTechnologyDidChangeNotification	What is the exact NSNotification.Name rawValue for CTServiceRadioAccessTechnologyDidChange?	telephony	Foundation overlay names the symbol; Apple notification string bytes are unobserved.
+c:@CTSubscriberTokenRefreshed	What is the exact Darwin string payload of CTSubscriberTokenRefreshed?	telephony	Public symbol exists in the TBD; payload bytes are unobserved.
+c:objc(cs)CTCellularData(py)cellularDataRestrictionDidUpdateNotifier	On Darwin, is the initial cellularDataRestrictionDidUpdateNotifier invocation always asynchronous relative to the setter, and is it skipped when replacing an already non-nil handler?	privacy	Linux hops the first nil-to-nonnil assignment; Apple queue/timing/replacement rules are unobserved.
+c:objc(pl)NSCoding(im)initWithCoder:::SYNTHESIZED::c:objc(cs)CTCellularPlanProvisioningRequest	What keyed-archive keys and classes does Darwin use for CTCellularPlanProvisioningRequest NSSecureCoding?	fail-closed	Linux init(coder:) returns nil because Apple archive keys are not in the seed.

--- a/full/coretelephony/tests/agent/CoreTelephonyRuntime.swift
+++ b/full/coretelephony/tests/agent/CoreTelephonyRuntime.swift
@@ -1,0 +1,306 @@
+import CoreTelephony
+import Dispatch
+import Foundation
+
+private func waitOnce(_ semaphore: DispatchSemaphore, seconds: Double = 2) {
+    precondition(semaphore.wait(timeout: .now() + seconds) == .success)
+}
+
+private func waitQuiet(_ semaphore: DispatchSemaphore, seconds: Double = 0.25) {
+    precondition(semaphore.wait(timeout: .now() + seconds) == .timedOut)
+}
+
+private final class NetworkDelegateProbe: NSObject, CTTelephonyNetworkInfoDelegate {
+    var seen: String?
+    func dataServiceIdentifierDidChange(_ identifier: String) {
+        seen = identifier
+    }
+}
+
+private final class SubscriberDelegateProbe: NSObject, CTSubscriberDelegate {
+    var refreshed: CTSubscriber?
+    func subscriberTokenRefreshed(_ subscriber: CTSubscriber) {
+        refreshed = subscriber
+    }
+}
+
+enum CoreTelephonyRuntime {
+    static func main() async {
+        exerciseErrorAndEnums()
+        exerciseCallCenter()
+        exerciseNetworkInfoAndDelegates()
+        exerciseSubscriber()
+        await exerciseCellularDataNotifier()
+        await exerciseCellularPlan()
+        print("CORETELEPHONY_AGENT_RUNTIME_OK")
+    }
+
+    static func exerciseErrorAndEnums() {
+        precondition(kCTErrorDomainNoError == 0)
+        precondition(kCTErrorDomainPOSIX == 1)
+        precondition(kCTErrorDomainMach == 2)
+
+        let zero = CTError()
+        precondition(zero.domain == Int32(kCTErrorDomainNoError))
+        precondition(zero.error == 0)
+        var err = CTError(domain: Int32(kCTErrorDomainPOSIX), error: 2)
+        precondition(err.domain == Int32(kCTErrorDomainPOSIX))
+        precondition(err.error == 2)
+        err.domain = Int32(kCTErrorDomainMach)
+        err.error = 9
+        precondition(err.domain == Int32(kCTErrorDomainMach))
+        precondition(err.error == 9)
+
+        precondition(CTCellularDataRestrictedState(rawValue: 0) == .restrictedStateUnknown)
+        precondition(CTCellularDataRestrictedState(rawValue: 1) == .restricted)
+        precondition(CTCellularDataRestrictedState(rawValue: 2) == .notRestricted)
+        precondition(CTCellularDataRestrictedState(rawValue: 99) == nil)
+        precondition(CTCellularDataRestrictedState.restricted != .notRestricted)
+        _ = CTCellularDataRestrictedState.restricted.hashValue
+        var hasher = Hasher()
+        CTCellularDataRestrictedState.notRestricted.hash(into: &hasher)
+        _ = hasher.finalize()
+
+        precondition(CTCellularPlanCapability(rawValue: 0) == .dataOnly)
+        precondition(CTCellularPlanCapability(rawValue: 1) == .dataAndVoice)
+        precondition(CTCellularPlanCapability(rawValue: 8) == nil)
+        precondition(CTCellularPlanCapability.dataOnly != .dataAndVoice)
+        let capabilityHash = CTCellularPlanCapability.dataOnly.hashValue
+        precondition(capabilityHash != CTCellularPlanCapability.dataAndVoice.hashValue)
+        var capabilityHasher = Hasher()
+        CTCellularPlanCapability.dataAndVoice.hash(into: &capabilityHasher)
+        _ = capabilityHasher.finalize()
+
+        precondition(CTCellularPlanProvisioningAddPlanResult(rawValue: 0) == .unknown)
+        precondition(CTCellularPlanProvisioningAddPlanResult(rawValue: 1) == .fail)
+        precondition(CTCellularPlanProvisioningAddPlanResult(rawValue: 2) == .success)
+        precondition(CTCellularPlanProvisioningAddPlanResult(rawValue: 3) == .cancel)
+        precondition(CTCellularPlanProvisioningAddPlanResult(rawValue: 4) == nil)
+        precondition(
+            CTCellularPlanProvisioningAddPlanResult.fail
+                != CTCellularPlanProvisioningAddPlanResult.success
+        )
+        let resultHash = CTCellularPlanProvisioningAddPlanResult.fail.hashValue
+        precondition(resultHash != CTCellularPlanProvisioningAddPlanResult.success.hashValue)
+        var resultHasher = Hasher()
+        CTCellularPlanProvisioningAddPlanResult.cancel.hash(into: &resultHasher)
+        _ = resultHasher.finalize()
+
+        _ = CTCallStateConnected
+        _ = CTRadioAccessTechnologyLTE
+        _ = CTSubscriberTokenRefreshed
+        _ = NSNotification.Name.CTRadioAccessTechnologyDidChange
+        _ = NSNotification.Name.CTServiceRadioAccessTechnologyDidChange
+        let _: CellularDataRestrictionDidUpdateNotifier = { _ in }
+    }
+
+    static func exerciseCallCenter() {
+        let call = CTCall()
+        precondition(call.callID.isEmpty)
+        precondition(call.callState.isEmpty)
+
+        let center = CTCallCenter()
+        precondition(center.currentCalls == nil)
+        var fired = false
+        center.callEventHandler = { _ in fired = true }
+        precondition(center.callEventHandler != nil)
+        precondition(!fired)
+        center.callEventHandler = nil
+        precondition(center.callEventHandler == nil)
+    }
+
+    static func exerciseNetworkInfoAndDelegates() {
+        let carrier = CTCarrier()
+        precondition(carrier.carrierName == nil)
+        precondition(carrier.mobileCountryCode == nil)
+        precondition(carrier.mobileNetworkCode == nil)
+        precondition(carrier.isoCountryCode == nil)
+        precondition(carrier.allowsVOIP == false)
+
+        let info = CTTelephonyNetworkInfo()
+        precondition(info.dataServiceIdentifier == nil)
+        precondition(info.subscriberCellularProvider == nil)
+        precondition(info.serviceSubscriberCellularProviders == nil)
+        precondition(info.currentRadioAccessTechnology == nil)
+        precondition(info.serviceCurrentRadioAccessTechnology == nil)
+
+        var providerFired = false
+        var serviceFired = false
+        info.subscriberCellularProviderDidUpdateNotifier = { _ in providerFired = true }
+        info.serviceSubscriberCellularProvidersDidUpdateNotifier = { _ in serviceFired = true }
+        precondition(!providerFired)
+        precondition(!serviceFired)
+
+        let override = NetworkDelegateProbe()
+        info.delegate = override
+        precondition(info.delegate === override)
+        let existential: any CTTelephonyNetworkInfoDelegate = override
+        existential.dataServiceIdentifierDidChange("probe-id")
+        precondition(override.seen == "probe-id")
+        info.delegate = nil
+        precondition(info.delegate == nil)
+    }
+
+    static func exerciseSubscriber() {
+        let subscriber = CTSubscriber()
+        precondition(subscriber.carrierToken == nil)
+        precondition(subscriber.identifier.isEmpty)
+        precondition(subscriber.isSIMInserted == false)
+        let probe = SubscriberDelegateProbe()
+        subscriber.delegate = probe
+        precondition(subscriber.delegate === probe)
+        precondition(subscriber.refreshCarrierToken() == false)
+        precondition(probe.refreshed == nil)
+        let existential: any CTSubscriberDelegate = probe
+        existential.subscriberTokenRefreshed(subscriber)
+        precondition(probe.refreshed === subscriber)
+
+        precondition(CTSubscriberInfo.subscribers().isEmpty)
+        let deprecated = CTSubscriberInfo.subscriber()
+        precondition(deprecated.isSIMInserted == false)
+    }
+
+    static func exerciseCellularDataNotifier() async {
+        let data = CTCellularData()
+        precondition(data.restrictedState == .restrictedStateUnknown)
+
+        let first = DispatchSemaphore(value: 0)
+        var hits = 0
+        var seen: CTCellularDataRestrictedState?
+        var inline = false
+        data.cellularDataRestrictionDidUpdateNotifier = { state in
+            hits += 1
+            seen = state
+            inline = true
+            first.signal()
+        }
+        precondition(!inline)
+        waitOnce(first)
+        precondition(hits == 1)
+        precondition(seen == .restrictedStateUnknown)
+        waitQuiet(first)
+
+        var secondHits = 0
+        data.cellularDataRestrictionDidUpdateNotifier = { _ in
+            secondHits += 1
+        }
+        waitQuiet(DispatchSemaphore(value: 0), seconds: 0.25)
+        precondition(secondHits == 0)
+        precondition(hits == 1)
+
+        data.cellularDataRestrictionDidUpdateNotifier = nil
+        let again = DispatchSemaphore(value: 0)
+        var thirdHits = 0
+        data.cellularDataRestrictionDidUpdateNotifier = { _ in
+            thirdHits += 1
+            again.signal()
+        }
+        waitOnce(again)
+        precondition(thirdHits == 1)
+    }
+
+    static func exerciseCellularPlan() async {
+        let properties = CTCellularPlanProperties()
+        properties.associatedIccid = "890000"
+        properties.simCapability = .dataAndVoice
+        properties.supportedRegionCodes = [Locale.Region("US")]
+        precondition(properties.associatedIccid == "890000")
+        precondition(properties.simCapability == .dataAndVoice)
+        precondition(properties.supportedRegionCodes == [Locale.Region("US")])
+        let dummyArchive: Data = {
+            let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+            archiver.encode("coretelephony-linux", forKey: "probe")
+            return archiver.encodedData
+        }()
+        let emptyPropertiesArchive = try! NSKeyedUnarchiver(forReadingFrom: dummyArchive)
+        precondition(CTCellularPlanProperties(coder: emptyPropertiesArchive) == nil)
+        let emptyRequestArchive = try! NSKeyedUnarchiver(forReadingFrom: dummyArchive)
+        precondition(CTCellularPlanProvisioningRequest(coder: emptyRequestArchive) == nil)
+
+        let request = CTCellularPlanProvisioningRequest()
+        precondition(request.address.isEmpty)
+        request.address = "https://example.test/esim"
+        request.matchingID = "match"
+        request.oid = "oid"
+        request.confirmationCode = "code"
+        request.iccid = "iccid"
+        request.eid = "eid"
+        precondition(request.address == "https://example.test/esim")
+        precondition(request.matchingID == "match")
+        precondition(request.oid == "oid")
+        precondition(request.confirmationCode == "code")
+        precondition(request.iccid == "iccid")
+        precondition(request.eid == "eid")
+
+        let provisioning = CTCellularPlanProvisioning()
+        precondition(provisioning.supportsCellularPlan() == false)
+        precondition(provisioning.supportsEmbeddedSIM == false)
+
+        let addSemaphore = DispatchSemaphore(value: 0)
+        var addInline = false
+        var addResult: CTCellularPlanProvisioningAddPlanResult?
+        provisioning.addPlan(with: request) { result in
+            addInline = true
+            addResult = result
+            addSemaphore.signal()
+        }
+        precondition(!addInline)
+        waitOnce(addSemaphore)
+        precondition(addResult == .fail)
+
+        let asyncFail = await provisioning.addPlan(with: request)
+        precondition(asyncFail == .fail)
+        let asyncFailWithProperties = await provisioning.addPlan(
+            request: request,
+            properties: properties
+        )
+        precondition(asyncFailWithProperties == .fail)
+
+        let updateSemaphore = DispatchSemaphore(value: 0)
+        var updateError: (any Error)?
+        var updateInline = false
+        provisioning.update(properties) { error in
+            updateInline = true
+            updateError = error
+            updateSemaphore.signal()
+        }
+        precondition(!updateInline)
+        waitOnce(updateSemaphore)
+        precondition(updateError != nil)
+        do {
+            try await provisioning.update(properties)
+            fatalError("update must fail closed")
+        } catch {
+            precondition((error as NSError).domain == NSPOSIXErrorDomain)
+        }
+
+        let tokenSemaphore = DispatchSemaphore(value: 0)
+        var token: String? = "sentinel"
+        var tokenError: (any Error)?
+        var tokenInline = false
+        CTCellularPlanStatus.getTokenWithCompletion { value, error in
+            tokenInline = true
+            token = value
+            tokenError = error
+            tokenSemaphore.signal()
+        }
+        precondition(!tokenInline)
+        waitOnce(tokenSemaphore)
+        precondition(token == nil)
+        precondition(tokenError != nil)
+        do {
+            _ = try await CTCellularPlanStatus.checkValidity(ofToken: "token")
+            fatalError("checkValidity must fail closed")
+        } catch {
+            precondition((error as NSError).domain == NSPOSIXErrorDomain)
+        }
+    }
+}
+
+let coreTelephonyRuntimeDone = DispatchSemaphore(value: 0)
+Task {
+    await CoreTelephonyRuntime.main()
+    coreTelephonyRuntimeDone.signal()
+}
+coreTelephonyRuntimeDone.wait()
+

--- a/full/coretelephony/tests/agent/CoreTelephonyRuntime.swift
+++ b/full/coretelephony/tests/agent/CoreTelephonyRuntime.swift
@@ -303,4 +303,3 @@ Task {
     coreTelephonyRuntimeDone.signal()
 }
 coreTelephonyRuntimeDone.wait()
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Promote `full/coretelephony/` onto `Vercantez/openuikit` main.

**Source:** platform branch `cursor/port-coretelephony-to-linux-7cc7` (legacy PR [#7](https://github.com/Vercantez/openuikit-linux-platform/pull/7)). Fetch of `github.com/Vercantez/openuikit-linux-platform` returned 404 with this GitHub App token (installation scoped to `Vercantez/openuikit` only). This PR is a seed-based deliverable that follows the in-repo PR #7 repair brief (`full/framework-fanout/repairs-wave1-pr4-9.json`): first non-nil `CTCellularData` notifier assignment hops and delivers honest Linux `.restrictedStateUnknown` exactly once; delegate protocols and plan-enum `hashValue` are exercised; 20 call/RAT/notification/token string IDs are `declared` with provisional-value notes.

**Reference dossier:** kept the monorepo `full/coretelephony/reference/` (generator SHA `2b8230ced5a3ed78f070607346f6a684d9e0fb74a8932b92bc0f5e38f46f0a8e`). The platform branch `reference/` could not be compared (`unavailable`).

## Gate outputs (verbatim last lines)

Deliverable (`python3 -B full/framework-fanout/validate_seed.py --framework full/coretelephony --phase deliverable`):

```
FRAMEWORK_FANOUT_DELIVERABLE_OK module=CoreTelephony lane=leaf-full symbols=112
```

Host (`bash full/coretelephony/tests/acceptance/test_host.sh`):

```
FRAMEWORK_FANOUT_HOST_OK module=CoreTelephony dylib=libCoreTelephony.dylib
```

(Full host run also printed `FRAMEWORK_FANOUT_REFERENCE_OK` and `CORETELEPHONY_AGENT_RUNTIME_OK`.)

## Coverage counts

| status | count |
| --- | --- |
| implemented | 92 |
| declared | 20 |
| deferred | 0 |
| total | 112 |
| nondeferred (floor 90) | 112 |

Declared rows are the 20 call-state, RAT, notification-name, and `CTSubscriberTokenRefreshed` string constants (provisional symbol-name fallbacks; Apple payloads unobserved — macios loads them via `Dlfcn` / `[Field]`).

## What changed to make the gates pass

Main was seed-only (`CoreTelephony.swift` missing). Added Linux sources listed in `coretelephony_guest_sources.txt`, `coverage.tsv`, `oracle-questions.tsv`, `README.md`, and `tests/agent/CoreTelephonyRuntime.swift`.

Fail-closed behavior: no baseband/SIM/eSIM/call stack. `addPlan` completes asynchronously with `.fail`; plan `update` and token APIs fail with `NSPOSIXErrorDomain`/`EPERM`. `init(coder:)` on plan types returns `nil`. Optional `CTTelephonyNetworkInfoDelegate.dataServiceIdentifierDidChange` is a real protocol requirement with a default no-op so existential dispatch reaches overrides. No module-local CF/Foundation aliases.

Did not touch `machorun/`, `uikit/`, `env/contract.json`, or `scripts/vendor_pins.sh`.

`python3 scripts/env/test_contract.py` is **unavailable** on this `origin/main` tree (those files are not in HEAD). Nothing it would pin was edited.

## Deferred / unavailable

- Hardware telephony, SIM/carrier token, eSIM host, and fabricated radio/call updates remain unavailable (APIs fail closed).
- Oracle questions: exact Darwin string bytes for the 20 declared constants, Darwin initial-notifier timing/replacement, and NSSecureCoding archive keys.
- Platform branch `reference/` comparison is `unavailable`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76e6795a-f445-4576-842c-b4163c4a6d65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76e6795a-f445-4576-842c-b4163c4a6d65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

