### PR TITLE
framework-fanout: seed non-framework SDK modules (Clang modules, Swift-only modules)

### DIFF
--- a/full/framework-fanout/test_validate_seed.py
+++ b/full/framework-fanout/test_validate_seed.py
@@ -1019,6 +1019,84 @@ class ValidatorTests(unittest.TestCase):
             errors,
         )
 
+    def test_optional_module_location_is_accepted(self) -> None:
+        temporary, fixture = self.make_fixture()
+        self.addCleanup(temporary.cleanup)
+        metadata_path = fixture.reference / "framework.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["moduleLocation"] = {
+            "kind": "framework",
+            "sdkRelativePath": metadata["provenance"]["frameworkSDKRelativePath"],
+            "reason": "public iPhoneOS framework bundle is present",
+        }
+        fixture.write_json(metadata_path, metadata)
+        fixture.reseal()
+        self.assertEqual([], self.validate(fixture, "seed"))
+
+    def test_unexpected_framework_metadata_key_is_rejected(self) -> None:
+        temporary, fixture = self.make_fixture()
+        self.addCleanup(temporary.cleanup)
+        metadata_path = fixture.reference / "framework.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["unexpected"] = True
+        fixture.write_json(metadata_path, metadata)
+        fixture.reseal()
+        errors = self.validate(fixture, "seed")
+        self.assertTrue(
+            any("reference/framework.json keys differ" in error for error in errors),
+            errors,
+        )
+
+    def test_roadmap_operator_override_is_accepted_without_module_record(self) -> None:
+        temporary, fixture = self.make_fixture()
+        self.addCleanup(temporary.cleanup)
+        roadmap_path = (
+            fixture.root / "full" / "framework-roadmap" / "framework-roadmap.json"
+        )
+        roadmap = json.loads(roadmap_path.read_text(encoding="utf-8"))
+        roadmap["modules"] = [{"module": "OtherKit"}]
+        roadmap["requested_roadmap_families"] = []
+        roadmap["iphoneos_runtime_port_candidate_rankings"] = {
+            "by_app_coverage": ["OtherKit"],
+            "by_focus_launch_build_relevance": ["OtherKit"],
+        }
+        fixture.write_json(roadmap_path, roadmap)
+        metadata_path = fixture.reference / "framework.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["roadmap"] = "none (operator override)"
+        metadata["provenance"]["roadmapSHA256"] = digest(roadmap_path)
+        fixture.write_json(metadata_path, metadata)
+        corpus_path = fixture.reference / "corpus-summary.json"
+        corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+        corpus["source"]["sha256"] = digest(roadmap_path)
+        corpus["moduleRecord"] = {"roadmap": "none (operator override)"}
+        corpus["requestedFamilies"] = []
+        corpus["rankings"] = {
+            "byAppCoverage": None,
+            "byFocusLaunchBuildRelevance": None,
+        }
+        fixture.write_json(corpus_path, corpus)
+        fixture.reseal()
+        self.assertEqual([], self.validate(fixture, "seed"))
+
+    def test_roadmap_operator_override_is_rejected_when_record_exists(self) -> None:
+        temporary, fixture = self.make_fixture()
+        self.addCleanup(temporary.cleanup)
+        metadata_path = fixture.reference / "framework.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["roadmap"] = "none (operator override)"
+        fixture.write_json(metadata_path, metadata)
+        corpus_path = fixture.reference / "corpus-summary.json"
+        corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+        corpus["moduleRecord"] = {"roadmap": "none (operator override)"}
+        fixture.write_json(corpus_path, corpus)
+        fixture.reseal()
+        errors = self.validate(fixture, "seed")
+        self.assertTrue(
+            any("operator override is invalid" in error for error in errors),
+            errors,
+        )
+
     def test_symbol_conflict_ledger_is_recomputed(self) -> None:
         temporary, fixture = self.make_fixture()
         self.addCleanup(temporary.cleanup)

--- a/full/framework-fanout/validate_seed.py
+++ b/full/framework-fanout/validate_seed.py
@@ -22,6 +22,17 @@ from typing import Any, Iterable, Sequence
 
 SCHEMA = 1
 FRAMEWORK_SCHEMAS = {1, 2}
+OPTIONAL_FRAMEWORK_METADATA_KEYS = {"moduleLocation", "roadmap"}
+MODULE_LOCATION_KEYS = {"kind", "sdkRelativePath", "reason"}
+MODULE_LOCATION_KINDS = {
+    "framework",
+    "framework-clang-module",
+    "swift-module",
+    "clang-module",
+    "clang-submodule",
+}
+ROADMAP_OPERATOR_OVERRIDE = "none (operator override)"
+ROADMAP_OPERATOR_OVERRIDE_RECORD = {"roadmap": ROADMAP_OPERATOR_OVERRIDE}
 EXTERNAL_EVIDENCE_LOCK = "full/framework-fanout/external-evidence-sources.json"
 EXTERNAL_POLICY_KEYS = {
     "behaviorAuthority",
@@ -1039,11 +1050,13 @@ class Validator:
                 "externalEvidence",
                 "symbolConflicts",
             }
-        if set(metadata) != expected_keys:
+        actual_keys = set(metadata)
+        missing = expected_keys - actual_keys
+        extra = actual_keys - expected_keys - OPTIONAL_FRAMEWORK_METADATA_KEYS
+        if missing or extra:
             self.error(
                 f"reference/framework.json keys differ from schema v{framework_schema}: "
-                f"missing={sorted(expected_keys - set(metadata))}, "
-                f"extra={sorted(set(metadata) - expected_keys)}"
+                f"missing={sorted(missing)}, extra={sorted(extra)}"
             )
         if type(framework_schema) is not int or framework_schema not in FRAMEWORK_SCHEMAS:
             self.error(
@@ -1319,6 +1332,41 @@ class Validator:
                 self.error(
                     f"provenance digest mismatch for {relative}: "
                     f"expected {expected_digest}, got {actual}"
+                )
+
+        if "moduleLocation" in metadata:
+            location = metadata.get("moduleLocation")
+            if not isinstance(location, dict) or set(location) != MODULE_LOCATION_KEYS:
+                self.error(
+                    "moduleLocation keys differ from schema: "
+                    f"expected {sorted(MODULE_LOCATION_KEYS)}"
+                )
+            else:
+                kind = location.get("kind")
+                relative = location.get("sdkRelativePath")
+                reason = location.get("reason")
+                if kind not in MODULE_LOCATION_KINDS:
+                    self.error(f"moduleLocation.kind is invalid: {kind!r}")
+                if (
+                    not isinstance(relative, str)
+                    or not self._is_safe_relative_text(relative)
+                ):
+                    self.error("moduleLocation.sdkRelativePath must be a safe SDK path")
+                elif (
+                    isinstance(provenance, dict)
+                    and provenance.get("frameworkSDKRelativePath") != relative
+                ):
+                    self.error(
+                        "moduleLocation.sdkRelativePath does not match "
+                        "provenance.frameworkSDKRelativePath"
+                    )
+                if not isinstance(reason, str) or not reason.strip():
+                    self.error("moduleLocation.reason must be a nonempty string")
+        if "roadmap" in metadata:
+            if metadata.get("roadmap") != ROADMAP_OPERATOR_OVERRIDE:
+                self.error(
+                    "framework roadmap override must be "
+                    f"{ROADMAP_OPERATOR_OVERRIDE!r}"
                 )
 
     def _validate_symbol_graphs(self, metadata: dict[str, Any]) -> set[str]:
@@ -2934,7 +2982,20 @@ class Validator:
             for record in modules
             if isinstance(record, dict) and record.get("module") == module
         ]
-        if len(matching_modules) != 1:
+        operator_override = metadata.get("roadmap") == ROADMAP_OPERATOR_OVERRIDE
+        if operator_override:
+            if matching_modules:
+                self.error(
+                    "roadmap operator override is invalid when the roadmap "
+                    f"contains a record for module {module!r}"
+                )
+            elif corpus.get("moduleRecord") != ROADMAP_OPERATOR_OVERRIDE_RECORD:
+                self.error(
+                    "corpus moduleRecord must record "
+                    f"{ROADMAP_OPERATOR_OVERRIDE!r} when the seed uses the "
+                    "roadmap operator override"
+                )
+        elif len(matching_modules) != 1:
             self.error(f"roadmap must contain exactly one record for module {module!r}")
         elif corpus.get("moduleRecord") != matching_modules[0]:
             self.error("corpus moduleRecord is not the exact pinned roadmap record")

--- a/scripts/framework-fanout/generate_seed_v2.py
+++ b/scripts/framework-fanout/generate_seed_v2.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import ctypes
+from dataclasses import dataclass
 import errno
 import hashlib
 import json
