### PR TITLE
premerge: grade difftest/build/fixture/scoreboard scripts as needs-linux on macOS

### DIFF
--- a/scripts/ops/premerge.sh
+++ b/scripts/ops/premerge.sh
@@ -140,7 +140,10 @@ while IFS= read -r script; do
     [ -n "$script" ] || continue
     [ -f "$WT/$script" ] || continue
     case "$script" in
-        *tests/acceptance/test_host.sh)
+        *tests/acceptance/test_host.sh|*/difftest.sh|*/build.sh|*build_fixtures_linux*|*scoreboard*)
+            # (difftest/build/fixture/scoreboard scripts are Linux-only too:
+            # measured 2026-09-03, PR #103 difftest printed PASS (exit 1) on
+            # macOS with no build dirs at all.)
             # A framework lane's acceptance gate needs the Linux toolchain
             # (swift 6.2.4 linux, ld64.lld-18). On macOS it cannot run and
             # must not read as FAIL (measured 2026-09-03: PR #75 CoreMotion


### PR DESCRIPTION
False green measured on PR #103: difftest ran on the Mac with no build dirs, printed PASS (exit 1) per fixture, verdict counted ok:pr:scripts/difftest.sh. Same needs-linux handling as the lane acceptance gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188aCUiPNF2xwAWXcozrKDS