### PR TITLE
Link libswiftDarwin at macosx15.0 so $ld$previous cannot rename the Builtin_float re-export

### DIFF
--- a/swiftcore-macho/scripts/clangxx_darwin_link.py
+++ b/swiftcore-macho/scripts/clangxx_darwin_link.py
@@ -26,6 +26,7 @@ dropped -platform_version/-arch).
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -466,6 +467,60 @@ def darwin_reexport_link_flags(argv: list[str]) -> list[str]:
     return flags
 
 
+# lld honours Apple's `$ld$previous$<name>$$<compat>$<start>$<end>$$` symbols:
+# our built libswift_Builtin_float carries
+# `$ld$previous$/usr/lib/swift/libswiftDarwin.dylib$$1$10.14.4$15.0$$`, so a
+# libswiftDarwin link at the CMake deployment target (macosx13.0) records the
+# Builtin_float re-export under the PREVIOUS name -- a self LC_REEXPORT of
+# libswiftDarwin and no Builtin_float (measured on the x86_64 box 2026-09-03:
+# target 13.0 -> [libswiftDarwin, DF1, DF2, DF3]; 15.0 -> Apple's four).
+# Link libswiftDarwin at the platform floor every guest links against.
+DARWIN_REEXPORT_MIN_DEPLOYMENT = "15.0"
+
+
+def raise_darwin_deployment_target(argv: list[str]) -> list[str]:
+    """When linking libswiftDarwin with the four shells, lift `-target
+    <arch>-apple-macosx<ver>` to macosx15.0 so `$ld$previous` ranges ending at
+    15.0 cannot rename the Builtin_float re-export. Other links untouched."""
+    if not find_darwin_reexport_shells(argv):
+        return argv
+    out: list[str] = []
+    i = 0
+    changed = None
+    pat = re.compile(r"^((?:--target=)?[^-]+-apple-macosx)(\d+(?:\.\d+)*)$")
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-target", "--target") and i + 1 < len(argv):
+            m = pat.match(argv[i + 1])
+            if m and _version_lt(m.group(2), DARWIN_REEXPORT_MIN_DEPLOYMENT):
+                changed = (argv[i + 1], m.group(1) + DARWIN_REEXPORT_MIN_DEPLOYMENT)
+                out.extend([a, changed[1]])
+                i += 2
+                continue
+        m = pat.match(a)
+        if m and a.startswith("--target=") and _version_lt(m.group(2), DARWIN_REEXPORT_MIN_DEPLOYMENT):
+            changed = (a, m.group(1) + DARWIN_REEXPORT_MIN_DEPLOYMENT)
+            out.append(changed[1])
+            i += 1
+            continue
+        out.append(a)
+        i += 1
+    if changed:
+        sys.stderr.write(
+            f"clangxx_darwin_link: libswiftDarwin deployment {changed[0]} -> {changed[1]} "
+            "(so $ld$previous cannot rename the Builtin_float re-export)\n"
+        )
+    return out
+
+
+def _version_lt(a: str, b: str) -> bool:
+    pa = [int(x) for x in a.split(".")]
+    pb = [int(x) for x in b.split(".")]
+    n = max(len(pa), len(pb))
+    pa += [0] * (n - len(pa)); pb += [0] * (n - len(pb))
+    return pa < pb
+
+
 def darwin_compiler_rt_osx_path() -> str:
     """Darwin-target compiler-rt builtins archive (generic C + os_version_check)."""
     env = os.environ.get("SWIFTCORE_COMPILER_RT_OSX")
@@ -558,6 +613,7 @@ def darwin_driver_argv(argv: list[str]) -> list[str]:
         kept.append(t)
     kept.extend(darwin_compiler_rt_link_flags(kept))
     kept.extend(darwin_reexport_link_flags(kept))
+    kept = raise_darwin_deployment_target(kept)
     # clang ignores argv after -###; keep diagnostics last.
     diag = [a for a in kept if a in ("-###", "-v", "--verbose")]
     if diag:

