### PR TITLE
verify_hello stages a copy of libswiftCore into the machorun root, not a symlink

### DIFF
--- a/scripts/ops/x86_cycle.sh
+++ b/scripts/ops/x86_cycle.sh
@@ -246,9 +246,13 @@ core_src=$TREE/swiftcore-macho/artifacts/swift-macosx/x86_64/libswiftCore.dylib
 core_dst=$TREE/machorun/darwin/usr/lib/swift/libswiftCore.dylib
 if [ -f "$core_src" ]; then
     mkdir -p "$(dirname "$core_dst")"
-    if [ -f "$core_dst" ] && [ "$(sha256sum "$core_src" | cut -c1-64)" = "$(sha256sum "$core_dst" | cut -c1-64)" ]; then
+    # A symlink here (verify_hello.sh left one into /root/work/build at the
+    # 44152400 cycle) reads as the same bytes but stage_swift_core_runtime.py
+    # refuses "not a regular non-symlink file"; only a regular file is reuse.
+    if [ -f "$core_dst" ] && [ ! -L "$core_dst" ] && [ "$(sha256sum "$core_src" | cut -c1-64)" = "$(sha256sum "$core_dst" | cut -c1-64)" ]; then
         emit_stage libswiftcore-darwin reused "$core_dst"
     else
+        rm -f "$core_dst"
         cp -f "$core_src" "$core_dst"
         emit_stage libswiftcore-darwin rebuilt "$core_dst"
     fi

--- a/swiftcore-macho/scripts/verify_hello.sh
+++ b/swiftcore-macho/scripts/verify_hello.sh
@@ -101,8 +101,11 @@ if [ -e "$dst_dir/libswiftCore.dylib" ]; then
     mv "$dst_dir/libswiftCore.dylib" "$dst_dir/libswiftCore.dylib.park-$$"
   fi
 fi
-ln -sfn "$LIBDIR/libswiftCore.dylib" "$dst_dir/libswiftCore.dylib"
-echo "probe: staged $dst_dir/libswiftCore.dylib -> $LIBDIR/libswiftCore.dylib"
+# A regular copy, not a symlink: this is the shared machorun root, and the
+# guest gates (stage_swift_core_runtime.py) refuse a symlinked canonical core
+# (measured 2026-09-03: rung b and c CANNOT after the overlays stage).
+cp -f "$LIBDIR/libswiftCore.dylib" "$dst_dir/libswiftCore.dylib"
+echo "probe: staged $dst_dir/libswiftCore.dylib (copy of $LIBDIR/libswiftCore.dylib)"
 
 echo "=== hello under machorun ==="
 set +e


### PR DESCRIPTION
Measured at the 44152400 full x86 cycle: rung b/c refused a symlinked canonical core left by verify_hello.sh; stage 7b reused it by content. Copy + regular-file-only reuse. Verified next by a full x86 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188aCUiPNF2xwAWXcozrKDS