### PR TITLE
Link the FoundationInternationalization bridge and oracle runners for the TARGET arch

### DIFF
--- a/full/foundation/build_json_runner.sh
+++ b/full/foundation/build_json_runner.sh
@@ -28,6 +28,7 @@ ROOTDIR=${ROOTDIR:-$W/scratch/mrroot_fe}
 OUT=${OUT:-$W/scratch/fe4_out}
 J=${J:-$W/full/oracle-json}
 TARGET=${TARGET:-arm64-apple-macos15.0}
+LINK_ARCH=${TARGET%%-*}
 mkdir -p "$OUT"
 
 # The 202-file FoundationEssentials compile belongs to build_fe.sh.  Refuse
@@ -51,7 +52,7 @@ swiftc -target "$TARGET" -sdk "$SYS" -wmo -O \
 clang-18 -target "$TARGET" -isysroot "$SYS" -O1 -nostdinc \
     -c -o "$OUT/fm_unimplemented.o" "$W/full/foundation/fm_unimplemented.c"
 
-ld64.lld-18 -arch arm64 -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
+ld64.lld-18 -arch "$LINK_ARCH" -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
     -rpath /usr/lib/swift -rpath @loader_path -dead_strip \
     -exported_symbol __mh_execute_header \
     -L"$ROOTDIR/darwin/usr/lib" \

--- a/full/foundation/build_url_runner.sh
+++ b/full/foundation/build_url_runner.sh
@@ -21,6 +21,7 @@ SYS=${SYS:-$W/scratch/sysroot_fe4}
 ROOTDIR=${ROOTDIR:-$W/scratch/mrroot_full}
 OUT=${OUT:-$W/scratch/fe4_out}
 TARGET=${TARGET:-arm64-apple-macos15.0}
+LINK_ARCH=${TARGET%%-*}
 mkdir -p "$OUT"
 
 swiftc -target "$TARGET" -sdk "$SYS" -wmo \
@@ -77,7 +78,7 @@ clang-18 -target "$TARGET" -isysroot "$SYS" -O1 -nostdinc \
 # machorun/scripts/stage_swiftcore.sh already knows how to stage.  Its
 # artifacts/ holds neither today.  Bounded work in a repo that has done it
 # twice -- not a new problem.
-ld64.lld-18 -arch arm64 -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
+ld64.lld-18 -arch "$LINK_ARCH" -platform_version macos 15.0 15.0 -syslibroot "$SYS" \
     -rpath /usr/lib/swift -rpath @loader_path -dead_strip \
     -exported_symbol __mh_execute_header \
     -L"$ROOTDIR/darwin/usr/lib" \

--- a/full/foundationinternationalization/build_foundation_internationalization.sh
+++ b/full/foundationinternationalization/build_foundation_internationalization.sh
@@ -13,6 +13,7 @@ SWIFT_FOUNDATION_ICU=${SWIFT_FOUNDATION_ICU:?SWIFT_FOUNDATION_ICU is required}
 STAGE=${STAGE:?STAGE is required}
 WORK=${WORK:?WORK is required}
 TARGET=${TARGET:-arm64-apple-macos15.0}
+LINK_ARCH=${TARGET%%-*}
 MIN_OS=${MIN_OS:-15.0}
 LINK_PLATFORM=${LINK_PLATFORM:-macos}
 LINK_SDK_VERSION=${LINK_SDK_VERSION:-$MIN_OS}
@@ -245,7 +246,7 @@ clang-18 -target "$TARGET" -isysroot "$STAGE/sdk" -std=c11 -O2 \
     -o "$INTL_WORK/open-foundation-internationalization-bridge.o"
 
 INTL_DARWIN=$STAGE/guest-root/darwin/usr/lib/libOpenFoundationInternationalization.dylib
-ld64.lld-18 -arch arm64 \
+ld64.lld-18 -arch "$LINK_ARCH" \
     -platform_version "$LINK_PLATFORM" "$MIN_OS" "$LINK_SDK_VERSION" \
     -syslibroot "$STAGE/sdk" -dylib -dead_strip -undefined dynamic_lookup \
     -install_name /usr/lib/libOpenFoundationInternationalization.dylib \
@@ -297,7 +298,7 @@ mapfile -d '' -t ICU_OBJECTS < <(
     find "$ICU_OBJECT_ROOT" -type f -name '*.o' -print0 | LC_ALL=C sort -z
 )
 RUNTIME_LIB=$STAGE/guest-root/darwin/usr/lib
-ld64.lld-18 -arch arm64 \
+ld64.lld-18 -arch "$LINK_ARCH" \
     -platform_version "$LINK_PLATFORM" "$MIN_OS" "$LINK_SDK_VERSION" \
     -syslibroot "$STAGE/guest-root/darwin" -dylib -dead_strip \
     -install_name "$DYLIB_INSTALL_PREFIX/lib_FoundationICU.dylib" \
@@ -353,7 +354,7 @@ mapfile -d '' -t INTL_SOURCES < <(
     -emit-object -o "$INTL_WORK/FoundationInternationalization.o" \
     "${INTL_SOURCES[@]}"
 
-ld64.lld-18 -arch arm64 \
+ld64.lld-18 -arch "$LINK_ARCH" \
     -platform_version "$LINK_PLATFORM" "$MIN_OS" "$LINK_SDK_VERSION" \
     -syslibroot "$STAGE/sdk" -dylib -dead_strip -ignore_auto_link \
     -install_name "$DYLIB_INSTALL_PREFIX/libFoundationInternationalization.dylib" \


### PR DESCRIPTION
x86 rung-b onboarding at 4c5fa474: `foundation_internationalization: REFUSING -- FoundationInternationalization Mach-O bridge exports drifted` because the bridge .o is x86_64 (compiled with -target $TARGET) but the three ld64.lld links said `-arch arm64` (warning: incompatible with target architecture; dylib had no symbols). LINK_ARCH=${TARGET%%-*} on all three links, plus the same literal in the URL/JSON oracle runners. arm64 unchanged. full/ only, no pins; test_contract.py green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188aCUiPNF2xwAWXcozrKDS