### PR TITLE
Promote Social Linux lane from fan-out PR #9

### DIFF
--- a/full/social/README.md
+++ b/full/social/README.md
@@ -1,0 +1,61 @@
+# Social
+
+Linux starting point for Apple's public `Social` module, reconstructed from
+the pinned Xcode 26.1 iPhoneOS symbol graph. The legacy platform branch
+`cursor/port-social-to-linux-fd3a` (fan-out PR #9) was **unavailable** to this
+run (private `openuikit-linux-platform` 404), so this is not a byte-copy of
+those 1553 Swift lines. Behavior follows the in-repo repair briefs
+(`full/framework-fanout/repairs-wave1-pr4-9.json` and
+`repairs-wave1-pr4-9-r2.json`).
+
+The isolated host gate compiles **without** UIKit or Accounts on the module
+path. That configuration is the standalone-unit-fixture path: fallback
+`UIView` / `UIViewController` / `UIImage` / `UITextView` / `UITextViewDelegate`
+and `ACAccount` types live in this module only when those dependencies cannot
+be imported. A build that `canImport` the canonical modules does not emit
+`Social.UIView*` or `Social.ACAccount`.
+
+## What is real
+
+- `SLComposeViewControllerResult` and `SLRequestMethod` (Int `NS_ENUM` overlays,
+  Hashable / Equatable / `init(rawValue:)`).
+- `SLComposeSheetConfigurationItem` title/value/pending/tapHandler.
+- `SLComposeServiceViewController` local sheet state: `textView` +
+  `UITextViewDelegate` wiring, `contentText`, placeholder, characters
+  remaining, `isContentValid` / `validateContent`, configuration item reload,
+  at most one pushed configuration controller, `cancel` → `didSelectCancel`
+  without recursion.
+- `SLComposeViewController.isAvailable(forServiceType:)` is always `false`.
+  `init(forServiceType:)` therefore returns nil.
+- Draft helpers (`setInitialText`, `add` image/URL, `removeAll*`, completion
+  handler clearing) on an `@_spi(OpenUIKitHost)` isolated-host instance.
+- `SLRequest` URLRequest construction (query/urlencoded and multipart), CR/LF/quote
+  rejection, collision-checked multipart boundaries. `preparedURLRequest()` is
+  nil when `account` is set (no OAuth signer). `perform(handler:)` does not
+  network.
+
+## Fail-closed boundaries
+
+Linux has no Twitter/Facebook/Weibo/LinkedIn compose UI, account OAuth, or
+share-extension host.
+
+- `didSelectPost` / `didSelectCancel` are **partial**: they increment local
+  counters and do not complete an `NSExtensionContext`.
+- `SLRequest.perform` hops once onto `Social.SLRequest.perform` and delivers
+  `NSError` domain `Social.linux.fail-closed` with nil data/response.
+- Service-type constant **payloads** are the commonly documented
+  `com.apple.social.*` strings and remain `declared` pending oracle.
+
+## Still open
+
+See `oracle-questions.tsv`. UIKit/Accounts identity is not proven by this
+standalone fixture. Real integration must consume staged platform UIKit and
+Accounts dylibs and must not treat `Social.UIView` / `Social.ACAccount` as
+success.
+
+`tests/agent/SocialRuntime.swift` prints `SOCIAL_AGENT_RUNTIME_OK`.
+`tests/agent/SocialDependencyIdentity.swift` is prepared for a future clean
+EC2 run; compiling it against fixture types is not platform-identity success.
+
+Run `bash tests/acceptance/test_host.sh` from this directory. Keep generated
+products out of the tree.

--- a/full/social/SLComposeServiceViewController.swift
+++ b/full/social/SLComposeServiceViewController.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Share-extension compose sheet controller.
+///
+/// Linux has no `NSExtensionContext` host. `didSelectPost` / `didSelectCancel`
+/// record local invocation only; they do not complete an Apple extension
+/// request. `cancel()` calls `didSelectCancel()` and refuses to re-enter.
+
+@MainActor
+open class SLComposeServiceViewController: UIViewController, UITextViewDelegate {
+    private let storedTextView = UITextView()
+    private var storedPlaceholder: String?
+    private var storedCharactersRemaining: NSNumber?
+    private var storedAutoCompletionViewController: UIViewController?
+    private var pushedConfigurationViewController: UIViewController?
+    private var isHandlingCancel = false
+    private var didFinishPresentationAnimation = false
+    private var lastValidatedContent: Bool?
+    private var configurationReloadCount = 0
+    private var didSelectPostCount = 0
+    private var didSelectCancelCount = 0
+    private var previewView: UIView?
+
+    public override init() {
+        #if canImport(UIKit)
+        super.init(nibName: nil, bundle: nil)
+        #else
+        super.init()
+        #endif
+        storedTextView.delegate = self
+        storedTextView.text = ""
+    }
+
+    #if canImport(UIKit)
+    public required init?(coder: NSCoder) {
+        return nil
+    }
+    #endif
+
+    open var textView: UITextView! { storedTextView }
+
+    open var contentText: String! { storedTextView.text ?? "" }
+
+    open var placeholder: String! {
+        get { storedPlaceholder }
+        set { storedPlaceholder = newValue }
+    }
+
+    open var charactersRemaining: NSNumber! {
+        get { storedCharactersRemaining }
+        set { storedCharactersRemaining = newValue }
+    }
+
+    open var autoCompletionViewController: UIViewController! {
+        get { storedAutoCompletionViewController }
+        set { storedAutoCompletionViewController = newValue }
+    }
+
+    open func presentationAnimationDidFinish() {
+        didFinishPresentationAnimation = true
+    }
+
+    open func isContentValid() -> Bool {
+        true
+    }
+
+    open func validateContent() {
+        lastValidatedContent = isContentValid()
+    }
+
+    open func configurationItems() -> [Any]! {
+        []
+    }
+
+    open func reloadConfigurationItems() {
+        configurationReloadCount += 1
+        _ = configurationItems()
+    }
+
+    /// At most one pushed configuration controller. A second push is ignored
+    /// until `popConfigurationViewController()`.
+    open func pushConfigurationViewController(_ viewController: UIViewController!) {
+        guard pushedConfigurationViewController == nil, let viewController else {
+            return
+        }
+        pushedConfigurationViewController = viewController
+    }
+
+    open func popConfigurationViewController() {
+        pushedConfigurationViewController = nil
+    }
+
+    open func loadPreviewView() -> UIView! {
+        if let previewView {
+            return previewView
+        }
+        let view = UIView()
+        previewView = view
+        return view
+    }
+
+    /// Calls `didSelectCancel()` once. Does not recurse if `didSelectCancel`
+    /// calls `cancel()` again.
+    open func cancel() {
+        guard !isHandlingCancel else { return }
+        isHandlingCancel = true
+        defer { isHandlingCancel = false }
+        didSelectCancel()
+    }
+
+    /// Partial Linux host: no `NSExtensionContext` to complete. Does not call
+    /// `cancel()`.
+    open func didSelectCancel() {
+        didSelectCancelCount += 1
+    }
+
+    /// Partial Linux host: no Apple share-sheet post pipeline.
+    open func didSelectPost() {
+        didSelectPostCount += 1
+    }
+
+    open func textViewDidChange(_ textView: UITextView) {
+        _ = textView.text
+    }
+}
+
+extension SLComposeServiceViewController {
+    @_spi(OpenUIKitHost)
+    public var isolatedHostConfigurationReloadCount: Int { configurationReloadCount }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostPushedConfigurationController: UIViewController? {
+        pushedConfigurationViewController
+    }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostDidFinishPresentationAnimation: Bool {
+        didFinishPresentationAnimation
+    }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostLastValidatedContent: Bool? { lastValidatedContent }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostDidSelectPostCount: Int { didSelectPostCount }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostDidSelectCancelCount: Int { didSelectCancelCount }
+
+    @_spi(OpenUIKitHost)
+    public func isolatedHostReplaceText(_ string: String) {
+        storedTextView.text = string
+        textViewDidChange(storedTextView)
+    }
+}

--- a/full/social/SLComposeSheetConfigurationItem.swift
+++ b/full/social/SLComposeSheetConfigurationItem.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Configuration row shown by a compose-service extension sheet.
+///
+/// Darwin pins `init!()`. This type subclasses `NSObject`, whose designated
+/// `init()` is nonfailable, so Swift requires a nonfailable `override init()`.
+/// There is no isolated-host failure condition that would return nil.
+open class SLComposeSheetConfigurationItem: NSObject {
+    open var title: String!
+    open var value: String!
+    open var valuePending: Bool = false
+    open var tapHandler: SLComposeSheetConfigurationItemTapHandler!
+
+    /// Stronger than the pinned `init!()`: see file comment.
+    public override init() {
+        super.init()
+        title = nil
+        value = nil
+        valuePending = false
+        tapHandler = nil
+    }
+}

--- a/full/social/SLComposeViewController.swift
+++ b/full/social/SLComposeViewController.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// System compose sheet for a social service.
+///
+/// Linux never reports a service as available and never presents Apple UI.
+/// `init(forServiceType:)` therefore returns nil. Local draft-state methods
+/// (`setInitialText`, `add`, `removeAll*`, `completionHandler`) are exercised
+/// through `SocialHostControl.makeComposeViewController`, which does not
+/// claim `isAvailable == true`.
+
+@MainActor
+open class SLComposeViewController: UIViewController {
+    private let storedServiceType: String?
+    private var storedInitialText: String?
+    private var storedImages: [UIImage] = []
+    private var storedURLs: [URL] = []
+    private var storedCompletionHandler: SLComposeViewControllerCompletionHandler?
+    private var presentedToHost = false
+
+    open class func isAvailable(forServiceType serviceType: String!) -> Bool {
+        _ = serviceType
+        return false
+    }
+
+    public init!(forServiceType serviceType: String!) {
+        guard Self.isAvailable(forServiceType: serviceType) else {
+            return nil
+        }
+        self.storedServiceType = serviceType
+        #if canImport(UIKit)
+        super.init(nibName: nil, bundle: nil)
+        #else
+        super.init()
+        #endif
+    }
+
+    init(isolatedHostServiceType serviceType: String) {
+        self.storedServiceType = serviceType
+        #if canImport(UIKit)
+        super.init(nibName: nil, bundle: nil)
+        #else
+        super.init()
+        #endif
+    }
+
+    #if canImport(UIKit)
+    public required init?(coder: NSCoder) {
+        return nil
+    }
+    #endif
+
+    open var serviceType: String! { storedServiceType }
+
+    open var completionHandler: SLComposeViewControllerCompletionHandler! {
+        get { storedCompletionHandler }
+        set { storedCompletionHandler = newValue }
+    }
+
+    open func setInitialText(_ text: String!) -> Bool {
+        guard !presentedToHost, let text else { return false }
+        storedInitialText = text
+        return true
+    }
+
+    open func add(_ image: UIImage!) -> Bool {
+        guard !presentedToHost, let image else { return false }
+        storedImages.append(image)
+        return true
+    }
+
+    open func add(_ url: URL!) -> Bool {
+        guard !presentedToHost, let url else { return false }
+        storedURLs.append(url)
+        return true
+    }
+
+    open func removeAllImages() -> Bool {
+        guard !presentedToHost else { return false }
+        storedImages.removeAll()
+        return true
+    }
+
+    open func removeAllURLs() -> Bool {
+        guard !presentedToHost else { return false }
+        storedURLs.removeAll()
+        return true
+    }
+
+    func invokeCompletionHandlerForIsolatedHost(_ result: SLComposeViewControllerResult) {
+        guard let handler = storedCompletionHandler else { return }
+        storedCompletionHandler = nil
+        handler(result)
+    }
+}
+
+extension SLComposeViewController {
+    @_spi(OpenUIKitHost)
+    public var isolatedHostInitialText: String? { storedInitialText }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostImageCount: Int { storedImages.count }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostURLCount: Int { storedURLs.count }
+}

--- a/full/social/SLRequest.swift
+++ b/full/social/SLRequest.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+#if canImport(Accounts)
+import Accounts
+#endif
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Social-network HTTP request builder.
+///
+/// Linux does not sign OAuth and does not perform network I/O.
+/// `preparedURLRequest()` returns nil when `account` is non-nil.
+/// `perform(handler:)` hops once onto a private queue and delivers a
+/// fail-closed `NSError` with no `HTTPURLResponse`.
+
+open class SLRequest: NSObject {
+    private let storedServiceType: String?
+    private let storedRequestMethod: SLRequestMethod
+    private let storedURL: URL?
+    private let storedParameters: [AnyHashable: Any]
+    private var storedAccount: ACAccount?
+    private var multipartParts: [MultipartPart] = []
+
+    public init!(
+        forServiceType serviceType: String!,
+        requestMethod: SLRequestMethod,
+        url: URL!,
+        parameters: [AnyHashable: Any]!
+    ) {
+        self.storedServiceType = serviceType
+        self.storedRequestMethod = requestMethod
+        self.storedURL = url
+        if let parameters {
+            self.storedParameters = parameters
+        } else {
+            self.storedParameters = [:]
+        }
+        super.init()
+    }
+
+    /// Swift 3 renamed this to `url:`. Kept as a declaration for the pinned
+    /// synthesized identifier; Swift 6 cannot call an obsoleted-in-Swift-3 API.
+    @available(swift, obsoleted: 3, renamed: "init(forServiceType:requestMethod:url:parameters:)")
+    public init!(
+        forServiceType serviceType: String!,
+        requestMethod: SLRequestMethod,
+        URL url: URL!,
+        parameters: [AnyHashable: Any]!
+    ) {
+        self.storedServiceType = serviceType
+        self.storedRequestMethod = requestMethod
+        self.storedURL = url
+        if let parameters {
+            self.storedParameters = parameters
+        } else {
+            self.storedParameters = [:]
+        }
+        super.init()
+    }
+
+    open var account: ACAccount! {
+        get { storedAccount }
+        set { storedAccount = newValue }
+    }
+
+    open var requestMethod: SLRequestMethod { storedRequestMethod }
+
+    open var url: URL! { storedURL }
+
+    open var parameters: [AnyHashable: Any]! { storedParameters }
+
+    open func addMultipartData(
+        _ data: Data!,
+        withName name: String!,
+        type: String!,
+        filename: String!
+    ) {
+        guard let data, let name, let type else { return }
+        guard socialMultipartMetadataIsSafe(name),
+              socialMultipartMetadataIsSafe(type),
+              filename == nil || socialMultipartMetadataIsSafe(filename!)
+        else {
+            return
+        }
+        multipartParts.append(
+            MultipartPart(data: data, name: name, type: type, filename: filename)
+        )
+    }
+
+    open func preparedURLRequest() -> URLRequest! {
+        if storedAccount != nil {
+            return nil
+        }
+        guard let storedURL else {
+            return nil
+        }
+        for (key, _) in storedParameters {
+            let keyText = String(describing: key)
+            if !socialMultipartMetadataIsSafe(keyText) {
+                return nil
+            }
+        }
+        if !multipartParts.isEmpty {
+            return preparedMultipartRequest(baseURL: storedURL)
+        }
+        return preparedURLEncodedRequest(baseURL: storedURL)
+    }
+
+    open func perform(handler: SLRequestHandler!) {
+        guard let handler else { return }
+        let error = socialFailClosedError(.appleServiceUnavailable)
+        socialDeliverPerform {
+            handler(nil, nil, error)
+        }
+    }
+
+    private func preparedURLEncodedRequest(baseURL: URL) -> URLRequest! {
+        var items: [URLQueryItem] = []
+        for (key, value) in storedParameters {
+            guard let encoded = socialEncodeParameterValue(value) else {
+                return nil
+            }
+            items.append(URLQueryItem(name: String(describing: key), value: encoded))
+        }
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = socialHTTPMethod(storedRequestMethod)
+        switch storedRequestMethod {
+        case .GET, .DELETE:
+            guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+                return nil
+            }
+            if !items.isEmpty {
+                components.queryItems = (components.queryItems ?? []) + items
+            }
+            guard let url = components.url else { return nil }
+            request.url = url
+        case .POST, .PUT:
+            if !items.isEmpty {
+                let encoded = items.map { item in
+                    let name = socialPercentEncode(item.name)
+                    let value = socialPercentEncode(item.value ?? "")
+                    return "\(name)=\(value)"
+                }.joined(separator: "&")
+                request.httpBody = Data(encoded.utf8)
+                request.setValue(
+                    "application/x-www-form-urlencoded",
+                    forHTTPHeaderField: "Content-Type"
+                )
+            }
+        }
+        return request
+    }
+
+    private func preparedMultipartRequest(baseURL: URL) -> URLRequest! {
+        for (key, _) in storedParameters {
+            if !socialMultipartMetadataIsSafe(String(describing: key)) {
+                return nil
+            }
+        }
+        for part in multipartParts {
+            if !socialMultipartMetadataIsSafe(part.name)
+                || !socialMultipartMetadataIsSafe(part.type)
+                || (part.filename.map(socialMultipartMetadataIsSafe) == false)
+            {
+                return nil
+            }
+        }
+        let corpus = socialMultipartCorpus(parameters: storedParameters, parts: multipartParts)
+        let boundary = socialMakeCollisionCheckedBoundary(corpus: corpus)
+        var body = Data()
+        func append(_ text: String) {
+            body.append(Data(text.utf8))
+        }
+        for (key, value) in storedParameters {
+            let name = String(describing: key)
+            guard let encoded = socialEncodeParameterValue(value) else {
+                return nil
+            }
+            append("--\(boundary)\r\n")
+            append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            append("\(encoded)\r\n")
+        }
+        for part in multipartParts {
+            append("--\(boundary)\r\n")
+            var disposition = "Content-Disposition: form-data; name=\"\(part.name)\""
+            if let filename = part.filename {
+                disposition += "; filename=\"\(filename)\""
+            }
+            append("\(disposition)\r\n")
+            append("Content-Type: \(part.type)\r\n\r\n")
+            body.append(part.data)
+            append("\r\n")
+        }
+        append("--\(boundary)--\r\n")
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = socialHTTPMethod(storedRequestMethod)
+        request.httpBody = body
+        request.setValue(
+            "multipart/form-data; boundary=\(boundary)",
+            forHTTPHeaderField: "Content-Type"
+        )
+        return request
+    }
+}
+
+private func socialHTTPMethod(_ method: SLRequestMethod) -> String {
+    switch method {
+    case .GET: return "GET"
+    case .POST: return "POST"
+    case .DELETE: return "DELETE"
+    case .PUT: return "PUT"
+    }
+}
+
+private func socialEncodeParameterValue(_ value: Any) -> String? {
+    if let text = value as? String {
+        return text
+    }
+    if let number = value as? NSNumber {
+        return number.stringValue
+    }
+    return nil
+}
+
+private func socialPercentEncode(_ value: String) -> String {
+    var allowed = CharacterSet.urlQueryAllowed
+    allowed.remove(charactersIn: "&+=")
+    return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+}
+
+extension SLRequest {
+    @_spi(OpenUIKitHost)
+    public var isolatedHostMultipartPartCount: Int { multipartParts.count }
+
+    @_spi(OpenUIKitHost)
+    public var isolatedHostServiceType: String? { storedServiceType }
+}

