### PR TITLE
premerge: test_phase2.sh and test_stage_fe_sysroot* are needs-linux on macOS

### DIFF
--- a/scripts/ops/premerge.sh
+++ b/scripts/ops/premerge.sh
@@ -140,7 +140,7 @@ while IFS= read -r script; do
     [ -n "$script" ] || continue
     [ -f "$WT/$script" ] || continue
     case "$script" in
-        *tests/acceptance/test_host.sh|*/difftest.sh|*/build.sh|*build_fixtures_linux*|*scoreboard*)
+        *tests/acceptance/test_host.sh|*/difftest.sh|*/build.sh|*build_fixtures_linux*|*scoreboard*|*/test_phase2.sh|*/test_stage_fe_sysroot*)
             # (difftest/build/fixture/scoreboard scripts are Linux-only too:
             # measured 2026-09-03, PR #103 difftest printed PASS (exit 1) on
             # macOS with no build dirs at all.)


### PR DESCRIPTION
Both refuse on macOS and were graded FAIL for PR #149 on every premerge run today; same handling as the lane acceptance gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188aCUiPNF2xwAWXcozrKDS