@@ -125,6 +126,60 @@ API_LIST_FIELDS = frozenset(("accessors", "children", "conformances", "declAttri
 FORBIDDEN_API_KEY_NORMALIZATIONS = frozenset(("location", "toolarguments"))
 MODULE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 SLUG_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+MODULE_LOCATION_KINDS = (
+    "framework",
+    "framework-clang-module",
+    "swift-module",
+    "clang-module",
+    "clang-submodule",
+)
+ROADMAP_OPERATOR_OVERRIDE = "none (operator override)"
+IGNORED_REEXPORT_MODULES = frozenset(
+    {
+        "Block",
+        "CFNetwork",
+        "CoreFoundation",
+        "Darwin",
+        "Dispatch",
+        "Foundation",
+        "ObjectiveC",
+        "Swift",
+        "SwiftOnoneSupport",
+        "SwiftShims",
+        "XPC",
+        "_Concurrency",
+        "_StringProcessing",
+        "os",
+        "os_object",
+        "os_workgroup",
+        "ptrauth",
+        "ptrcheck",
+    }
+)
+_MODULEMAP_DECL_RE = re.compile(
+    r"(?:(?P<extern>extern)\s+)?(?:explicit\s+)?(?:framework\s+)?"
+    r"(?<![A-Za-z0-9_])module\s+"
+    r"(?P<name>\*|[_A-Za-z][_A-Za-z0-9]*)"
+)
+_MODULEMAP_HEADER_RE = re.compile(
+    r"""(?:exclude\s+)?(?:umbrella\s+)?header\s+("(?:\\.|[^"\\])*"|<(?:\\.|[^>\\])*>)"""
+)
+_MODULEMAP_UMBRELLA_DIR_RE = re.compile(
+    r"""umbrella\s+("(?:\\.|[^"\\])*")"""
+)
+_MODULEMAP_EXPORT_RE = re.compile(
+    r"export\s+(\*|[_A-Za-z][_A-Za-z0-9]*(?:\.[_A-Za-z][_A-Za-z0-9]*)*)"
+)
+_MODULEMAP_ALIAS_RE = re.compile(
+    r"=\s*([_A-Za-z][_A-Za-z0-9]*)"
+)
+_SWIFT_EXPORTED_IMPORT_RE = re.compile(
+    r"@_exported\s+import\s+(?:(?:class|enum|func|let|protocol|struct|typealias|var)\s+)?"
+    r"([A-Za-z_][A-Za-z0-9_]*)"
+)
+_OBJC_IMPORT_RE = re.compile(
+    r"""(?:@import\s+([A-Za-z_][A-Za-z0-9_]*)|#\s*(?:import|include)\s*<([A-Za-z_][A-Za-z0-9_]*)/)"""
+)
 CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 EXTERNAL_EVIDENCE_LOCK = "full/framework-fanout/external-evidence-sources.json"
@@ -476,10 +531,18 @@ def looks_like_tbd(path: Path) -> bool:
     return b"!tapi-tbd" in prefix or b"tbd-version:" in prefix
 
 
-def classify_sdk_input(path: Path, framework_root: Path) -> str | None:
-    relative = path.relative_to(framework_root)
-    parts = relative.parts
-    if "Headers" in parts and "PrivateHeaders" not in parts:
+def classify_sdk_input(
+    path: Path, walk_root: Path, *, allow_loose_headers: bool = False
+) -> str | None:
+    try:
+        parts = path.relative_to(walk_root).parts
+    except ValueError:
+        parts = path.parts
+    if "PrivateHeaders" in parts:
+        return None
+    if "Headers" in parts:
+        return "header"
+    if allow_loose_headers and path.suffix == ".h":
         return "header"
     if path.name.endswith("modulemap"):
         return "modulemap"
@@ -490,28 +553,13 @@ def classify_sdk_input(path: Path, framework_root: Path) -> str | None:
     return None
 
 
-def collect_sdk_inputs(
-    framework_root: Path, sdk_root: Path, module: str
+def _sdk_input_records(
+    selected: dict[str, tuple[str, Path]], sdk_root: Path, module: str
 ) -> tuple[list[dict[str, Any]], list[Path]]:
-    selected: dict[str, tuple[str, Path]] = {}
-    tbd_paths: dict[str, Path] = {}
-    logical_binary = framework_root / module
-    for path in logical_sdk_walk(framework_root, sdk_root):
-        category = classify_sdk_input(path, framework_root)
-        if path == logical_binary and looks_like_tbd(path):
-            category = "tbd"
-        if category is None:
-            continue
-        sdk_relative = path.relative_to(sdk_root).as_posix()
-        if sdk_relative in selected:
-            raise SeedError(f"duplicate logical SDK input: {sdk_relative}")
-        selected[sdk_relative] = (category, path)
-        if category == "tbd":
-            tbd_paths[sdk_relative] = path
     if not selected:
         raise SeedError(f"no public SDK inputs found for {module}")
-
     records: list[dict[str, Any]] = []
+    tbd_paths: dict[str, Path] = {}
     for sdk_relative, (category, path) in sorted(selected.items()):
         real = path.resolve(strict=True)
         mode = real.stat().st_mode
@@ -528,7 +576,33 @@ def collect_sdk_inputs(
                 "sha256": digest,
             }
         )
+        if category == "tbd":
+            tbd_paths[sdk_relative] = path
     return records, [tbd_paths[key] for key in sorted(tbd_paths)]
+
+
+def collect_sdk_inputs(
+    framework_root: Path,
+    sdk_root: Path,
+    module: str,
+    *,
+    allow_loose_headers: bool = False,
+) -> tuple[list[dict[str, Any]], list[Path]]:
+    selected: dict[str, tuple[str, Path]] = {}
+    logical_binary = framework_root / module
+    for path in logical_sdk_walk(framework_root, sdk_root):
+        category = classify_sdk_input(
+            path, framework_root, allow_loose_headers=allow_loose_headers
+        )
+        if path == logical_binary and looks_like_tbd(path):
+            category = "tbd"
+        if category is None:
+            continue
+        sdk_relative = path.relative_to(sdk_root).as_posix()
+        if sdk_relative in selected:
+            raise SeedError(f"duplicate logical SDK input: {sdk_relative}")
+        selected[sdk_relative] = (category, path)
+    return _sdk_input_records(selected, sdk_root, module)
 
 
 def write_sdk_input_ledger(path: Path, records: Sequence[dict[str, Any]]) -> None:
@@ -547,6 +621,689 @@ def write_sdk_input_ledger(path: Path, records: Sequence[dict[str, Any]]) -> Non
     write_text(path, "\n".join(lines) + "\n")
 
 
+@dataclass(frozen=True)
+class ModuleLocation:
+    """Resolved public SDK module location and extractor path."""
+
+    kind: str
+    sdk_relative_path: str
+    reason: str
+    input_root: Path
+    module_map: Path | None
+
+    def record(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "sdkRelativePath": self.sdk_relative_path,
+            "reason": self.reason,
+        }
+
+
+def _require_inside_sdk(path: Path, sdk_root: Path) -> Path:
+    try:
+        real = path.resolve(strict=True)
+        sdk_real = sdk_root.resolve(strict=True)
+    except OSError as error:
+        raise SeedError(f"cannot resolve SDK path {path}: {error}") from error
+    if not within(real, sdk_real):
+        raise SeedError(f"SDK path escapes SDK root: {path}")
+    return path
+
+
+def _existing_sdk_path(sdk_root: Path, *parts: str) -> Path | None:
+    path = sdk_root.joinpath(*parts)
+    if not path.exists():
+        return None
+    return _require_inside_sdk(path, sdk_root)
+
+
+def _sdk_relative(path: Path, sdk_root: Path) -> str:
+    return path.relative_to(sdk_root).as_posix()
+
+
+def _framework_has_swift_artifacts(
+    framework_root: Path, sdk_root: Path, module: str
+) -> bool:
+    modules_dir = framework_root / "Modules"
+    swiftmodule = modules_dir / f"{module}.swiftmodule"
+    if swiftmodule.exists():
+        _require_inside_sdk(swiftmodule, sdk_root)
+        return True
+    if not modules_dir.is_dir():
+        return False
+    _require_inside_sdk(modules_dir, sdk_root)
+    for path in logical_sdk_walk(modules_dir, sdk_root):
+        if path.name.endswith(".swiftinterface") or path.name.endswith(".swiftmodule"):
+            return True
+    return False
+
+
+def _framework_module_map(framework_root: Path, sdk_root: Path) -> Path | None:
+    for candidate in (
+        framework_root / "Modules" / "module.modulemap",
+        framework_root / "Modules" / "module.map",
+    ):
+        if candidate.is_file():
+            return _require_inside_sdk(candidate, sdk_root)
+    return None
+
+
+def _strip_modulemap_comments(text: str) -> str:
+    output: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        if text.startswith("//", index):
+            newline = text.find("\n", index)
+            if newline < 0:
+                break
+            output.append("\n")
+            index = newline + 1
+            continue
+        if text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            if end < 0:
+                raise SeedError("unterminated module map comment")
+            output.append(" ")
+            index = end + 2
+            continue
+        char = text[index]
+        if char == '"':
+            index += 1
+            output.append('"')
+            while index < length:
+                current = text[index]
+                output.append(current)
+                index += 1
+                if current == "\\" and index < length:
+                    output.append(text[index])
+                    index += 1
+                    continue
+                if current == '"':
+                    break
+            else:
+                raise SeedError("unterminated module map string")
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _quoted_modulemap_path(token: str) -> str:
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        return token[1:-1].replace("\\\\", "\\").replace('\\"', '"')
+    if len(token) >= 2 and token[0] == "<" and token[-1] == ">":
+        return token[1:-1]
+    raise SeedError(f"invalid module map path token: {token!r}")
+
+
+def _matching_brace_end(text: str, open_index: int) -> int:
+    if open_index >= len(text) or text[open_index] != "{":
+        raise SeedError("module map body is not a brace group")
+    depth = 0
+    index = open_index
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == '"':
+            index += 1
+            while index < length:
+                current = text[index]
+                index += 1
+                if current == "\\":
+                    index += 1
+                    continue
+                if current == '"':
+                    break
+            else:
+                raise SeedError("unterminated module map string")
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    raise SeedError("unterminated module map body")
+
+
+def _iter_modulemap_decls(text: str) -> Iterator[tuple[str, str | None, str | None]]:
+    """Yield (module_name, body_or_none, extern_or_alias_target)."""
+
+    stripped = _strip_modulemap_comments(text)
+    search_from = 0
+    while True:
+        match = _MODULEMAP_DECL_RE.search(stripped, search_from)
+        if match is None:
+            return
+        name = match.group("name")
+        cursor = match.end()
+        while cursor < len(stripped) and stripped[cursor] in " \t\r\n":
+            cursor += 1
+        while cursor < len(stripped) and stripped[cursor] == "[":
+            close = stripped.find("]", cursor)
+            if close < 0:
+                raise SeedError("unterminated module map attribute")
+            cursor = close + 1
+            while cursor < len(stripped) and stripped[cursor] in " \t\r\n":
+                cursor += 1
+        if match.group("extern"):
+            if cursor >= len(stripped) or stripped[cursor] != '"':
+                raise SeedError(f"extern module {name} is missing a module map path")
+            end = cursor + 1
+            while end < len(stripped) and stripped[end] != '"':
+                if stripped[end] == "\\":
+                    end += 2
+                    continue
+                end += 1
+            if end >= len(stripped):
+                raise SeedError("unterminated extern module map path")
+            yield name, None, _quoted_modulemap_path(stripped[cursor : end + 1])
+            search_from = end + 1
+            continue
+        if cursor < len(stripped) and stripped[cursor] == "=":
+            alias = _MODULEMAP_ALIAS_RE.match(stripped, cursor)
+            if alias is None:
+                raise SeedError(f"module {name} has an invalid alias")
+            yield name, None, alias.group(1)
+            search_from = alias.end()
+            continue
+        if cursor >= len(stripped) or stripped[cursor] != "{":
+            search_from = match.end()
+            continue
+        close = _matching_brace_end(stripped, cursor)
+        yield name, stripped[cursor + 1 : close], None
+        search_from = close + 1
+
+
+def _find_named_module_in_map(
+    text: str, module: str
+) -> tuple[str | None, str | None]:
+    """Return (body, alias_or_extern_target) for the first named module."""
+
+    for name, body, target in _iter_modulemap_decls(text):
+        if name == module:
+            return body, target
+        if body:
+            nested_body, nested_target = _find_named_module_in_map(body, module)
+            if nested_body is not None or nested_target is not None:
+                return nested_body, nested_target
+    return None, None
+
+
+def module_map_declares(text: str, module: str) -> bool:
+    body, target = _find_named_module_in_map(text, module)
+    return body is not None or target is not None
+
+
+def _read_sdk_text(path: Path, *, label: str) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise SeedError(f"cannot read {label}: {error}") from error
+
+
+def _resolve_clang_module_map(
+    map_path: Path, sdk_root: Path, module: str, *, seen: frozenset[Path]
+) -> tuple[Path, str | None, str | None]:
+    real = map_path.resolve(strict=True)
+    if real in seen:
+        raise SeedError(f"cyclic Clang module map redirect for {module}")
+    text = _read_sdk_text(map_path, label=f"module map {map_path.name}")
+    body, target = _find_named_module_in_map(text, module)
+    if body is None and target is None:
+        raise SeedError(f"module map does not declare {module}: {map_path}")
+    if body is not None:
+        return map_path, body, None
+    assert target is not None
+    if MODULE_RE.fullmatch(target):
+        return map_path, None, target
+    redirected = (map_path.parent / target).resolve(strict=False)
+    if not redirected.is_file():
+        raise SeedError(f"extern module map for {module} is missing: {target}")
+    _require_inside_sdk(redirected, sdk_root)
+    return _resolve_clang_module_map(
+        redirected, sdk_root, module, seen=seen | {real}
+    )
+
+
+def _collect_loose_headers(directory: Path, sdk_root: Path) -> list[Path]:
+    headers: list[Path] = []
+    for path in logical_sdk_walk(directory, sdk_root):
+        if path.suffix == ".h" and "PrivateHeaders" not in path.parts:
+            headers.append(path)
+    return headers
+
+
+def _clang_module_headers(
+    map_path: Path, body: str, sdk_root: Path
+) -> list[Path]:
+    headers: list[Path] = []
+    search_from = 0
+    while True:
+        next_module = _MODULEMAP_DECL_RE.search(body, search_from)
+        next_header = _MODULEMAP_HEADER_RE.search(body, search_from)
+        next_umbrella = _MODULEMAP_UMBRELLA_DIR_RE.search(body, search_from)
+        candidates: list[tuple[int, str, re.Match[str]]] = []
+        if next_module is not None:
+            candidates.append((next_module.start(), "module", next_module))
+        if next_header is not None:
+            candidates.append((next_header.start(), "header", next_header))
+        if (
+            next_umbrella is not None
+            and "header"
+            not in body[max(0, next_umbrella.start() - 8) : next_umbrella.start()]
+        ):
+            candidates.append((next_umbrella.start(), "umbrella", next_umbrella))
+        if not candidates:
+            break
+        candidates.sort(key=lambda item: item[0])
+        kind = candidates[0][1]
+        match = candidates[0][2]
+        if kind == "module":
+            name = match.group("name")
+            cursor = match.end()
+            while cursor < len(body) and body[cursor] in " \t\r\n":
+                cursor += 1
+            while cursor < len(body) and body[cursor] == "[":
+                close = body.find("]", cursor)
+                if close < 0:
+                    break
+                cursor = close + 1
+                while cursor < len(body) and body[cursor] in " \t\r\n":
+                    cursor += 1
+            if cursor < len(body) and body[cursor] == "{":
+                close = _matching_brace_end(body, cursor)
+                if name != "*":
+                    headers.extend(
+                        _clang_module_headers(
+                            map_path, body[cursor + 1 : close], sdk_root
+                        )
+                    )
+                search_from = close + 1
+            else:
+                search_from = match.end()
+            continue
+        if kind == "header" and not match.group(0).startswith("exclude"):
+            relative = _quoted_modulemap_path(match.group(1))
+            header = map_path.parent / relative
+            if header.is_file():
+                headers.append(_require_inside_sdk(header, sdk_root))
+        elif kind == "umbrella":
+            relative = _quoted_modulemap_path(match.group(1))
+            directory = map_path.parent / relative
+            if directory.is_dir():
+                _require_inside_sdk(directory, sdk_root)
+                headers.extend(_collect_loose_headers(directory, sdk_root))
+        search_from = match.end()
+    return headers
+
+
+def _module_map_export_names(body: str, module: str) -> set[str]:
+    names: set[str] = set()
+    for match in _MODULEMAP_EXPORT_RE.finditer(body):
+        value = match.group(1)
+        if value == "*":
+            continue
+        exported = value.split(".", 1)[0]
+        if exported != module and MODULE_RE.fullmatch(exported):
+            names.add(exported)
+    return names
+
+
+def locate_sdk_module(sdk_root: Path, module: str) -> ModuleLocation:
+    """Locate a public iPhoneOS framework, Swift module, or Clang module."""
+
+    if not MODULE_RE.fullmatch(module):
+        raise SeedError(f"invalid Swift module identifier: {module!r}")
+    _require_inside_sdk(sdk_root, sdk_root)
+
+    framework_root = _existing_sdk_path(
+        sdk_root, "System", "Library", "Frameworks", f"{module}.framework"
+    )
+    if framework_root is not None and framework_root.is_dir():
+        relative = _sdk_relative(framework_root, sdk_root)
+        module_map = _framework_module_map(framework_root, sdk_root)
+        if _framework_has_swift_artifacts(framework_root, sdk_root, module):
+            return ModuleLocation(
+                kind="framework",
+                sdk_relative_path=relative,
+                reason=(
+                    "public iPhoneOS framework bundle is present at "
+                    f"{relative}"
+                ),
+                input_root=framework_root,
+                module_map=module_map,
+            )
+        if module_map is None:
+            raise SeedError(
+                f"public iPhoneOS framework {module}.framework has no Swift "
+                "module and no Clang module map"
+            )
+        return ModuleLocation(
+            kind="framework-clang-module",
+            sdk_relative_path=relative,
+            reason=(
+                "public iPhoneOS framework bundle is present at "
+                f"{relative} but has no Swift module; using Clang module map at "
+                f"{_sdk_relative(module_map, sdk_root)}"
+            ),
+            input_root=framework_root,
+            module_map=module_map,
+        )
+
+    swiftmodule = _existing_sdk_path(
+        sdk_root, "usr", "lib", "swift", f"{module}.swiftmodule"
+    )
+    if swiftmodule is not None:
+        relative = _sdk_relative(swiftmodule, sdk_root)
+        return ModuleLocation(
+            kind="swift-module",
+            sdk_relative_path=relative,
+            reason=(
+                "public iPhoneOS framework is absent; located Swift module at "
+                f"{relative}"
+            ),
+            input_root=swiftmodule,
+            module_map=None,
+        )
+
+    clang_dir_map = _existing_sdk_path(
+        sdk_root, "usr", "include", module, "module.modulemap"
+    )
+    if clang_dir_map is not None and clang_dir_map.is_file():
+        relative = _sdk_relative(clang_dir_map, sdk_root)
+        text = _read_sdk_text(
+            clang_dir_map, label=f"Clang module map {relative}"
+        )
+        if not module_map_declares(text, module):
+            raise SeedError(
+                f"module map at {relative} does not declare {module}"
+            )
+        return ModuleLocation(
+            kind="clang-module",
+            sdk_relative_path=relative,
+            reason=(
+                "public iPhoneOS framework is absent; located Clang module map "
+                f"at {relative}"
+            ),
+            input_root=clang_dir_map.parent,
+            module_map=clang_dir_map,
+        )
+
+    top_level_map = _existing_sdk_path(
+        sdk_root, "usr", "include", "module.modulemap"
+    )
+    if top_level_map is not None and top_level_map.is_file():
+        text = _read_sdk_text(top_level_map, label="usr/include/module.modulemap")
+        if module_map_declares(text, module):
+            resolved_map, _body, alias = _resolve_clang_module_map(
+                top_level_map, sdk_root, module, seen=frozenset()
+            )
+            relative = _sdk_relative(resolved_map, sdk_root)
+            reason = (
+                "public iPhoneOS framework is absent; located Clang submodule "
+                f"{module} in usr/include/module.modulemap"
+            )
+            if resolved_map != top_level_map:
+                reason += f" (redirected to {relative})"
+            if alias is not None:
+                reason += f"; module aliases {alias}"
+            return ModuleLocation(
+                kind="clang-submodule",
+                sdk_relative_path=relative,
+                reason=reason,
+                input_root=resolved_map.parent,
+                module_map=resolved_map,
+            )
+
+    raise SeedError(
+        "public iPhoneOS module is missing: no "
+        f"{module}.framework, usr/lib/swift/{module}.swiftmodule, "
+        f"usr/include/{module}/module.modulemap, or {module} submodule in "
+        "usr/include/module.modulemap"
+    )
+
+
+def extractor_clang_module_args(location: ModuleLocation) -> list[str]:
+    if location.kind not in {
+        "clang-module",
+        "clang-submodule",
+        "framework-clang-module",
+    }:
+        return []
+    if location.module_map is None:
+        raise SeedError(
+            f"Clang module location is missing a module map: {location.sdk_relative_path}"
+        )
+    return ["-Xcc", f"-fmodule-map-file={location.module_map}"]
+
+
+def collect_located_sdk_inputs(
+    location: ModuleLocation, sdk_root: Path, module: str
+) -> tuple[list[dict[str, Any]], list[Path]]:
+    if location.kind in {"framework", "framework-clang-module"}:
+        return collect_sdk_inputs(location.input_root, sdk_root, module)
+    if location.kind == "swift-module":
+        root = location.input_root
+        if root.is_dir():
+            return collect_sdk_inputs(
+                root, sdk_root, module, allow_loose_headers=True
+            )
+        selected: dict[str, tuple[str, Path]] = {}
+        category = classify_sdk_input(root, root.parent, allow_loose_headers=True)
+        if category is None and root.name.endswith(".swiftinterface"):
+            category = "swiftinterface"
+        if category is None:
+            raise SeedError(f"no public SDK inputs found for {module}")
+        selected[_sdk_relative(root, sdk_root)] = (category, root)
+        return _sdk_input_records(selected, sdk_root, module)
+    if location.kind == "clang-module":
+        return collect_sdk_inputs(
+            location.input_root, sdk_root, module, allow_loose_headers=True
+        )
+    if location.kind != "clang-submodule" or location.module_map is None:
+        raise SeedError(f"unsupported module location kind: {location.kind}")
+    selected = {}
+    map_path = location.module_map
+    selected[_sdk_relative(map_path, sdk_root)] = ("modulemap", map_path)
+    _resolved, body, _alias = _resolve_clang_module_map(
+        map_path, sdk_root, module, seen=frozenset()
+    )
+    if body:
+        for header in _clang_module_headers(map_path, body, sdk_root):
+            relative = _sdk_relative(header, sdk_root)
+            selected.setdefault(relative, ("header", header))
+    return _sdk_input_records(selected, sdk_root, module)
+
+
+def _iter_location_text_files(
+    location: ModuleLocation, sdk_root: Path
+) -> Iterator[Path]:
+    roots: list[Path] = []
+    if location.module_map is not None and location.module_map.is_file():
+        yield location.module_map
+    if location.input_root.is_file():
+        yield location.input_root
+        return
+    if location.input_root.is_dir():
+        roots.append(location.input_root)
+    seen: set[Path] = set()
+    for root in roots:
+        for path in logical_sdk_walk(root, sdk_root):
+            resolved = path.resolve(strict=True)
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            if path.suffix in {".h", ".swiftinterface"} or path.name.endswith(
+                "modulemap"
+            ):
+                yield path
+
+
+def _imported_module_names_from_header(text: str) -> set[str]:
+    names: set[str] = set()
+    for match in _OBJC_IMPORT_RE.finditer(text):
+        imported = match.group(1) or match.group(2)
+        if imported:
+            names.add(imported)
+    return names
+
+
+def _strip_c_comments_and_strings(text: str) -> str:
+    output: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        if text.startswith("//", index):
+            newline = text.find("\n", index)
+            if newline < 0:
+                break
+            output.append("\n")
+            index = newline + 1
+            continue
+        if text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            if end < 0:
+                break
+            output.append(" ")
+            index = end + 2
+            continue
+        char = text[index]
+        if char in {'"', "'"}:
+            quote = char
+            index += 1
+            while index < length:
+                current = text[index]
+                index += 1
+                if current == "\\":
+                    index += 1
+                    continue
+                if current == quote:
+                    break
+            output.append(" ")
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _header_is_import_only(text: str) -> bool:
+    for raw_line in _strip_c_comments_and_strings(text).splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            continue
+        if line.startswith("@import "):
+            continue
+        if line in {"{", "}", "@end"}:
+            continue
+        return False
+    return True
+
+
+def _swiftinterface_exports(text: str) -> tuple[set[str], bool]:
+    exported: set[str] = set()
+    has_other_api = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("//") or stripped.startswith("#"):
+            continue
+        match = _SWIFT_EXPORTED_IMPORT_RE.search(stripped)
+        if match:
+            exported.add(match.group(1))
+            continue
+        if stripped.startswith("import "):
+            continue
+        if stripped.startswith("@_"):
+            continue
+        has_other_api = True
+    return exported, has_other_api
+
+
+def candidate_reexport_modules(
+    module: str, location: ModuleLocation, sdk_root: Path
+) -> set[str]:
+    names: set[str] = set()
+    if location.module_map is not None:
+        text = _read_sdk_text(location.module_map, label="module map")
+        body, target = _find_named_module_in_map(text, module)
+        if target and MODULE_RE.fullmatch(target):
+            names.add(target)
+        if body:
+            names |= _module_map_export_names(body, module)
+    for path in _iter_location_text_files(location, sdk_root):
+        if path.name.endswith("modulemap"):
+            continue
+        text = _read_sdk_text(path, label=path.name)
+        if path.name.endswith(".swiftinterface"):
+            exported, _has_other = _swiftinterface_exports(text)
+            names |= exported
+            continue
+        if path.suffix == ".h":
+            names |= _imported_module_names_from_header(text)
+    names.discard(module)
+    names -= IGNORED_REEXPORT_MODULES
+    return names
+
+
+def surface_looks_like_pure_reexport(
+    module: str, location: ModuleLocation, sdk_root: Path
+) -> bool:
+    saw_surface = False
+    if location.module_map is not None:
+        text = _read_sdk_text(location.module_map, label="module map")
+        _body, target = _find_named_module_in_map(text, module)
+        if target and MODULE_RE.fullmatch(target) and target != module:
+            return True
+    for path in _iter_location_text_files(location, sdk_root):
+        if path.name.endswith("modulemap"):
+            continue
+        text = _read_sdk_text(path, label=path.name)
+        if path.name.endswith(".swiftinterface"):
+            saw_surface = True
+            _exported, has_other = _swiftinterface_exports(text)
+            if has_other:
+                return False
+            continue
+        if path.suffix == ".h":
+            saw_surface = True
+            if not _header_is_import_only(text):
+                return False
+    return saw_surface
+
+
+def detect_umbrella_reexport(
+    module: str,
+    location: ModuleLocation,
+    sdk_root: Path,
+    *,
+    require_pure: bool = False,
+) -> str | None:
+    candidates = candidate_reexport_modules(module, location, sdk_root)
+    if len(candidates) != 1:
+        return None
+    if require_pure and not surface_looks_like_pure_reexport(
+        module, location, sdk_root
+    ):
+        return None
+    return next(iter(candidates))
+
+
+def refuse_empty_or_umbrella(
+    module: str, symbol_count: int, reexport: str | None
+) -> None:
+    if symbol_count > 0:
+        return
+    if reexport:
+        raise SeedError(
+            f"umbrella re-export of {reexport}; seed {reexport} instead"
+        )
+    raise SeedError(f"public surface is empty (0 symbols) for {module}")
+
+
 def generate_symbol_graphs(
     module: str,
     sdk_root: Path,
@@ -554,6 +1311,7 @@ def generate_symbol_graphs(
     reference_root: Path,
     clean_env: dict[str, str],
     extractor: Path,
+    extra_frontend_args: Sequence[str] = (),
 ) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
     raw_root = temp_root / "symbol-graphs"
     raw_root.mkdir()
@@ -565,6 +1323,7 @@ def generate_symbol_graphs(
         TARGET,
         "-sdk",
         str(sdk_root),
+        *extra_frontend_args,
         "-minimum-access-level",
         "public",
         "-module-cache-path",
@@ -1038,6 +1797,7 @@ def generate_api_digester(
     clean_env: dict[str, str],
     digester: Path,
     symbols_by_precise: dict[str, dict[str, Any]],
+    extra_frontend_args: Sequence[str] = (),
 ) -> dict[str, int]:
     """Emit a location-free Swift API-digester tree for declaration identity.
 
@@ -1059,6 +1819,7 @@ def generate_api_digester(
         TARGET,
         "-sdk",
         str(sdk_root),
+        *extra_frontend_args,
         "-avoid-location",
         "-avoid-tool-args",
         "-abort-on-module-fail",
@@ -1297,7 +2058,9 @@ def write_tbd_exports(
     return len(rows)
 
 
-def roadmap_summary(roadmap_path: Path, module: str) -> dict[str, Any]:
+def roadmap_summary(
+    roadmap_path: Path, module: str, *, allow_missing: bool = False
+) -> dict[str, Any]:
     try:
         roadmap = json.loads(roadmap_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
@@ -1305,9 +2068,16 @@ def roadmap_summary(roadmap_path: Path, module: str) -> dict[str, Any]:
     if not isinstance(roadmap, dict) or not isinstance(roadmap.get("modules"), list):
         raise SeedError("framework roadmap has an unsupported schema")
     matches = [item for item in roadmap["modules"] if item.get("module") == module]
-    if len(matches) != 1:
+    if len(matches) > 1:
         raise SeedError(f"framework roadmap must contain exactly one {module} record")
-    module_record = matches[0]
+    if not matches:
+        if not allow_missing:
+            raise SeedError(
+                f"framework roadmap must contain exactly one {module} record"
+            )
+        module_record: Any = {"roadmap": ROADMAP_OPERATOR_OVERRIDE}
+    else:
+        module_record = matches[0]
     families = [
         family
         for family in roadmap.get("requested_roadmap_families", [])
@@ -2845,20 +3615,23 @@ def generate(args: argparse.Namespace) -> Path:
         clean_env = prepare_clean_environment(temp_root, developer_dir)
         toolchain = validate_xcode(developer_dir, clean_env)
         sdk_root = Path(toolchain["_sdkPath"])
-        framework_root = (
-            sdk_root / "System/Library/Frameworks" / f"{module}.framework"
+        location = locate_sdk_module(sdk_root, module)
+        extra_frontend_args = extractor_clang_module_args(location)
+        umbrella = detect_umbrella_reexport(
+            module, location, sdk_root, require_pure=True
         )
-        if not framework_root.is_dir():
-            raise SeedError(f"public iPhoneOS framework is missing: {module}.framework")
-        framework_real = framework_root.resolve(strict=True)
-        if not within(framework_real, sdk_root.resolve(strict=True)):
-            raise SeedError("framework path escapes the iPhoneOS SDK")
+        if umbrella is not None:
+            raise SeedError(
+                f"umbrella re-export of {umbrella}; seed {umbrella} instead"
+            )
 
         reference_root = stage / "reference"
         reference_root.mkdir()
         (stage / "tests/acceptance").mkdir(parents=True)
 
-        sdk_records, tbd_paths = collect_sdk_inputs(framework_root, sdk_root, module)
+        sdk_records, tbd_paths = collect_located_sdk_inputs(
+            location, sdk_root, module
+        )
         write_sdk_input_ledger(reference_root / "sdk-inputs.tsv", sdk_records)
 
         graph_manifest, symbols = generate_symbol_graphs(
@@ -2868,9 +3641,15 @@ def generate(args: argparse.Namespace) -> Path:
             reference_root,
             clean_env,
             Path(toolchain["_symbolGraphExtractorExecutable"]),
+            extra_frontend_args,
         )
         write_json(reference_root / "symbol-graphs.json", graph_manifest)
         write_public_surface(reference_root / "public-surface.tsv", symbols)
+        refuse_empty_or_umbrella(
+            module,
+            graph_manifest["symbolCount"],
+            detect_umbrella_reexport(module, location, sdk_root),
+        )
         api_stats = generate_api_digester(
             module,
             sdk_root,
@@ -2879,12 +3658,17 @@ def generate(args: argparse.Namespace) -> Path:
             clean_env,
             Path(toolchain["_apiDigesterExecutable"]),
             symbols,
+            extra_frontend_args,
         )
         tbd_export_count = write_tbd_exports(
             reference_root / "tbd-exports.tsv", tbd_paths, sdk_root, clean_env
         )
 
-        corpus = roadmap_summary(roadmap_path, module)
+        corpus = roadmap_summary(
+            roadmap_path,
+            module,
+            allow_missing=bool(getattr(args, "allow_no_roadmap_record", False)),
+        )
         write_json(reference_root / "corpus-summary.json", corpus)
         external_evidence = external_evidence_summary(
             external_evidence_lock_path, module
@@ -2980,7 +3764,7 @@ def generate(args: argparse.Namespace) -> Path:
                 "sdkName": toolchain["sdkName"],
                 "sdkVersion": toolchain["sdkVersion"],
                 "target": TARGET,
-                "frameworkSDKRelativePath": framework_root.relative_to(sdk_root).as_posix(),
+                "frameworkSDKRelativePath": location.sdk_relative_path,
                 "symbolGraphExtractorPath": toolchain[
                     "symbolGraphExtractorPath"
                 ],
@@ -3020,6 +3804,9 @@ def generate(args: argparse.Namespace) -> Path:
                 ),
             },
         }
+        framework_json["moduleLocation"] = location.record()
+        if corpus.get("moduleRecord") == {"roadmap": ROADMAP_OPERATOR_OVERRIDE}:
+            framework_json["roadmap"] = ROADMAP_OPERATOR_OVERRIDE
         write_json(reference_root / "framework.json", framework_json)
 
         immutable_paths = [
@@ -3076,6 +3863,14 @@ def argument_parser() -> argparse.ArgumentParser:
         "--output-root",
         required=True,
         help="existing destination parent (the repository's full directory)",
+    )
+    parser.add_argument(
+        "--allow-no-roadmap-record",
+        action="store_true",
+        help=(
+            "if the framework roadmap has no module record, record "
+            f"{ROADMAP_OPERATOR_OVERRIDE!r} instead of refusing; default still refuses"
+        ),
     )
     return parser
 

--- a/scripts/framework-fanout/generate_seed_v2.py
+++ b/scripts/framework-fanout/generate_seed_v2.py
@@ -1066,6 +1066,55 @@ def locate_sdk_module(sdk_root: Path, module: str) -> ModuleLocation:
     )
 
 
+def clang_include_directories(location: ModuleLocation) -> list[Path]:
+    directories: list[Path] = []
+    if location.kind == "clang-module":
+        directories.append(location.input_root)
+        parent = location.input_root.parent
+        if parent.name == "include":
+            directories.append(parent)
+    elif location.kind == "clang-submodule" and location.module_map is not None:
+        directories.append(location.module_map.parent)
+    elif location.kind == "framework-clang-module":
+        headers = location.input_root / "Headers"
+        if headers.is_dir():
+            directories.append(headers)
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for directory in directories:
+        if directory not in seen:
+            seen.add(directory)
+            unique.append(directory)
+    return unique
+
+
+def xcc_passthrough(*clang_args: str) -> list[str]:
+    """Spell Clang importer flags as argv pairs ``-Xcc``, ``<clang-arg>``.
+
+    ``swift-symbolgraph-extract`` only accepts options in the
+    SwiftSymbolGraphExtract group.  ``-fmodule-map-file`` is a Clang flag, so
+    it must be the Separate value of ``-Xcc``, never a top-level extractor
+    argument.
+    """
+
+    argv: list[str] = []
+    for clang_arg in clang_args:
+        if not clang_arg or clang_arg.startswith("-Xcc"):
+            raise SeedError(f"invalid Clang importer passthrough: {clang_arg!r}")
+        argv.extend(("-Xcc", clang_arg))
+    return argv
+
+
+def reject_bare_clang_importer_flags(argv: Sequence[str], *, tool: str) -> None:
+    for index, argument in enumerate(argv):
+        if argument.startswith("-fmodule-map-file") and (
+            index == 0 or argv[index - 1] != "-Xcc"
+        ):
+            raise SeedError(
+                f"{tool} received Clang flag {argument!r} without a preceding -Xcc"
+            )
+
+
 def extractor_clang_module_args(location: ModuleLocation) -> list[str]:
     if location.kind not in {
         "clang-module",
@@ -1077,7 +1126,84 @@ def extractor_clang_module_args(location: ModuleLocation) -> list[str]:
         raise SeedError(
             f"Clang module location is missing a module map: {location.sdk_relative_path}"
         )
-    return ["-Xcc", f"-fmodule-map-file={location.module_map}"]
+    include_dirs = clang_include_directories(location)
+    argv: list[str] = []
+    for directory in include_dirs:
+        argv.extend(("-I", str(directory)))
+    argv.extend(xcc_passthrough(f"-fmodule-map-file={location.module_map}"))
+    argv.extend(xcc_passthrough(*(f"-I{directory}" for directory in include_dirs)))
+    reject_bare_clang_importer_flags(argv, tool="swift-symbolgraph-extract")
+    return argv
+
+
+def digester_clang_module_args(location: ModuleLocation) -> list[str]:
+    """Xcode 26.1's api-digester option table does not accept ``-Xcc``."""
+
+    if location.kind not in {
+        "clang-module",
+        "clang-submodule",
+        "framework-clang-module",
+    }:
+        return []
+    argv: list[str] = []
+    for directory in clang_include_directories(location):
+        argv.extend(("-I", str(directory)))
+    return argv
+
+
+def symbol_graph_extract_command(
+    extractor: Path | str,
+    module: str,
+    sdk_root: Path,
+    output_dir: Path,
+    module_cache: Path,
+    extra_frontend_args: Sequence[str] = (),
+) -> list[str]:
+    argv = [
+        str(extractor),
+        "-module-name",
+        module,
+        "-target",
+        TARGET,
+        "-sdk",
+        str(sdk_root),
+        *extra_frontend_args,
+        "-minimum-access-level",
+        "public",
+        "-module-cache-path",
+        str(module_cache),
+        "-output-dir",
+        str(output_dir),
+    ]
+    reject_bare_clang_importer_flags(argv, tool="swift-symbolgraph-extract")
+    return argv
+
+
+def api_digester_command(
+    digester: Path | str,
+    module: str,
+    sdk_root: Path,
+    output_path: Path,
+    extra_frontend_args: Sequence[str] = (),
+) -> list[str]:
+    argv = [
+        str(digester),
+        "-dump-sdk",
+        "-module",
+        module,
+        "-o",
+        str(output_path),
+        "-target",
+        TARGET,
+        "-sdk",
+        str(sdk_root),
+        *extra_frontend_args,
+        "-avoid-location",
+        "-avoid-tool-args",
+        "-abort-on-module-fail",
+    ]
+    reject_bare_clang_importer_flags(argv, tool="swift-api-digester")
+    return argv
 
 
 def collect_located_sdk_inputs(
@@ -1315,22 +1441,14 @@ def generate_symbol_graphs(
 ) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
     raw_root = temp_root / "symbol-graphs"
     raw_root.mkdir()
-    command = [
-        str(extractor),
-        "-module-name",
+    command = symbol_graph_extract_command(
+        extractor,
         module,
-        "-target",
-        TARGET,
-        "-sdk",
-        str(sdk_root),
-        *extra_frontend_args,
-        "-minimum-access-level",
-        "public",
-        "-module-cache-path",
-        str(temp_root / "swift-module-cache"),
-        "-output-dir",
-        str(raw_root),
-    ]
+        sdk_root,
+        raw_root,
+        temp_root / "swift-module-cache",
+        extra_frontend_args,
+    )
     run_checked(command, env=clean_env)
     graph_files = sorted(raw_root.glob("*.symbols.json"), key=lambda item: item.name)
     if not graph_files:
@@ -1808,22 +1926,13 @@ def generate_api_digester(
     """
 
     raw_path = temp_root / f"{module}.api-digester.json"
-    command = [
-        str(digester),
-        "-dump-sdk",
-        "-module",
+    command = api_digester_command(
+        digester,
         module,
-        "-o",
-        str(raw_path),
-        "-target",
-        TARGET,
-        "-sdk",
-        str(sdk_root),
-        *extra_frontend_args,
-        "-avoid-location",
-        "-avoid-tool-args",
-        "-abort-on-module-fail",
-    ]
+        sdk_root,
+        raw_path,
+        extra_frontend_args,
+    )
     run_checked(command, env=clean_env)
     document = strict_json_load(raw_path, label=f"API-digester output for {module}")
     root, node_count, declarations = validate_api_declarations(document, module)
@@ -3616,7 +3725,8 @@ def generate(args: argparse.Namespace) -> Path:
         toolchain = validate_xcode(developer_dir, clean_env)
         sdk_root = Path(toolchain["_sdkPath"])
         location = locate_sdk_module(sdk_root, module)
-        extra_frontend_args = extractor_clang_module_args(location)
+        extract_frontend_args = extractor_clang_module_args(location)
+        digester_frontend_args = digester_clang_module_args(location)
         umbrella = detect_umbrella_reexport(
             module, location, sdk_root, require_pure=True
         )
@@ -3641,7 +3751,7 @@ def generate(args: argparse.Namespace) -> Path:
             reference_root,
             clean_env,
             Path(toolchain["_symbolGraphExtractorExecutable"]),
-            extra_frontend_args,
+            extract_frontend_args,
         )
         write_json(reference_root / "symbol-graphs.json", graph_manifest)
         write_public_surface(reference_root / "public-surface.tsv", symbols)
@@ -3658,7 +3768,7 @@ def generate(args: argparse.Namespace) -> Path:
             clean_env,
             Path(toolchain["_apiDigesterExecutable"]),
             symbols,
-            extra_frontend_args,
+            digester_frontend_args,
         )
         tbd_export_count = write_tbd_exports(
             reference_root / "tbd-exports.tsv", tbd_paths, sdk_root, clean_env

--- a/scripts/framework-fanout/generate_seed_v2_scoped.py
+++ b/scripts/framework-fanout/generate_seed_v2_scoped.py
@@ -658,6 +658,7 @@ def _generate_one(
         risks=args.risks,
         dependencies=args.dependencies,
         output_root=str(output_root),
+        allow_no_roadmap_record=getattr(args, "allow_no_roadmap_record", False),
     )
     base.run_checked = scoped_run_checked
     try:
@@ -849,6 +850,15 @@ def argument_parser() -> argparse.ArgumentParser:
         type=int,
         default=DEFAULT_REPRODUCIBILITY_RUN_COUNT,
         help="number of fresh evidence runs to retain (minimum: 3)",
+    )
+    parser.add_argument(
+        "--allow-no-roadmap-record",
+        action="store_true",
+        help=(
+            "if the framework roadmap has no module record, record "
+            f"{base.ROADMAP_OPERATOR_OVERRIDE!r} instead of refusing; "
+            "default still refuses"
+        ),
     )
     return parser
 

--- a/scripts/framework-fanout/test_generate_seed_v2_scoped.py
+++ b/scripts/framework-fanout/test_generate_seed_v2_scoped.py
@@ -376,14 +376,15 @@ class NonFrameworkSeedTests(unittest.TestCase):
         )
         location = base.locate_sdk_module(sdk, "IOKit")
         self.assertEqual("framework-clang-module", location.kind)
-        self.assertEqual(
-            [
-                "-Xcc",
-                f"-fmodule-map-file={framework / 'Modules/module.modulemap'}",
-            ],
-            base.extractor_clang_module_args(location),
-        )
         self.assertIn("no Swift module", location.reason)
+        args = base.extractor_clang_module_args(location)
+        module_map = str(framework / "Modules/module.modulemap")
+        self.assertIn("-Xcc", args)
+        self.assertIn(f"-fmodule-map-file={module_map}", args)
+        self.assertEqual(
+            "-Xcc",
+            args[args.index(f"-fmodule-map-file={module_map}") - 1],
+        )
 
     def test_locator_finds_swift_only_module(self) -> None:
         _temporary, sdk = self.make_sdk()
@@ -421,16 +422,88 @@ class NonFrameworkSeedTests(unittest.TestCase):
             location.sdk_relative_path,
         )
         self.assertIn("located Clang module map", location.reason)
+        args = base.extractor_clang_module_args(location)
+        module_map = str(sdk / "usr/include/CommonCrypto/module.modulemap")
         self.assertEqual(
             [
+                "-I",
+                str(sdk / "usr/include/CommonCrypto"),
+                "-I",
+                str(sdk / "usr/include"),
                 "-Xcc",
-                f"-fmodule-map-file={sdk / 'usr/include/CommonCrypto/module.modulemap'}",
+                f"-fmodule-map-file={module_map}",
+                "-Xcc",
+                f"-I{sdk / 'usr/include/CommonCrypto'}",
+                "-Xcc",
+                f"-I{sdk / 'usr/include'}",
             ],
-            base.extractor_clang_module_args(location),
+            args,
         )
         records, _tbds = base.collect_located_sdk_inputs(location, sdk, "CommonCrypto")
         categories = {row["category"] for row in records}
         self.assertEqual({"header", "modulemap"}, categories)
+
+    def test_clang_module_map_flag_is_passed_via_xcc(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk / "usr/include/CommonCrypto/module.modulemap",
+            'module CommonCrypto [system] [extern_c] {\n    header "CommonCrypto.h"\n    export *\n}\n',
+        )
+        write_file(
+            sdk / "usr/include/CommonCrypto/CommonCrypto.h",
+            "int CC_SHA256(const void *data, unsigned int len, unsigned char *md);\n",
+        )
+        location = base.locate_sdk_module(sdk, "CommonCrypto")
+        extract_args = base.extractor_clang_module_args(location)
+        module_map_flag = (
+            f"-fmodule-map-file={sdk / 'usr/include/CommonCrypto/module.modulemap'}"
+        )
+        self.assertIn(module_map_flag, extract_args)
+        self.assertEqual(
+            "-Xcc", extract_args[extract_args.index(module_map_flag) - 1]
+        )
+        self.assertTrue(
+            any(
+                argument == "-Xcc" and extract_args[index + 1].startswith("-I")
+                for index, argument in enumerate(extract_args[:-1])
+            )
+        )
+        extract_command = base.symbol_graph_extract_command(
+            "/usr/bin/swift-symbolgraph-extract",
+            "CommonCrypto",
+            sdk,
+            Path("/tmp/out"),
+            Path("/tmp/cache"),
+            extract_args,
+        )
+        self.assertEqual(
+            extract_command[extract_command.index(module_map_flag) - 1],
+            "-Xcc",
+        )
+        with self.assertRaisesRegex(base.SeedError, "without a preceding -Xcc"):
+            base.symbol_graph_extract_command(
+                "/usr/bin/swift-symbolgraph-extract",
+                "CommonCrypto",
+                sdk,
+                Path("/tmp/out"),
+                Path("/tmp/cache"),
+                [module_map_flag],
+            )
+        digester_args = base.digester_clang_module_args(location)
+        self.assertNotIn("-Xcc", digester_args)
+        self.assertFalse(
+            any(argument.startswith("-fmodule-map-file") for argument in digester_args)
+        )
+        self.assertEqual(
+            [
+                "-I",
+                str(sdk / "usr/include/CommonCrypto"),
+                "-I",
+                str(sdk / "usr/include"),
+            ],
+            digester_args,
+        )
+
 
     def test_locator_finds_top_level_clang_submodule(self) -> None:
         _temporary, sdk = self.make_sdk()

--- a/scripts/framework-fanout/test_generate_seed_v2_scoped.py
+++ b/scripts/framework-fanout/test_generate_seed_v2_scoped.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import tempfile
 import unittest
 
+import generate_seed_v2 as base
 import generate_seed_v2_scoped as scoped
 
 
@@ -327,6 +328,312 @@ class ScopedGeneratorTests(unittest.TestCase):
                         run(3, left_projection),
                     ]
                 )
+
+
+def write_file(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class NonFrameworkSeedTests(unittest.TestCase):
+    def make_sdk(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        sdk = Path(temporary.name) / "iPhoneOS.sdk"
+        sdk.mkdir()
+        return temporary, sdk
+
+    def test_locator_prefers_swift_framework_bundle(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk
+            / "System/Library/Frameworks/Foundation.framework/Modules/Foundation.swiftmodule/arm64-apple-ios.swiftinterface",
+            "// swift-interface-format-version: 1.0\npublic struct FoundationMarker {}\n",
+        )
+        write_file(
+            sdk / "usr/lib/swift/Foundation.swiftmodule/arm64-apple-ios.swiftinterface",
+            "// should not win over the framework bundle\n",
+        )
+        location = base.locate_sdk_module(sdk, "Foundation")
+        self.assertEqual("framework", location.kind)
+        self.assertEqual(
+            "System/Library/Frameworks/Foundation.framework",
+            location.sdk_relative_path,
+        )
+        self.assertIn("framework bundle is present", location.reason)
+        self.assertEqual([], base.extractor_clang_module_args(location))
+
+    def test_locator_uses_clang_module_map_for_c_only_framework(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        framework = sdk / "System/Library/Frameworks/IOKit.framework"
+        write_file(
+            framework / "Modules/module.modulemap",
+            'framework module IOKit [system] {\n    umbrella header "IOKitLib.h"\n    export *\n}\n',
+        )
+        write_file(
+            framework / "Headers/IOKitLib.h",
+            "typedef int IOReturn;\nIOReturn IOMasterPort(void);\n",
+        )
+        location = base.locate_sdk_module(sdk, "IOKit")
+        self.assertEqual("framework-clang-module", location.kind)
+        self.assertEqual(
+            [
+                "-Xcc",
+                f"-fmodule-map-file={framework / 'Modules/module.modulemap'}",
+            ],
+            base.extractor_clang_module_args(location),
+        )
+        self.assertIn("no Swift module", location.reason)
+
+    def test_locator_finds_swift_only_module(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk
+            / "usr/lib/swift/Compression.swiftmodule/arm64-apple-ios.swiftinterface",
+            "// swift-interface-format-version: 1.0\npublic enum compression_algorithm: Int {}\n",
+        )
+        location = base.locate_sdk_module(sdk, "Compression")
+        self.assertEqual("swift-module", location.kind)
+        self.assertEqual(
+            "usr/lib/swift/Compression.swiftmodule",
+            location.sdk_relative_path,
+        )
+        self.assertIn("located Swift module", location.reason)
+        self.assertEqual([], base.extractor_clang_module_args(location))
+        records, tbds = base.collect_located_sdk_inputs(location, sdk, "Compression")
+        self.assertEqual([], tbds)
+        self.assertEqual(["swiftinterface"], [row["category"] for row in records])
+
+    def test_locator_finds_clang_module_directory_map(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk / "usr/include/CommonCrypto/module.modulemap",
+            'module CommonCrypto [system] [extern_c] {\n    header "CommonCrypto.h"\n    export *\n}\n',
+        )
+        write_file(
+            sdk / "usr/include/CommonCrypto/CommonCrypto.h",
+            "int CC_SHA256(const void *data, unsigned int len, unsigned char *md);\n",
+        )
+        location = base.locate_sdk_module(sdk, "CommonCrypto")
+        self.assertEqual("clang-module", location.kind)
+        self.assertEqual(
+            "usr/include/CommonCrypto/module.modulemap",
+            location.sdk_relative_path,
+        )
+        self.assertIn("located Clang module map", location.reason)
+        self.assertEqual(
+            [
+                "-Xcc",
+                f"-fmodule-map-file={sdk / 'usr/include/CommonCrypto/module.modulemap'}",
+            ],
+            base.extractor_clang_module_args(location),
+        )
+        records, _tbds = base.collect_located_sdk_inputs(location, sdk, "CommonCrypto")
+        categories = {row["category"] for row in records}
+        self.assertEqual({"header", "modulemap"}, categories)
+
+    def test_locator_finds_top_level_clang_submodule(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk / "usr/include/module.modulemap",
+            'module Darwin [system] { header "stdio.h" }\n'
+            'module zlib [system] [extern_c] {\n    header "zlib.h"\n    export *\n}\n',
+        )
+        write_file(sdk / "usr/include/zlib.h", "int compress(void);\n")
+        write_file(sdk / "usr/include/stdio.h", "int printf(const char *fmt, ...);\n")
+        location = base.locate_sdk_module(sdk, "zlib")
+        self.assertEqual("clang-submodule", location.kind)
+        self.assertEqual("usr/include/module.modulemap", location.sdk_relative_path)
+        self.assertIn("located Clang submodule zlib", location.reason)
+        records, _tbds = base.collect_located_sdk_inputs(location, sdk, "zlib")
+        paths = {row["sdkRelativePath"] for row in records}
+        self.assertIn("usr/include/module.modulemap", paths)
+        self.assertIn("usr/include/zlib.h", paths)
+        self.assertNotIn("usr/include/stdio.h", paths)
+
+    def test_locator_prefers_swiftmodule_over_clang_map(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk / "usr/lib/swift/Compression.swiftmodule/arm64-apple-ios.swiftinterface",
+            "public enum compression_algorithm: Int {}\n",
+        )
+        write_file(
+            sdk / "usr/include/Compression/module.modulemap",
+            'module Compression { header "compression.h" }\n',
+        )
+        location = base.locate_sdk_module(sdk, "Compression")
+        self.assertEqual("swift-module", location.kind)
+
+    def test_systemconfiguration_is_a_framework(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk
+            / "System/Library/Frameworks/SystemConfiguration.framework/Modules/module.modulemap",
+            'framework module SystemConfiguration [system] {\n    umbrella header "SystemConfiguration.h"\n    export *\n}\n',
+        )
+        write_file(
+            sdk
+            / "System/Library/Frameworks/SystemConfiguration.framework/Headers/SystemConfiguration.h",
+            "typedef int SCNetworkReachabilityRef;\n",
+        )
+        location = base.locate_sdk_module(sdk, "SystemConfiguration")
+        self.assertEqual("framework-clang-module", location.kind)
+        self.assertEqual(
+            "System/Library/Frameworks/SystemConfiguration.framework",
+            location.sdk_relative_path,
+        )
+
+    def test_locator_refuses_unknown_module(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(sdk / "usr/include/stdio.h", "int printf(const char *fmt, ...);\n")
+        with self.assertRaisesRegex(
+            base.SeedError, "public iPhoneOS module is missing"
+        ):
+            base.locate_sdk_module(sdk, "CommonCrypto")
+
+    def test_locator_refuses_clang_map_that_does_not_declare_the_module(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk / "usr/include/CommonCrypto/module.modulemap",
+            'module SomethingElse [system] { header "CommonCrypto.h" }\n',
+        )
+        write_file(
+            sdk / "usr/include/CommonCrypto/CommonCrypto.h",
+            "int CC_SHA256(const void *data, unsigned int len, unsigned char *md);\n",
+        )
+        with self.assertRaisesRegex(base.SeedError, "does not declare CommonCrypto"):
+            base.locate_sdk_module(sdk, "CommonCrypto")
+
+    def test_umbrella_reexport_from_swiftinterface_is_named(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk
+            / "System/Library/Frameworks/MobileCoreServices.framework/Modules/MobileCoreServices.swiftmodule/arm64-apple-ios.swiftinterface",
+            "// swift-interface-format-version: 1.0\n"
+            "@_exported import UniformTypeIdentifiers\n",
+        )
+        write_file(
+            sdk
+            / "System/Library/Frameworks/MobileCoreServices.framework/Headers/MobileCoreServices.h",
+            "#ifndef MOBILECORESERVICES\n"
+            "#define MOBILECORESERVICES\n"
+            "#include <CoreFoundation/CoreFoundation.h>\n"
+            "#include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>\n"
+            "#endif\n",
+        )
+        location = base.locate_sdk_module(sdk, "MobileCoreServices")
+        self.assertEqual("framework", location.kind)
+        self.assertEqual(
+            "UniformTypeIdentifiers",
+            base.detect_umbrella_reexport(
+                "MobileCoreServices", location, sdk, require_pure=True
+            ),
+        )
+        with self.assertRaisesRegex(
+            base.SeedError,
+            r"umbrella re-export of UniformTypeIdentifiers; seed UniformTypeIdentifiers instead",
+        ):
+            base.refuse_empty_or_umbrella("MobileCoreServices", 0, "UniformTypeIdentifiers")
+
+    def test_real_clang_module_is_not_an_umbrella(self) -> None:
+        _temporary, sdk = self.make_sdk()
+        write_file(
+            sdk / "usr/include/CommonCrypto/module.modulemap",
+            'module CommonCrypto [system] [extern_c] {\n    header "CommonCrypto.h"\n    export *\n}\n',
+        )
+        write_file(
+            sdk / "usr/include/CommonCrypto/CommonCrypto.h",
+            "#include <CoreFoundation/CoreFoundation.h>\n"
+            "int CC_SHA256(const void *data, unsigned int len, unsigned char *md);\n",
+        )
+        location = base.locate_sdk_module(sdk, "CommonCrypto")
+        self.assertIsNone(
+            base.detect_umbrella_reexport(
+                "CommonCrypto", location, sdk, require_pure=True
+            )
+        )
+        base.refuse_empty_or_umbrella("CommonCrypto", 12, None)
+
+    def test_empty_surface_without_named_reexport_is_refused(self) -> None:
+        with self.assertRaisesRegex(
+            base.SeedError, r"public surface is empty \(0 symbols\) for EmptyKit"
+        ):
+            base.refuse_empty_or_umbrella("EmptyKit", 0, None)
+
+    def test_roadmap_override_is_opt_in(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            roadmap_path = Path(temporary) / "framework-roadmap.json"
+            roadmap_path.write_text(
+                json.dumps(
+                    {
+                        "schema": 2,
+                        "modules": [{"module": "Foundation"}],
+                        "requested_roadmap_families": [
+                            {"family": "data", "modules": ["SwiftData"]}
+                        ],
+                        "iphoneos_runtime_port_candidate_rankings": {
+                            "by_app_coverage": ["Foundation"],
+                            "by_focus_launch_build_relevance": ["Foundation"],
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                base.SeedError, "exactly one SwiftData record"
+            ):
+                base.roadmap_summary(roadmap_path, "SwiftData")
+            summary = base.roadmap_summary(
+                roadmap_path, "SwiftData", allow_missing=True
+            )
+            self.assertEqual(
+                {"roadmap": base.ROADMAP_OPERATOR_OVERRIDE},
+                summary["moduleRecord"],
+            )
+            self.assertEqual(
+                [{"family": "data", "modules": ["SwiftData"]}],
+                summary["requestedFamilies"],
+            )
+            recorded = base.roadmap_summary(roadmap_path, "Foundation", allow_missing=True)
+            self.assertEqual({"module": "Foundation"}, recorded["moduleRecord"])
+
+    def test_allow_no_roadmap_record_flag_defaults_off(self) -> None:
+        parser = base.argument_parser()
+        args = parser.parse_args(
+            [
+                "--module",
+                "Compression",
+                "--slug",
+                "compression",
+                "--lane",
+                "medium-full",
+                "--risks",
+                "fail-closed",
+                "--output-root",
+                "/tmp",
+            ]
+        )
+        self.assertFalse(args.allow_no_roadmap_record)
+        scoped_parser = scoped.argument_parser()
+        scoped_args = scoped_parser.parse_args(
+            [
+                "--module",
+                "Compression",
+                "--slug",
+                "compression",
+                "--lane",
+                "medium-full",
+                "--risks",
+                "fail-closed",
+                "--output-root",
+                "/tmp",
+                "--exclude-cross-import-overlay-module",
+                "_Compression_SwiftUI",
+                "--allow-no-roadmap-record",
+            ]
+        )
+        self.assertTrue(scoped_args.allow_no_roadmap_record)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`generate_seed_v2.py` no longer requires a public `System/Library/Frameworks/<Module>.framework` bundle. When that bundle is absent, it locates the module in the iPhoneOS SDK and records **which path was taken and why** in `reference/framework.json` (`moduleLocation` plus `provenance.frameworkSDKRelativePath`).

Empty umbrella re-exports (MobileCoreServices) are refused with a named replacement. Roadmap-less modules (SwiftData) still refuse by default; `--allow-no-roadmap-record` is an explicit operator override.

## Locator rules

Checked in this order against the pinned iPhoneOS SDK root:

1. **`System/Library/Frameworks/<Module>.framework`**
   - If the bundle contains a Swift module / `.swiftinterface`, kind = `framework` (existing extractor invocation).
   - If it has no Swift artifacts but has `Modules/module.modulemap`, kind = `framework-clang-module` and the extractor gets `-Xcc -fmodule-map-file=<that map>` plus `-Xcc -I` / Swift `-I` for `Headers` (IOKit without a map still refuses honestly).
2. **`usr/lib/swift/<Module>.swiftmodule`** — kind = `swift-module` (Compression). Ordinary `swift-symbolgraph-extract -module-name <Module> -sdk …`.
3. **`usr/include/<Module>/module.modulemap`** — kind = `clang-module` (CommonCrypto). Extractor argv pairs **`-Xcc` then `-fmodule-map-file=<path>`**, plus **`-Xcc` then `-I<dir>`**, and first-class **`-I <dir>`** for `usr/include/<Module>` and `usr/include`.
4. **`usr/include/module.modulemap` submodule** named `<Module>` — kind = `clang-submodule` (zlib). Same Clang extractor spelling; SDK-input ledger records the map plus that submodule’s headers only.

If none of those exist, refuse: `public iPhoneOS module is missing: no <Module>.framework, usr/lib/swift/<Module>.swiftmodule, …`.

**SystemConfiguration is a public iPhoneOS framework** (`System/Library/Frameworks/SystemConfiguration.framework`). The Linux lane under `full/systemconfiguration/` is C/ObjC, but the seed locator treats it as `framework-clang-module` when the bundle has no Swift module.

## Clang flag spelling (CommonCrypto dry-run)

`swift-symbolgraph-extract` only accepts its own option group. A bare `-fmodule-map-file=…` is `error: unknown argument`. Importer flags are now always two argv tokens:

```text
-Xcc -fmodule-map-file=<abs-path>
-Xcc -I<abs-dir>
```

Xcode 26.1 `swift-api-digester` does not accept `-Xcc`; it gets first-class `-I` only. A unit test (`test_clang_module_map_flag_is_passed_via_xcc`) locks the extract spelling and refuses a bare Clang flag on the extract command.

## `--output-root scratch/seeds-wave6`

That refusal is **pre-existing** `safe_output_root` (same guard in frozen `generate_seed.py`): in-repo destinations must be exactly the repo `full/` directory. This change does not relax it. Operator re-runs should keep `--output-root full` in a throwaway worktree.

## Umbrella / zero-symbol refusal

Pure re-export (module alias, `@_exported import Other`, or import-only umbrella header of a single non-system module) refuses immediately:

```text
framework_seed: REFUSING -- umbrella re-export of UniformTypeIdentifiers; seed UniformTypeIdentifiers instead
```

After extraction, `symbolCount == 0` also refuses: named umbrella reason when a unique re-export target is known, otherwise `public surface is empty (0 symbols) for <Module>`.

## Roadmap override

Default is unchanged. `--allow-no-roadmap-record` records `roadmap: none (operator override)` when there is no module record. If a record exists, the flag does not ignore it.

## Schema addition (`validate_seed.py`)

Unavoidable so new seeds can pass `--phase seed` without breaking existing dossiers:

- Optional `moduleLocation` `{kind, sdkRelativePath, reason}` on `reference/framework.json`.
- Optional `roadmap: "none (operator override)"` when the flag is used.

## Tests (Linux, no SDK)

```text
python3 scripts/framework-fanout/test_*.py
python3 full/framework-fanout/test_validate_seed.py
```

Green on this VM (21 generator tests, 35 validator tests).

## Operator re-run (Xcode 26.1, `--output-root full` in a throwaway worktree)

```sh
python3 scripts/framework-fanout/generate_seed_v2.py \
  --module CommonCrypto --slug commoncrypto --lane medium-full \
  --risks ui,fail-closed --dependencies Foundation \
  --output-root full

python3 scripts/framework-fanout/generate_seed_v2.py \
  --module Compression --slug compression --lane medium-full \
  --risks ui,fail-closed --dependencies Foundation \
  --output-root full

python3 scripts/framework-fanout/generate_seed_v2.py \
  --module IOKit --slug iokit --lane medium-full \
  --risks ui,fail-closed --dependencies Foundation \
  --output-root full
# expected unchanged: REFUSING -- public iPhoneOS framework IOKit.framework has no Swift module and no Clang module map

python3 scripts/framework-fanout/generate_seed_v2.py \
  --module SwiftData --slug swiftdata --lane medium-full \
  --risks ui,fail-closed --dependencies Foundation \
  --output-root full \
  --allow-no-roadmap-record
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd55e1d9-294c-4e73-8a70-37ad0c87fa75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd55e1d9-294c-4e73-8a70-37ad0c87fa75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