--- a/full/social/Social.swift
+++ b/full/social/Social.swift
@@ -1,0 +1,238 @@
+@_exported import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: - Service type constants
+//
+// Payloads below are the commonly documented `com.apple.social.*` identifiers.
+// They are **not** Apple-oracle observations on this host. Coverage lists them
+// as `declared` until a central probe confirms the exact exported bytes.
+
+public let SLServiceTypeTwitter = "com.apple.social.twitter"
+public let SLServiceTypeFacebook = "com.apple.social.facebook"
+public let SLServiceTypeSinaWeibo = "com.apple.social.sinaweibo"
+public let SLServiceTypeTencentWeibo = "com.apple.social.tencentweibo"
+public let SLServiceTypeLinkedIn = "com.apple.social.linkedin"
+
+// MARK: - Public typealiases
+
+public typealias SLComposeSheetConfigurationItemTapHandler = () -> Void
+public typealias SLComposeViewControllerCompletionHandler = (SLComposeViewControllerResult) -> Void
+public typealias SLRequestHandler = (Data?, HTTPURLResponse?, (any Error)?) -> Void
+
+// MARK: - Enumerations
+//
+// Raw values follow NS_ENUM declaration order in the pinned overlay
+// (`GET, POST, DELETE, PUT` and `cancelled, done`). Exact Darwin numeric
+// ABI is still an oracle question.
+
+public enum SLRequestMethod: Int, Sendable, Hashable {
+    case GET = 0
+    case POST = 1
+    case DELETE = 2
+    case PUT = 3
+}
+
+public enum SLComposeViewControllerResult: Int, Sendable, Hashable {
+    case cancelled = 0
+    case done = 1
+}
+
+// MARK: - Linux fail-closed error
+//
+// Not an Apple Social error domain. Public `perform` delivers this as
+// Foundation `NSError`. The typed surface lives under `@_spi(OpenUIKitHost)`.
+
+public let SocialLinuxErrorDomain = "Social.linux.fail-closed"
+
+@_spi(OpenUIKitHost)
+public enum SocialServiceError: Error, Hashable, Sendable {
+    case appleServiceUnavailable
+    case accountRequiresOAuth
+    case invalidMultipartMetadata
+    case missingURL
+    case unsupportedParameterValue
+
+    public var nsError: NSError {
+        let code: Int
+        let description: String
+        switch self {
+        case .appleServiceUnavailable:
+            code = 1
+            description = "Linux Social has no Apple social-network host"
+        case .accountRequiresOAuth:
+            code = 2
+            description = "SLRequest.account is set but Linux has no OAuth signer"
+        case .invalidMultipartMetadata:
+            code = 3
+            description = "multipart field metadata contains CR, LF, or quote"
+        case .missingURL:
+            code = 4
+            description = "SLRequest.url is nil"
+        case .unsupportedParameterValue:
+            code = 5
+            description = "parameter values must be String or NSNumber"
+        }
+        return NSError(
+            domain: SocialLinuxErrorDomain,
+            code: code,
+            userInfo: [NSLocalizedDescriptionKey: description]
+        )
+    }
+}
+
+func socialFailClosedError(_ error: SocialServiceError) -> NSError {
+    error.nsError
+}
+
+let socialPerformQueue = DispatchQueue(
+    label: "Social.SLRequest.perform",
+    qos: .utility
+)
+
+private struct SocialUncheckedWork: @unchecked Sendable {
+    let body: () -> Void
+}
+
+func socialDeliverPerform(_ body: @escaping () -> Void) {
+    let work = SocialUncheckedWork(body: body)
+    socialPerformQueue.async {
+        work.body()
+    }
+}
+
+// MARK: - Multipart helpers (non-Apple; SPI)
+
+@_spi(OpenUIKitHost)
+public struct MultipartPart: Equatable {
+    public var data: Data
+    public var name: String
+    public var type: String
+    public var filename: String?
+
+    public init(data: Data, name: String, type: String, filename: String?) {
+        self.data = data
+        self.name = name
+        self.type = type
+        self.filename = filename
+    }
+}
+
+func socialMultipartMetadataIsSafe(_ value: String) -> Bool {
+    for scalar in value.unicodeScalars {
+        if scalar == "\r" || scalar == "\n" || scalar == "\"" {
+            return false
+        }
+    }
+    return true
+}
+
+func socialBoundaryCollides(_ boundary: String, corpus: [Data]) -> Bool {
+    guard let needle = boundary.data(using: .utf8), !needle.isEmpty else {
+        return true
+    }
+    for blob in corpus {
+        if blob.range(of: needle) != nil {
+            return true
+        }
+    }
+    return false
+}
+
+func socialMultipartCorpus(
+    parameters: [AnyHashable: Any],
+    parts: [MultipartPart]
+) -> [Data] {
+    var corpus: [Data] = []
+    for (key, value) in parameters {
+        corpus.append(Data(String(describing: key).utf8))
+        corpus.append(Data(String(describing: value).utf8))
+    }
+    for part in parts {
+        corpus.append(Data(part.name.utf8))
+        corpus.append(Data(part.type.utf8))
+        if let filename = part.filename {
+            corpus.append(Data(filename.utf8))
+        }
+        corpus.append(part.data)
+    }
+    return corpus
+}
+
+func socialMakeCollisionCheckedBoundary(corpus: [Data]) -> String {
+    while true {
+        let candidate = SocialHostControl.nextBoundaryCandidate()
+        if !socialBoundaryCollides(candidate, corpus: corpus) {
+            return candidate
+        }
+    }
+}
+
+// MARK: - Isolated-host control
+//
+// Not part of Apple's public Social module. Ordinary `import Social` clients
+// do not see these names.
+
+@_spi(OpenUIKitHost)
+public enum SocialHostControl {
+    private static let lock = NSLock()
+    private static var candidateSource: () -> String = SocialHostControl.defaultBoundaryCandidate
+
+    public static func defaultBoundaryCandidate() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+
+    public static func nextBoundaryCandidate() -> String {
+        lock.lock()
+        let source = candidateSource
+        lock.unlock()
+        return source()
+    }
+
+    public static func setBoundaryCandidateSource(_ source: @escaping () -> String) {
+        lock.lock()
+        candidateSource = source
+        lock.unlock()
+    }
+
+    public static func resetBoundaryCandidateSource() {
+        setBoundaryCandidateSource(defaultBoundaryCandidate)
+    }
+
+    public static func enqueuePerformProbe(_ body: @escaping () -> Void) {
+        socialDeliverPerform(body)
+    }
+
+    @MainActor
+    public static func makeComposeViewController(serviceType: String) -> SLComposeViewController {
+        SLComposeViewController(isolatedHostServiceType: serviceType)
+    }
+
+    @MainActor
+    public static func invokeCompletion(
+        _ controller: SLComposeViewController,
+        result: SLComposeViewControllerResult
+    ) {
+        controller.invokeCompletionHandlerForIsolatedHost(result)
+    }
+
+    public static func makeAccountFixture() -> ACAccount {
+        #if canImport(Accounts)
+        // Canonical Accounts.ACAccount has no zero-argument initializer.
+        // Isolated host compiles the fallback ACAccount in SocialHostTypes.
+        fatalError("Accounts.ACAccount fixture construction is an integration concern")
+        #else
+        ACAccount()
+        #endif
+    }
+
+    public static var isStandaloneUnitFixture: Bool {
+        #if canImport(UIKit) && canImport(Accounts)
+        return false
+        #else
+        return true
+        #endif
+    }
+}