--- a/swiftcore-macho/scripts/overlay_targets.inc
+++ b/swiftcore-macho/scripts/overlay_targets.inc
@@ -616,7 +616,7 @@ overlay_ensure_darwin_reexports() {
     fi
     echo "overlay_ensure_darwin_reexports: relink $darwin with -reexport_library of four shells"
     set +e
-    python3 - "$py" "$cmds_file" <<'PY'
+    python3 - "$py" "$cmds_file" "$build_dir" <<'PY'
 import os, pathlib, shlex, subprocess, sys
 
 def compiler_args(line):
@@ -635,7 +635,7 @@ def compiler_args(line):
             break
     return argv[i + 1 :]
 
-py, cmds_path = sys.argv[1], sys.argv[2]
+py, cmds_path, build_dir = sys.argv[1], sys.argv[2], sys.argv[3]
 text = pathlib.Path(cmds_path).read_text(errors="replace")
 line = None
 for raw in text.splitlines():
@@ -648,7 +648,9 @@ if line is None:
     sys.stderr.write("CANNOT_DARWIN_REEXPORT reason=no clang++ Darwin link line\n")
     sys.exit(2)
 args = compiler_args(line)
-proc = subprocess.run([sys.executable, py, *args])
+# ninja command lines are relative to the build dir (measured 2026-09-03: "no such
+# file or directory: stdlib/public/Platform/OSX/x86_64/Darwin.o" from elsewhere).
+proc = subprocess.run([sys.executable, py, *args], cwd=build_dir)
 sys.exit(proc.returncode)
 PY
     local st=$?

--- a/swiftcore-macho/scripts/stage_artifacts.sh
+++ b/swiftcore-macho/scripts/stage_artifacts.sh
@@ -52,6 +52,24 @@ while IFS= read -r -d '' f; do
       if [ -f "$dest" ]; then
         check_cpu "$dest"
       fi
+      if [ "$bn" = libswiftDarwin.dylib ]; then
+        # Apple's libswiftDarwin carries exactly four LC_REEXPORT_DYLIB
+        # (Builtin_float, _DarwinFoundation1/2/3). A Darwin linked at the
+        # CMake deployment target records Builtin_float under its
+        # $ld$previous name (a self re-export) -- that image was staged and
+        # reused for a whole day (2026-09-03). Refuse to publish it.
+        want=$(printf '%s\n' /usr/lib/swift/libswift_Builtin_float.dylib \
+          /usr/lib/swift/libswift_DarwinFoundation1.dylib \
+          /usr/lib/swift/libswift_DarwinFoundation2.dylib \
+          /usr/lib/swift/libswift_DarwinFoundation3.dylib)
+        have=$("${OTOOL:-llvm-otool-18}" -l "$f" 2>/dev/null \
+          | awk '/LC_REEXPORT_DYLIB/{r=1} r&&/^ *name /{print $2; r=0}' | sort -u)
+        if [ "$have" != "$want" ]; then
+          echo "stage_artifacts: REFUSING — $f LC_REEXPORT_DYLIB set is not Apple's four (CANNOT_DARWIN_REEXPORT)" >&2
+          printf '  have: %s\n' "${have:-<none>}" >&2
+          exit 2
+        fi
+      fi
       ;;
     *.a) ;;
     *) continue ;;


### PR DESCRIPTION
x86 onboarding wall root cause. Box experiment: same ninja link at 13.0 → LC_REEXPORT [libswiftDarwin(self), DF1, DF2, DF3]; at 15.0 → Apple's four. Shim lifts the Darwin link's deployment target; the corrective relink now runs in the build dir; stage_artifacts refuses a Darwin without the four. swiftcore-macho only, no pins; test_overlay_targets/test_staged_slice pass on the Mac, shim test's two FAILs are no-sysroot-on-Mac (needs-linux). Verified next by a full x86 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188aCUiPNF2xwAWXcozrKDS