--- a/full/social/SocialHostTypes.swift
+++ b/full/social/SocialHostTypes.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#elseif os(Linux) || SOCIAL_STANDALONE_TEST_FIXTURES
+// Isolated-host / standalone-unit-fixture types. These compile the sealed
+// `test_host.sh` gate, which does not pass `-I` for UIKit. They are **not**
+// Apple UIKit identities. A production build that can import UIKit never
+// emits `Social.UIView` / `Social.UIViewController` / `Social.UIImage` /
+// `Social.UITextView` / `Social.UITextViewDelegate`.
+//
+// Missing UIKit on a non-Linux host without `-D SOCIAL_STANDALONE_TEST_FIXTURES`
+// is a hard dependency blocker (see `#else` below).
+
+@MainActor
+open class UIView: NSObject {
+    public override init() {
+        super.init()
+    }
+}
+
+@MainActor
+open class UIViewController: NSObject {
+    public override init() {
+        super.init()
+    }
+}
+
+open class UIImage: NSObject {
+    public override init() {
+        super.init()
+    }
+}
+
+@MainActor
+public protocol UITextViewDelegate: AnyObject {
+    func textViewDidChange(_ textView: UITextView)
+}
+
+@MainActor
+extension UITextViewDelegate {
+    public func textViewDidChange(_ textView: UITextView) {}
+}
+
+@MainActor
+open class UITextView: UIView {
+    open var text: String! = ""
+    open weak var delegate: UITextViewDelegate?
+
+    public override init() {
+        super.init()
+        text = ""
+    }
+}
+#else
+#error("Social requires the canonical UIKit module. Isolated host tests: compile with -D SOCIAL_STANDALONE_TEST_FIXTURES")
+#endif
+
+#if canImport(Accounts)
+import Accounts
+#elseif os(Linux) || SOCIAL_STANDALONE_TEST_FIXTURES
+// Standalone-unit-fixture `ACAccount`. Not `Accounts.ACAccount`. Production
+// that can import Accounts never emits `Social.ACAccount`.
+
+open class ACAccount: NSObject {
+    public override init() {
+        super.init()
+    }
+}
+#else
+#error("Social.SLRequest.account requires the canonical Accounts.ACAccount type")
+#endif

--- a/full/social/coverage.tsv
+++ b/full/social/coverage.tsv
@@ -1,0 +1,68 @@
+precise	status	evidence	notes
+c:@E@SLComposeViewControllerResult	implemented	Social.swift;SocialRuntime.swift:assertEnums	Int NS_ENUM overlay; raw values follow declaration order pending oracle.
+c:@E@SLComposeViewControllerResult@SLComposeViewControllerResultCancelled	implemented	Social.swift;SocialRuntime.swift:assertEnums	case cancelled; rawValue 0 by NS_ENUM order.
+c:@E@SLComposeViewControllerResult@SLComposeViewControllerResultDone	implemented	Social.swift;SocialRuntime.swift:assertEnums	case done; rawValue 1 by NS_ENUM order.
+c:@E@SLRequestMethod	implemented	Social.swift;SocialRuntime.swift:assertEnums	Int NS_ENUM overlay; raw values follow declaration order pending oracle.
+c:@E@SLRequestMethod@SLRequestMethodDELETE	implemented	Social.swift;SocialRuntime.swift:assertEnums	case DELETE; rawValue 2 by NS_ENUM order.
+c:@E@SLRequestMethod@SLRequestMethodGET	implemented	Social.swift;SocialRuntime.swift:assertEnums	case GET; rawValue 0 by NS_ENUM order.
+c:@E@SLRequestMethod@SLRequestMethodPOST	implemented	Social.swift;SocialRuntime.swift:assertEnums	case POST; rawValue 1 by NS_ENUM order.
+c:@E@SLRequestMethod@SLRequestMethodPUT	implemented	Social.swift;SocialRuntime.swift:assertEnums	case PUT; rawValue 3 by NS_ENUM order.
+c:@SLServiceTypeFacebook	declared	Social.swift	Provisional com.apple.social.facebook; Darwin bytes unobserved.
+c:@SLServiceTypeLinkedIn	declared	Social.swift	Provisional com.apple.social.linkedin; Darwin bytes unobserved.
+c:@SLServiceTypeSinaWeibo	declared	Social.swift	Provisional com.apple.social.sinaweibo; Darwin bytes unobserved.
+c:@SLServiceTypeTencentWeibo	declared	Social.swift	Provisional com.apple.social.tencentweibo; Darwin bytes unobserved.
+c:@SLServiceTypeTwitter	declared	Social.swift	Provisional com.apple.social.twitter; Darwin bytes unobserved.
+c:@T@SLComposeSheetConfigurationItemTapHandler	implemented	Social.swift;SocialRuntime.swift:assertConfigurationItem	typealias () -> Void; invoked from tapHandler.
+c:@T@SLComposeViewControllerCompletionHandler	implemented	Social.swift;SocialRuntime.swift:assertComposeViewController	typealias (SLComposeViewControllerResult) -> Void; cleared after invoke.
+c:@T@SLRequestHandler	implemented	Social.swift;SocialRuntime.swift:assertPerformFailClosed	typealias (Data?, HTTPURLResponse?, Error?) -> Void; fail-closed perform.
+c:objc(cs)SLComposeServiceViewController	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	UIViewController + UITextViewDelegate; standalone fixture types on this host.
+c:objc(cs)SLComposeServiceViewController(im)cancel	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Calls didSelectCancel once; recursion guard.
+c:objc(cs)SLComposeServiceViewController(im)configurationItems	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Default empty array.
+c:objc(cs)SLComposeServiceViewController(im)didSelectCancel	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Partial local count; no NSExtensionContext completion.
+c:objc(cs)SLComposeServiceViewController(im)didSelectPost	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Partial local count; no Apple post pipeline.
+c:objc(cs)SLComposeServiceViewController(im)isContentValid	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Default true.
+c:objc(cs)SLComposeServiceViewController(im)loadPreviewView	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Returns a local UIView; not Apple preview UI.
+c:objc(cs)SLComposeServiceViewController(im)popConfigurationViewController	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Clears the single pushed controller.
+c:objc(cs)SLComposeServiceViewController(im)presentationAnimationDidFinish	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Sets isolated-host flag.
+c:objc(cs)SLComposeServiceViewController(im)pushConfigurationViewController:	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	At most one pushed controller.
+c:objc(cs)SLComposeServiceViewController(im)reloadConfigurationItems	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Reinvokes configurationItems; increments reload count.
+c:objc(cs)SLComposeServiceViewController(im)validateContent	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Stores isContentValid result.
+c:objc(cs)SLComposeServiceViewController(py)autoCompletionViewController	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Stored UIViewController property.
+c:objc(cs)SLComposeServiceViewController(py)charactersRemaining	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Stored NSNumber property.
+c:objc(cs)SLComposeServiceViewController(py)contentText	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Reads textView.text.
+c:objc(cs)SLComposeServiceViewController(py)placeholder	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Stored string; not Apple placeholder rendering.
+c:objc(cs)SLComposeServiceViewController(py)textView	implemented	SLComposeServiceViewController.swift;SocialRuntime.swift:assertComposeService	Wired UITextView with delegate = self.
+c:objc(cs)SLComposeSheetConfigurationItem	implemented	SLComposeSheetConfigurationItem.swift;SocialRuntime.swift:assertConfigurationItem	NSObject row model.
+c:objc(cs)SLComposeSheetConfigurationItem(im)init	implemented	SLComposeSheetConfigurationItem.swift;SocialRuntime.swift:assertConfigurationItem	Stronger nonfailable override of NSObject.init; pinned Darwin is init!().
+c:objc(cs)SLComposeSheetConfigurationItem(py)tapHandler	implemented	SLComposeSheetConfigurationItem.swift;SocialRuntime.swift:assertConfigurationItem	Stored IUO handler.
+c:objc(cs)SLComposeSheetConfigurationItem(py)title	implemented	SLComposeSheetConfigurationItem.swift;SocialRuntime.swift:assertConfigurationItem	Stored IUO string.
+c:objc(cs)SLComposeSheetConfigurationItem(py)value	implemented	SLComposeSheetConfigurationItem.swift;SocialRuntime.swift:assertConfigurationItem	Stored IUO string.
+c:objc(cs)SLComposeSheetConfigurationItem(py)valuePending	implemented	SLComposeSheetConfigurationItem.swift;SocialRuntime.swift:assertConfigurationItem	Stored Bool.
+c:objc(cs)SLComposeViewController	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	UIViewController; public init returns nil because unavailable.
+c:objc(cs)SLComposeViewController(cm)composeViewControllerForServiceType:	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Returns nil when isAvailable is false.
+c:objc(cs)SLComposeViewController(cm)isAvailableForServiceType:	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Always false; no Apple compose UI.
+c:objc(cs)SLComposeViewController(im)addImage:	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Local draft list via isolated-host instance; not presented UI.
+c:objc(cs)SLComposeViewController(im)addURL:	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Local draft list via isolated-host instance.
+c:objc(cs)SLComposeViewController(im)removeAllImages	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Clears local image list.
+c:objc(cs)SLComposeViewController(im)removeAllURLs	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Clears local URL list.
+c:objc(cs)SLComposeViewController(im)setInitialText:	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Stores draft text on isolated-host instance.
+c:objc(cs)SLComposeViewController(py)completionHandler	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Cleared after a single isolated-host invoke.
+c:objc(cs)SLComposeViewController(py)serviceType	implemented	SLComposeViewController.swift;SocialRuntime.swift:assertComposeViewController	Stored on isolated-host instance.
+c:objc(cs)SLRequest	implemented	SLRequest.swift;SocialRuntime.swift:assertRequestSurface	NSObject request builder; no networking.
+c:objc(cs)SLRequest(cm)requestForServiceType:requestMethod:URL:parameters:	implemented	SLRequest.swift;SocialRuntime.swift:assertRequestSurface	init!(forServiceType:requestMethod:url:parameters:).
+c:objc(cs)SLRequest(cm)requestForServiceType:requestMethod:URL:parameters:::SYNTHESIZED::c:objc(cs)SLRequest	declared	SLRequest.swift	Swift-3-obsoleted URL: label; compiles, not callable from Swift 6.
+c:objc(cs)SLRequest(im)addMultipartData:withName:type:filename:	implemented	SLRequest.swift;SocialRuntime.swift:assertMultipart	Rejects CR/LF/quote metadata; stores safe parts.
+c:objc(cs)SLRequest(im)performRequestWithHandler:	implemented	SLRequest.swift;SocialRuntime.swift:assertPerformFailClosed	Async fail-closed; no HTTP.
+c:objc(cs)SLRequest(im)preparedURLRequest	implemented	SLRequest.swift;SocialRuntime.swift:assertRequestSurface;assertAccountFailClosed;assertMultipart	Nil when account set or URL/metadata invalid.
+c:objc(cs)SLRequest(py)URL	implemented	SLRequest.swift;SocialRuntime.swift:assertRequestSurface	Stored URL.
+c:objc(cs)SLRequest(py)account	implemented	SLRequest.swift;SocialRuntime.swift:assertAccountFailClosed	Setter exercised with standalone ACAccount fixture; UIKit/Accounts identity unproven.
+c:objc(cs)SLRequest(py)parameters	implemented	SLRequest.swift;SocialRuntime.swift:assertRequestSurface	Stored dictionary.
+c:objc(cs)SLRequest(py)requestMethod	implemented	SLRequest.swift;SocialRuntime.swift:assertRequestSurface	Stored SLRequestMethod.
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@SLComposeViewControllerResult	implemented	Social.swift;SocialRuntime.swift:assertEnums	Synthesized Equatable !=.
+s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@SLRequestMethod	implemented	Social.swift;SocialRuntime.swift:assertEnums	Synthesized Equatable !=.
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@SLComposeViewControllerResult	implemented	Social.swift;SocialRuntime.swift:assertEnums	Hashable hashValue.
+s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@SLRequestMethod	implemented	Social.swift;SocialRuntime.swift:assertEnums	Hashable hashValue.
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@SLComposeViewControllerResult	implemented	Social.swift;SocialRuntime.swift:assertEnums	Hashable hash(into:).
+s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@SLRequestMethod	implemented	Social.swift;SocialRuntime.swift:assertEnums	Hashable hash(into:).
+s:So15SLRequestMethodV8rawValueABSgSi_tcfc	implemented	Social.swift;SocialRuntime.swift:assertEnums	init?(rawValue:).
+s:So29SLComposeViewControllerResultV8rawValueABSgSi_tcfc	implemented	Social.swift;SocialRuntime.swift:assertEnums	init?(rawValue:).

--- a/full/social/oracle-questions.tsv
+++ b/full/social/oracle-questions.tsv
@@ -1,0 +1,11 @@
+precise	question	risk	reason
+c:@SLServiceTypeTwitter	What exact UTF-8 payload does Darwin export for SLServiceTypeTwitter?	account-service	Commonly documented as com.apple.social.twitter; not measured on this host.
+c:@SLServiceTypeFacebook	What exact UTF-8 payload does Darwin export for SLServiceTypeFacebook?	account-service	Commonly documented as com.apple.social.facebook; not measured on this host.
+c:@SLServiceTypeSinaWeibo	What exact UTF-8 payload does Darwin export for SLServiceTypeSinaWeibo?	account-service	Commonly documented as com.apple.social.sinaweibo; not measured on this host.
+c:@SLServiceTypeTencentWeibo	What exact UTF-8 payload does Darwin export for SLServiceTypeTencentWeibo?	account-service	Commonly documented as com.apple.social.tencentweibo; not measured on this host.
+c:@SLServiceTypeLinkedIn	What exact UTF-8 payload does Darwin export for SLServiceTypeLinkedIn?	account-service	Commonly documented as com.apple.social.linkedin; not measured on this host.
+c:@E@SLRequestMethod@SLRequestMethodGET	What are the Darwin NS_ENUM raw values for SLRequestMethod GET/POST/DELETE/PUT?	fail-closed	Overlay uses declaration order 0...3; numeric ABI unobserved.
+c:@E@SLComposeViewControllerResult@SLComposeViewControllerResultCancelled	What are the Darwin NS_ENUM raw values for SLComposeViewControllerResult cancelled/done?	fail-closed	Overlay uses declaration order 0, 1; numeric ABI unobserved.
+c:objc(cs)SLComposeServiceViewController(im)didSelectPost	When NSExtensionContext is nil, does Darwin didSelectPost complete the extension, dismiss, or no-op?	ui	Linux has no extension host; local counters are partial only.
+c:objc(cs)SLRequest(im)preparedURLRequest	Does Darwin preparedURLRequest return an unsigned request, nil, or throw when account is set but OAuth tokens are missing?	account-service	Linux returns nil; Apple signing behavior unobserved.
+module	Does a production Linux guest build import UIKit.UIViewController / UIKit.UITextViewDelegate / Accounts.ACAccount without emitting Social-owned fallbacks?	ui	Isolated host gate has no UIKit or Accounts modules; integration identity is unavailable.

--- a/full/social/social_guest_sources.txt
+++ b/full/social/social_guest_sources.txt
@@ -1,0 +1,6 @@
+full/social/SLComposeServiceViewController.swift
+full/social/SLComposeSheetConfigurationItem.swift
+full/social/SLComposeViewController.swift
+full/social/SLRequest.swift
+full/social/Social.swift
+full/social/SocialHostTypes.swift

--- a/full/social/tests/agent/SocialDependencyIdentity.swift
+++ b/full/social/tests/agent/SocialDependencyIdentity.swift
@@ -1,0 +1,56 @@
+#if canImport(Accounts)
+import Accounts
+#endif
+import Foundation
+@_spi(OpenUIKitHost) import Social
+#if canImport(UIKit)
+import UIKit
+#endif
+
+#if false
+import Accounts
+import UIKit
+#endif
+
+/// Future clean EC2 dependency-identity client. Isolated host-gate success
+/// against Social standalone fixtures is not UIKit/Accounts integration.
+///
+/// Expected EC2 steps (no local Docker):
+/// 1. Build staged platform Foundation, UIKit (OpenUIKit implementation),
+///    and Accounts modules/dylibs.
+/// 2. Build Social with those modules on `-I` / `-L` and no fallback path.
+/// 3. Link this file as a client that imports Social, UIKit, and Accounts.
+/// 4. Assign `SLComposeServiceViewController` to `UIKit.UIViewController` and
+///    `UIKit.UITextViewDelegate`, `textView` to `UIKit.UITextView`, images to
+///    `UIKit.UIImage`, and `SLRequest.account` to `Accounts.ACAccount`.
+/// 5. Inspect the Social interface/symbol graph for the absence of
+///    `Social.UIView*`, `Social.UITextViewDelegate`, and `Social.ACAccount`.
+/// 6. Confirm `SOCIAL_DEPENDENCY_IDENTITY_OK` only after those assignments.
+
+func socialDependencyIdentityProbe() {
+    #if canImport(UIKit) && canImport(Accounts)
+    let controller = SLComposeServiceViewController()
+    let _: UIKit.UIViewController = controller
+    let _: UIKit.UITextViewDelegate = controller
+    let _: UIKit.UITextView = controller.textView
+    let _: UIKit.UIView = controller.loadPreviewView()
+    let compose = SocialHostControl.makeComposeViewController(serviceType: "identity")
+    precondition(compose.add(UIKit.UIImage()))
+    let request = SLRequest(
+        forServiceType: SLServiceTypeTwitter,
+        requestMethod: .GET,
+        url: URL(string: "https://example.invalid/"),
+        parameters: [:]
+    )!
+    let _: Accounts.ACAccount? = request.account
+    #else
+    FileHandle.standardError.write(
+        Data("UNAVAILABLE dependency=UIKit+Accounts reason=not-staged-on-isolated-host\n".utf8)
+    )
+    #endif
+}
+
+#if SOCIAL_IDENTITY_MAIN
+socialDependencyIdentityProbe()
+print("SOCIAL_DEPENDENCY_IDENTITY_OK")
+#endif

--- a/full/social/tests/agent/SocialRuntime.swift
+++ b/full/social/tests/agent/SocialRuntime.swift
@@ -1,0 +1,407 @@
+@_spi(OpenUIKitHost) import Social
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+private let eventTimeout = DispatchTimeInterval.seconds(5)
+
+private final class LockedState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var returned = false
+    private var sawReturned = false
+    private var count = 0
+
+    func markReturned() {
+        lock.lock()
+        returned = true
+        lock.unlock()
+    }
+
+    func noteCallback() {
+        lock.lock()
+        sawReturned = returned
+        count += 1
+        lock.unlock()
+    }
+
+    func snapshot() -> (sawReturned: Bool, count: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (sawReturned, count)
+    }
+}
+
+private func waitEvent(_ semaphore: DispatchSemaphore, _ message: String) {
+    precondition(semaphore.wait(timeout: .now() + eventTimeout) == .success, message)
+}
+
+private final class PerformQueueBlocker: @unchecked Sendable {
+    private let occupied = DispatchSemaphore(value: 0)
+    private let hold = DispatchSemaphore(value: 0)
+
+    func occupy() {
+        SocialHostControl.enqueuePerformProbe {
+            self.occupied.signal()
+            self.hold.wait()
+        }
+        waitEvent(occupied, "perform queue blocker did not start")
+    }
+
+    func release() {
+        hold.signal()
+    }
+}
+
+private func onMain(_ body: @MainActor () -> Void) {
+    if Thread.isMainThread {
+        MainActor.assumeIsolated(body)
+    } else {
+        DispatchQueue.main.sync {
+            MainActor.assumeIsolated(body)
+        }
+    }
+}
+
+private func requireUITextViewDelegate(_ value: any UITextViewDelegate) {
+    _ = value
+}
+
+private func requireFailClosedPerformError(_ error: (any Error)?) {
+    guard let error else {
+        fatalError("expected fail-closed NSError")
+    }
+    let nsError = error as NSError
+    precondition(nsError.domain == SocialLinuxErrorDomain)
+    precondition(nsError.code == 1)
+}
+
+private func assertEnums() {
+    precondition(SLRequestMethod.GET.rawValue == 0)
+    precondition(SLRequestMethod.POST.rawValue == 1)
+    precondition(SLRequestMethod.DELETE.rawValue == 2)
+    precondition(SLRequestMethod.PUT.rawValue == 3)
+    precondition(SLRequestMethod(rawValue: 0) == .GET)
+    precondition(SLRequestMethod(rawValue: 99) == nil)
+    precondition(SLRequestMethod.GET != .POST)
+    precondition(!(SLRequestMethod.GET != .GET))
+    var hasher = Hasher()
+    SLRequestMethod.GET.hash(into: &hasher)
+    _ = SLRequestMethod.POST.hashValue
+    _ = hasher.finalize()
+
+    precondition(SLComposeViewControllerResult.cancelled.rawValue == 0)
+    precondition(SLComposeViewControllerResult.done.rawValue == 1)
+    precondition(SLComposeViewControllerResult(rawValue: 1) == .done)
+    precondition(SLComposeViewControllerResult(rawValue: -1) == nil)
+    precondition(SLComposeViewControllerResult.cancelled != .done)
+    var resultHasher = Hasher()
+    SLComposeViewControllerResult.done.hash(into: &resultHasher)
+    _ = SLComposeViewControllerResult.cancelled.hashValue
+    _ = resultHasher.finalize()
+}
+
+private func assertDeclaredServiceConstants() {
+    precondition(!SLServiceTypeTwitter.isEmpty)
+    precondition(!SLServiceTypeFacebook.isEmpty)
+    precondition(!SLServiceTypeSinaWeibo.isEmpty)
+    precondition(!SLServiceTypeTencentWeibo.isEmpty)
+    precondition(!SLServiceTypeLinkedIn.isEmpty)
+}
+
+private func assertConfigurationItem() {
+    let item = SLComposeSheetConfigurationItem()
+    precondition(item.title == nil)
+    item.title = "Account"
+    item.value = "user"
+    item.valuePending = true
+    var tapped = false
+    let handler: SLComposeSheetConfigurationItemTapHandler = {
+        tapped = true
+    }
+    item.tapHandler = handler
+    item.tapHandler()
+    precondition(tapped)
+    precondition(item.title == "Account")
+    precondition(item.value == "user")
+    precondition(item.valuePending)
+}
+
+@MainActor
+private final class RecursingCancelController: SLComposeServiceViewController {
+    override func didSelectCancel() {
+        super.didSelectCancel()
+        cancel()
+    }
+}
+
+@MainActor
+private func assertComposeService() {
+    let controller = SLComposeServiceViewController()
+    requireUITextViewDelegate(controller)
+    let _: UIViewController = controller
+    let _: UITextView = controller.textView
+
+    precondition((controller.contentText ?? "") == "")
+    controller.isolatedHostReplaceText("hello")
+    precondition(controller.contentText == "hello")
+
+    controller.placeholder = "Write something"
+    precondition(controller.placeholder == "Write something")
+    controller.charactersRemaining = NSNumber(value: 140)
+    precondition(controller.charactersRemaining.intValue == 140)
+
+    precondition(controller.isContentValid())
+    controller.validateContent()
+    precondition(controller.isolatedHostLastValidatedContent == true)
+
+    let items = controller.configurationItems() ?? []
+    precondition(items.isEmpty)
+    controller.reloadConfigurationItems()
+    precondition(controller.isolatedHostConfigurationReloadCount == 1)
+
+    let first = UIViewController()
+    let second = UIViewController()
+    controller.pushConfigurationViewController(first)
+    controller.pushConfigurationViewController(second)
+    precondition(controller.isolatedHostPushedConfigurationController === first)
+    controller.popConfigurationViewController()
+    precondition(controller.isolatedHostPushedConfigurationController == nil)
+    controller.pushConfigurationViewController(second)
+    precondition(controller.isolatedHostPushedConfigurationController === second)
+
+    let preview = controller.loadPreviewView()
+    precondition(preview != nil)
+    let _: UIView = preview!
+
+    controller.autoCompletionViewController = first
+    precondition(controller.autoCompletionViewController === first)
+
+    controller.presentationAnimationDidFinish()
+    precondition(controller.isolatedHostDidFinishPresentationAnimation)
+
+    controller.didSelectPost()
+    precondition(controller.isolatedHostDidSelectPostCount == 1)
+
+    let cancelController = RecursingCancelController()
+    cancelController.cancel()
+    precondition(cancelController.isolatedHostDidSelectCancelCount == 1)
+}
+
+@MainActor
+private func assertComposeViewController() {
+    precondition(SLComposeViewController.isAvailable(forServiceType: SLServiceTypeTwitter) == false)
+    precondition(SLComposeViewController.isAvailable(forServiceType: nil) == false)
+    precondition(SLComposeViewController(forServiceType: SLServiceTypeTwitter) == nil)
+    precondition(SLComposeViewController(forServiceType: "unknown") == nil)
+
+    let controller = SocialHostControl.makeComposeViewController(serviceType: "isolated")
+    precondition(controller.serviceType == "isolated")
+    precondition(controller.setInitialText("draft"))
+    precondition(controller.isolatedHostInitialText == "draft")
+    precondition(controller.setInitialText(nil) == false)
+
+    let image = UIImage()
+    precondition(controller.add(image))
+    precondition(controller.isolatedHostImageCount == 1)
+    precondition(controller.add(UIImage?.none) == false)
+    precondition(controller.removeAllImages())
+    precondition(controller.isolatedHostImageCount == 0)
+
+    let url = URL(string: "https://example.invalid/a")!
+    precondition(controller.add(url))
+    precondition(controller.isolatedHostURLCount == 1)
+    precondition(controller.add(URL?.none) == false)
+    precondition(controller.removeAllURLs())
+    precondition(controller.isolatedHostURLCount == 0)
+
+    var calls = 0
+    var last: SLComposeViewControllerResult?
+    let completion: SLComposeViewControllerCompletionHandler = { result in
+        calls += 1
+        last = result
+    }
+    controller.completionHandler = completion
+    SocialHostControl.invokeCompletion(controller, result: .done)
+    precondition(calls == 1)
+    precondition(last == .done)
+    precondition(controller.completionHandler == nil)
+    SocialHostControl.invokeCompletion(controller, result: .cancelled)
+    precondition(calls == 1)
+}
+
+private func exampleURL() -> URL {
+    URL(string: "https://example.invalid/social")!
+}
+
+private func assertRequestSurface() {
+    let parameters: [AnyHashable: Any] = ["status": "hello"]
+    let request = SLRequest(
+        forServiceType: SLServiceTypeTwitter,
+        requestMethod: .POST,
+        url: exampleURL(),
+        parameters: parameters
+    )
+    precondition(request != nil)
+    precondition(request!.requestMethod == .POST)
+    precondition(request!.url == exampleURL())
+    precondition((request!.parameters["status"] as? String) == "hello")
+    precondition(request!.isolatedHostServiceType == SLServiceTypeTwitter)
+    precondition(request!.account == nil)
+
+    let prepared = request!.preparedURLRequest()
+    precondition(prepared != nil)
+    precondition(prepared!.httpMethod == "POST")
+    precondition(prepared!.httpBody != nil)
+
+    let get = SLRequest(
+        forServiceType: "x",
+        requestMethod: .GET,
+        url: exampleURL(),
+        parameters: ["q": "term"]
+    )!
+    let getPrepared = get.preparedURLRequest()!
+    precondition(getPrepared.httpMethod == "GET")
+    precondition(getPrepared.url?.query?.contains("q=term") == true)
+
+    let missing = SLRequest(
+        forServiceType: "x",
+        requestMethod: .GET,
+        url: nil,
+        parameters: [:]
+    )!
+    precondition(missing.preparedURLRequest() == nil)
+}
+
+private func assertAccountFailClosed() {
+    let request = SLRequest(
+        forServiceType: "x",
+        requestMethod: .POST,
+        url: exampleURL(),
+        parameters: [:]
+    )!
+    request.account = SocialHostControl.makeAccountFixture()
+    precondition(request.account != nil)
+    precondition(request.preparedURLRequest() == nil)
+}
+
+private func assertMultipart() {
+    let request = SLRequest(
+        forServiceType: "x",
+        requestMethod: .POST,
+        url: exampleURL(),
+        parameters: ["caption": "hi"]
+    )!
+    request.addMultipartData(nil, withName: "file", type: "text/plain", filename: "a.txt")
+    precondition(request.isolatedHostMultipartPartCount == 0)
+    request.addMultipartData(Data("no".utf8), withName: "bad\nname", type: "text/plain", filename: "a.txt")
+    precondition(request.isolatedHostMultipartPartCount == 0)
+    request.addMultipartData(Data("no".utf8), withName: "file", type: "text/\rplain", filename: "a.txt")
+    precondition(request.isolatedHostMultipartPartCount == 0)
+    request.addMultipartData(Data("no".utf8), withName: "file", type: "text/plain", filename: "a\"b.txt")
+    precondition(request.isolatedHostMultipartPartCount == 0)
+
+    request.addMultipartData(Data("payload".utf8), withName: "file", type: "text/plain", filename: "note.txt")
+    precondition(request.isolatedHostMultipartPartCount == 1)
+    let prepared = request.preparedURLRequest()
+    precondition(prepared != nil)
+    let body = String(data: prepared!.httpBody ?? Data(), encoding: .utf8) ?? ""
+    precondition(body.contains("name=\"caption\""))
+    precondition(body.contains("name=\"file\""))
+    precondition(body.contains("filename=\"note.txt\""))
+    precondition(body.contains("payload"))
+    precondition(prepared!.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data") == true)
+
+    let injected = SLRequest(
+        forServiceType: "x",
+        requestMethod: .POST,
+        url: exampleURL(),
+        parameters: ["na\nme": "v"]
+    )!
+    injected.addMultipartData(Data("x".utf8), withName: "file", type: "text/plain", filename: nil)
+    precondition(injected.preparedURLRequest() == nil)
+}
+
+private func assertBoundaryCollisionRetry() {
+    var n = 0
+    SocialHostControl.setBoundaryCandidateSource {
+        n += 1
+        if n < 3 {
+            return "COLLIDE"
+        }
+        return "UNIQUEBOUND"
+    }
+    let request = SLRequest(
+        forServiceType: "x",
+        requestMethod: .POST,
+        url: exampleURL(),
+        parameters: ["token": "COLLIDE"]
+    )!
+    request.addMultipartData(Data("z".utf8), withName: "file", type: "text/plain", filename: nil)
+    let prepared = request.preparedURLRequest()
+    precondition(prepared != nil)
+    let body = String(data: prepared!.httpBody ?? Data(), encoding: .utf8) ?? ""
+    precondition(body.contains("UNIQUEBOUND"))
+    precondition(!body.contains("--COLLIDE"))
+    precondition(n >= 3)
+    SocialHostControl.resetBoundaryCandidateSource()
+}
+
+private func assertPerformFailClosed() {
+    let request = SLRequest(
+        forServiceType: "x",
+        requestMethod: .GET,
+        url: exampleURL(),
+        parameters: [:]
+    )!
+    let state = LockedState()
+    let finished = DispatchSemaphore(value: 0)
+    let blocker = PerformQueueBlocker()
+    blocker.occupy()
+    request.perform { data, response, error in
+        precondition(data == nil)
+        precondition(response == nil)
+        requireFailClosedPerformError(error)
+        state.noteCallback()
+        finished.signal()
+    }
+    state.markReturned()
+    let duringBlock = state.snapshot()
+    precondition(duringBlock.count == 0)
+    blocker.release()
+    waitEvent(finished, "perform handler did not run")
+    let after = state.snapshot()
+    precondition(after.count == 1)
+    precondition(after.sawReturned)
+}
+
+@MainActor
+private func assertStandaloneFixtureMarker() {
+    #if canImport(UIKit)
+    let view = UIView()
+    let name = String(reflecting: type(of: view))
+    precondition(name.hasPrefix("UIKit."), "expected UIKit.UIView, got \(name)")
+    #else
+    let view = UIView()
+    let name = String(reflecting: type(of: view))
+    precondition(name.hasPrefix("Social."), "expected Social.UIView fixture, got \(name)")
+    print("SOCIAL_STANDALONE_UNIT_FIXTURE_ONLY")
+    #endif
+    precondition(SocialHostControl.isStandaloneUnitFixture == true || SocialHostControl.isStandaloneUnitFixture == false)
+}
+
+assertEnums()
+assertDeclaredServiceConstants()
+assertConfigurationItem()
+onMain {
+    assertComposeService()
+    assertComposeViewController()
+    assertStandaloneFixtureMarker()
+}
+assertRequestSurface()
+assertAccountFailClosed()
+assertMultipart()
+assertBoundaryCollisionRetry()
+assertPerformFailClosed()
+print("SOCIAL_AGENT_RUNTIME_OK")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Source branch: `cursor/port-social-to-linux-fd3a` on `github.com/Vercantez/openuikit-linux-platform` (legacy PR #9, claimed 1553 Swift lines).

This run’s GitHub token could not fetch that private repository (`git fetch` / `gh api` → 404). The original fan-out agent transcript was also inaccessible. The lane was therefore reconstructed by content from the monorepo seed and the in-repo repair briefs (`full/framework-fanout/repairs-wave1-pr4-9.json` and `repairs-wave1-pr4-9-r2.json`). It is not a byte-copy of the inaccessible branch.

**Reference dossier:** kept the monorepo’s current `full/social/reference/` (generator `scripts/framework-fanout/generate_seed.py`, SHA256 `2b8230ced5a3ed78f070607346f6a684d9e0fb74a8932b92bc0f5e38f46f0a8e`, iPhoneOS 26.1 / Xcode 17B55). The platform branch’s `reference/` could not be compared (`unavailable`).

## Gate outputs (last lines)

Deliverable (`python3 -B full/framework-fanout/validate_seed.py --framework full/social --phase deliverable`):

```
FRAMEWORK_FANOUT_DELIVERABLE_OK module=Social lane=leaf-full symbols=67
```

Host (`bash full/social/tests/acceptance/test_host.sh`):

```
FRAMEWORK_FANOUT_HOST_OK module=Social dylib=libSocial.dylib
```

(`test_host.sh` also printed `FRAMEWORK_FANOUT_REFERENCE_OK`, `SOCIAL_STANDALONE_UNIT_FIXTURE_ONLY`, and `SOCIAL_AGENT_RUNTIME_OK`.)

`python3 scripts/env/test_contract.py` stayed green: 10 tests OK. `env/contract.json` and `scripts/vendor_pins.sh` were not modified.

## Coverage (67 public IDs)

- implemented: 61
- declared: 6
- deferred: 0
- unavailable: 0
- not-applicable: 0
- nondeferred (implemented + declared): 67 (floor 54)

Declared rows: five `SLServiceType*` payloads (provisional `com.apple.social.*` strings pending oracle) and the Swift-3-obsoleted `SLRequest` `URL:` initializer.

## What changed to make the gates pass

Main had only the seed (empty guest manifest, no `Social.swift`); the deliverable gate reported a missing required file. Added:

- `Social.swift`, `SocialHostTypes.swift`, `SLComposeSheetConfigurationItem.swift`, `SLComposeServiceViewController.swift`, `SLComposeViewController.swift`, `SLRequest.swift`
- `social_guest_sources.txt`, `coverage.tsv`, `oracle-questions.tsv`, `README.md`
- `tests/agent/SocialRuntime.swift` and `tests/agent/SocialDependencyIdentity.swift`

Behavior is fail-closed: `isAvailable(forServiceType:)` is always false; public `init(forServiceType:)` returns nil; `preparedURLRequest()` is nil when `account` is set (no OAuth); `perform(handler:)` does not network. `cancel()` calls `didSelectCancel()` without recursion. Multipart metadata rejects CR/LF/quote; boundaries are collision-checked against parameter and part bytes.

Isolated host compiles without UIKit/Accounts, so fallback types exist only on that standalone-unit-fixture path (`canImport` uses the canonical modules when present).

Did not touch `machorun/`, `uikit/`, `env/contract.json`, or `scripts/vendor_pins.sh`.

## Deferred / unavailable

- Platform branch byte-copy: unavailable (private repo not in this token’s installation).
- UIKit/Accounts identity: unavailable on this isolated host (no staged modules). `SocialDependencyIdentity.swift` is for a future EC2 integration probe.
- Apple compose UI, OAuth signing, and `NSExtensionContext` host completion: fail-closed / partial (local counters only).
- Exact Darwin `SLServiceType*` bytes and NS_ENUM numeric ABI: oracle questions.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c282a57d-86e6-4aa0-828c-660bc4c3deba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c282a57d-86e6-4aa0-828c-660bc4c3deba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

